### PR TITLE
feat(week): add rolling Today ranges

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -181,18 +181,7 @@ async fn get_week(
     state: tauri::State<'_, AppState>,
     week_start_ms: i64,
 ) -> Result<commands::WeekPayload, String> {
-    let tz = display_tz(&state.pool);
-    // Widen the fetch by a day either side so an event that begins just before
-    // the week (or a DST-lengthened final day) is not missed.
-    const DAY: i64 = 24 * 3_600_000;
-    let events = omacal_store::events_in_window(
-        &state.pool,
-        week_start_ms - DAY,
-        week_start_ms + 8 * DAY,
-    )
-    .await
-    .map_err(|e| e.to_string())?;
-    Ok(commands::assemble_week(&events, week_start_ms, &tz))
+    get_days_impl(&state.pool, week_start_ms, 7).await
 }
 
 #[tauri::command]
@@ -200,18 +189,45 @@ async fn get_day(
     state: tauri::State<'_, AppState>,
     day_start_ms: i64,
 ) -> Result<commands::WeekPayload, String> {
-    let tz = display_tz(&state.pool);
-    // Same widening as `get_week`, for the same reason: an event that begins
-    // just before the day, or a DST-lengthened day, must not be missed.
+    get_days_impl(&state.pool, day_start_ms, 1).await
+}
+
+/// A rolling Week-view window beginning at `day_start_ms`. The settings UI
+/// offers exactly these three sizes; validate again at the command boundary so
+/// a malformed invoke cannot turn one calendar view into an unbounded query.
+#[tauri::command]
+async fn get_range(
+    state: tauri::State<'_, AppState>,
+    day_start_ms: i64,
+    day_count: u8,
+) -> Result<commands::WeekPayload, String> {
+    if !matches!(day_count, 3 | 5 | 7) {
+        return Err("the rolling week can show 3, 5, or 7 days".to_string());
+    }
+    get_days_impl(&state.pool, day_start_ms, day_count as usize).await
+}
+
+async fn get_days_impl(
+    pool: &SqlitePool,
+    day_start_ms: i64,
+    day_count: usize,
+) -> Result<commands::WeekPayload, String> {
+    let tz = display_tz(pool);
+    // Widen by a day either side so an event that begins just before the range
+    // (or a DST-lengthened final day) is not missed.
     const DAY: i64 = 24 * 3_600_000;
     let events = omacal_store::events_in_window(
-        &state.pool,
+        pool,
         day_start_ms - DAY,
-        day_start_ms + 2 * DAY,
+        day_start_ms + (day_count as i64 + 1) * DAY,
     )
     .await
     .map_err(|e| e.to_string())?;
-    Ok(commands::assemble_days(&events, day_start_ms, 1, &tz))
+    Ok(if day_count == 7 {
+        commands::assemble_week(&events, day_start_ms, &tz)
+    } else {
+        commands::assemble_days(&events, day_start_ms, day_count, &tz)
+    })
 }
 
 #[tauri::command]
@@ -1322,6 +1338,7 @@ pub fn run() {
             get_palette,
             get_week,
             get_day,
+            get_range,
             get_month,
             get_year,
             get_big_year,
@@ -1361,6 +1378,8 @@ pub fn run() {
             settings::set_default_calendar,
             settings::set_time_format,
             settings::set_week_start,
+            settings::set_week_starts_today,
+            settings::set_week_view_days,
             events::event_detail,
             events::respond_to_event,
             events::refresh_event,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -18,6 +18,8 @@ const FALLBACK_KEY: &str = "fallback_reminder_minutes";
 const DEFAULT_CALENDAR_KEY: &str = "default_calendar_id";
 const TIME_FORMAT_KEY: &str = "time_format";
 const WEEK_START_KEY: &str = "week_start";
+const WEEK_STARTS_TODAY_KEY: &str = "week_starts_today";
+const WEEK_VIEW_DAYS_KEY: &str = "week_view_days";
 const TRAY_ICON_KEY: &str = "tray_icon";
 const WEATHER_KEY: &str = "weather_enabled";
 const DISPLAY_TZ_KEY: &str = "display_timezone";
@@ -208,8 +210,18 @@ pub struct AppSettings {
     pub time_format: TimeFormat,
     /// The day a week begins on, honoured by the Week grid's own anchor, the
     /// month grid's leading blanks, the Year view's twelve small grids, and
-    /// Big Year's 392-day ribbon.
+    /// Big Year's 392-day ribbon. When `week_starts_today` is on, this still
+    /// aligns the three calendar-shaped views; it is preserved so switching
+    /// back from the rolling Week view restores the user's last fixed day.
     pub week_start: WeekStart,
+    /// Whether Week view is a rolling range whose first column is the current
+    /// day instead of a calendar-aligned week. This deliberately does not
+    /// change Month, Year or Big Year: "today" is not a stable weekday those
+    /// grids can align rows to.
+    pub week_starts_today: bool,
+    /// Total columns in the rolling Week view, including today. Only 3, 5 and
+    /// 7 are written; an absent or hand-edited value falls back to 7.
+    pub week_view_days: u8,
     /// The IANA zone every time in the app is read in, or `None` for the
     /// system's. Applied by exporting `TZ` before the webview starts — the
     /// one mechanism that keeps the browser, Rust, notifications and the
@@ -319,6 +331,20 @@ pub async fn read_settings(pool: &SqlitePool) -> AppSettings {
             Some("sunday") => WeekStart::Sunday,
             Some("saturday") => WeekStart::Saturday,
             _ => WeekStart::Monday,
+        },
+        // Opt-in, like list mode: absent, garbage and a future spelling keep
+        // the calendar-aligned week the app has always drawn.
+        week_starts_today: read(pool, WEEK_STARTS_TODAY_KEY)
+            .await
+            .map(|v| v == "1")
+            .unwrap_or(false),
+        // The select offers exactly these three. A row edited by hand must not
+        // become an unbounded query or a zero-column grid, so all other values
+        // return to the old seven-day shape.
+        week_view_days: match read(pool, WEEK_VIEW_DAYS_KEY).await.as_deref() {
+            Some("3") => 3,
+            Some("5") => 5,
+            _ => 7,
         },
         // Same polarity as `notifications_enabled`, same reason: absent and
         // garbage both keep the icon — losing the quit affordance must take
@@ -599,17 +625,69 @@ pub async fn set_time_format(
     Ok(read_settings(&state.pool).await)
 }
 
-/// Stores the day a week begins on. Nothing to refuse: [`WeekStart`] has
-/// three variants and the select offers all three.
+/// Stores the day a calendar-aligned week begins on and leaves rolling mode.
+/// Nothing to refuse: [`WeekStart`] has three variants and the select offers
+/// all three. The two writes are one user choice; the helper keeps that shape
+/// reachable from tests without constructing a Tauri `State`.
 #[tauri::command]
 pub async fn set_week_start(
     state: tauri::State<'_, AppState>,
     start: WeekStart,
 ) -> Result<AppSettings, String> {
-    write(&state.pool, WEEK_START_KEY, start.as_str())
+    set_week_start_impl(&state.pool, start)
+        .await
+        .map_err(|e| crate::errors::user_facing(&e))
+}
+
+async fn set_week_start_impl(pool: &SqlitePool, start: WeekStart) -> anyhow::Result<AppSettings> {
+    let mut tx = pool.begin().await?;
+    for (key, value) in [(WEEK_START_KEY, start.as_str()), (WEEK_STARTS_TODAY_KEY, "0")] {
+        sqlx::query(
+            "INSERT INTO settings (key, value) VALUES (?1, ?2)
+             ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+        )
+        .bind(key)
+        .bind(value)
+        .execute(&mut *tx)
+        .await?;
+    }
+    tx.commit().await?;
+    Ok(read_settings(pool).await)
+}
+
+/// Turns the rolling Week view on or off. Turning it on preserves the concrete
+/// `week_start` used by Month, Year and Big Year, and by Week when this is later
+/// turned off again.
+#[tauri::command]
+pub async fn set_week_starts_today(
+    state: tauri::State<'_, AppState>,
+    on: bool,
+) -> Result<AppSettings, String> {
+    write(&state.pool, WEEK_STARTS_TODAY_KEY, if on { "1" } else { "0" })
         .await
         .map_err(|e| crate::errors::user_facing(&e))?;
     Ok(read_settings(&state.pool).await)
+}
+
+/// Stores the number of columns in a rolling Week view. The browser offers
+/// only these values, and this guard keeps a hand-written invoke from asking
+/// the backend to allocate an arbitrary number of day columns.
+#[tauri::command]
+pub async fn set_week_view_days(
+    state: tauri::State<'_, AppState>,
+    days: u8,
+) -> Result<AppSettings, String> {
+    set_week_view_days_impl(&state.pool, days)
+        .await
+        .map_err(|e| crate::errors::user_facing(&e))
+}
+
+async fn set_week_view_days_impl(pool: &SqlitePool, days: u8) -> anyhow::Result<AppSettings> {
+    if !matches!(days, 3 | 5 | 7) {
+        anyhow::bail!("the rolling week can show 3, 5, or 7 days");
+    }
+    write(pool, WEEK_VIEW_DAYS_KEY, &days.to_string()).await?;
+    Ok(read_settings(pool).await)
 }
 
 #[cfg(test)]
@@ -645,6 +723,8 @@ mod tests {
             WeekStart::Monday,
             "the week omacal has always drawn"
         );
+        assert!(!s.week_starts_today, "a fresh install keeps the calendar-aligned week");
+        assert_eq!(s.week_view_days, 7, "the old Week view has seven columns");
     }
 
     /// `None` must clear a previously stored id back to the old rule — a
@@ -850,6 +930,41 @@ mod tests {
                 "{stored:?} is not a day this version writes",
             );
         }
+    }
+
+    #[tokio::test]
+    async fn the_rolling_week_settings_round_trip_and_reject_other_day_counts() {
+        let p = pool().await;
+
+        write(&p, WEEK_STARTS_TODAY_KEY, "1").await.unwrap();
+        for days in [3, 5, 7] {
+            let s = set_week_view_days_impl(&p, days).await.unwrap();
+            assert!(s.week_starts_today);
+            assert_eq!(s.week_view_days, days);
+        }
+
+        let before = read(&p, WEEK_VIEW_DAYS_KEY).await;
+        for days in [0, 1, 4, 6, 8, u8::MAX] {
+            assert!(set_week_view_days_impl(&p, days).await.is_err());
+            assert_eq!(read(&p, WEEK_VIEW_DAYS_KEY).await, before, "{days} changed the row");
+        }
+
+        for stored in ["", "0", "4", "8", "three", "255"] {
+            write(&p, WEEK_VIEW_DAYS_KEY, stored).await.unwrap();
+            assert_eq!(read_settings(&p).await.week_view_days, 7, "{stored:?} must fall back");
+        }
+    }
+
+    #[tokio::test]
+    async fn choosing_a_fixed_week_start_leaves_rolling_mode_atomically() {
+        let p = pool().await;
+        write(&p, WEEK_STARTS_TODAY_KEY, "1").await.unwrap();
+
+        let s = set_week_start_impl(&p, WeekStart::Sunday).await.unwrap();
+        assert_eq!(s.week_start, WeekStart::Sunday);
+        assert!(!s.week_starts_today);
+        assert_eq!(read(&p, WEEK_START_KEY).await.as_deref(), Some("sunday"));
+        assert_eq!(read(&p, WEEK_STARTS_TODAY_KEY).await.as_deref(), Some("0"));
     }
 
     /// The polarity rule, witnessed by a value the app never writes. A row

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -3,7 +3,7 @@
   import { listen } from '@tauri-apps/api/event';
   import { applyPalette, setPalette, type Palette } from './lib/theme';
   import {
-    getWeek, getDay, getMonth, getYear, getBigYear, weekStart,
+    getWeek, getDay, getRange, getMonth, getYear, getBigYear, weekStart,
     type WeekPayload, type MonthPayload, type YearPayload, type BigYearPayload, type UiEvent,
   } from './lib/api';
   import { getStatus, installUpdate, openLatestRelease, restartApp, signIn, syncNow, takeOpenDate, type AppStatus } from './lib/status';
@@ -20,7 +20,7 @@
   } from './lib/eventform';
   import type { Rect } from './lib/position';
   import { daysFromMonth, daysFromWeek, listable } from './lib/filmstrip';
-  import { getSettings, setListMode } from './lib/settings';
+  import { getSettings, setListMode, type AppSettings, type WeekViewDays } from './lib/settings';
   import { setClockFormat } from './lib/clock.svelte';
   import { setSecondZone } from './lib/secondzone.svelte';
   import { setWeekStartDay } from './lib/weekstartstore.svelte';
@@ -63,6 +63,11 @@
   // button, and Month's own `ondaypick` ever assign it.
   let anchorMs = $state(dayStart(Date.now()));
   let view = $state<View>('week');
+  /** Week view can either align to the stored concrete weekday or begin on
+   *  the current/anchored day and show a rolling 3/5/7-day range. The fixed
+   *  weekday remains in `weekstartstore` for Month, Year and Big Year. */
+  let weekStartsToday = $state(false);
+  let weekViewDays = $state<WeekViewDays>(7);
 
   // Year and Big Year read a bare calendar year rather than a millisecond
   // anchor — there is no single day inside them for `anchorMs` to name — so
@@ -91,10 +96,12 @@
   const YEAR_MIN = 1970;
   const YEAR_MAX = 9998;
 
-  // Derived purely for Header's title, and only in Week view: the week of Mon
-  // 29 Jan reads "January" even though it runs into February. Day and Month
-  // title themselves from `anchorMs` instead — see `Header`'s own `titleMs`.
-  const weekStartMs = $derived(weekStart(new Date(anchorMs)));
+  // Week's actual first column, for both its fetch and Header title. A fixed
+  // week floors the anchor to its configured weekday; a rolling one preserves
+  // the anchor itself, which is always a day boundary.
+  const weekStartMs = $derived(
+    weekStartsToday ? anchorMs : weekStart(new Date(anchorMs))
+  );
 
   let week = $state<WeekPayload | null>(null);
   let month = $state<MonthPayload | null>(null);
@@ -110,6 +117,24 @@
   let pickerOpen = $state(false);
 
   $effect(() => { applyPalette(); });
+
+  // Keep a rolling view literally anchored on today across midnight and a
+  // laptop wake. A range the user has navigated away from today is left where
+  // they put it: only an anchor that matched the previously-current day moves
+  // with the clock.
+  let trackedTodayMs = dayStart(Date.now());
+  $effect(() => {
+    const snap = () => {
+      const next = dayStart(Date.now());
+      if (weekStartsToday && anchorMs === trackedTodayMs && next !== trackedTodayMs) {
+        anchorMs = next;
+      }
+      trackedTodayMs = next;
+    };
+    const id = setInterval(snap, 60_000);
+    window.addEventListener('focus', snap);
+    return () => { clearInterval(id); window.removeEventListener('focus', snap); };
+  });
 
   // Live theme reload (spec §10): repaint when the Rust watcher notices
   // `omarchy-theme-set` replaced the theme symlink. A no-op off Linux, since
@@ -248,6 +273,9 @@
    * working.
    */
   let listModeChoices = 0;
+  /** Settings-modal writes supersede the startup read for the rolling Week
+   *  controls, just as `listModeChoices` does for the filmstrip toggle. */
+  let weekViewChoices = 0;
 
   /** The stored default for new events, or `null` for the old rule. Seeded
    *  below and kept fresh by `SettingsModal`'s `onsettingschange` — without
@@ -259,14 +287,23 @@
    *  setting: it is a thing you look at, not a thing you configure. */
   let helpOpen = $state(false);
 
+  function applyWeekSettings(s: AppSettings, jumpOnEntry: boolean) {
+    const enteringRolling = !weekStartsToday && s.weekStartsToday;
+    setWeekStartDay(s.weekStart);
+    weekStartsToday = s.weekStartsToday;
+    weekViewDays = s.weekViewDays;
+    if (jumpOnEntry && enteringRolling) anchorMs = dayStart(Date.now());
+  }
+
   $effect(() => {
     const before = listModeChoices;
+    const weekBefore = weekViewChoices;
     getSettings()
       .then((s) => {
         defaultCalendarId = s.defaultCalendarId;
         setClockFormat(s.timeFormat);
-        setWeekStartDay(s.weekStart);
         setSecondZone(s.secondTimezone);
+        if (weekViewChoices === weekBefore) applyWeekSettings(s, false);
         if (listModeChoices !== before) return; // superseded by the user's own choice
         listMode = s.listMode;
       })
@@ -301,6 +338,7 @@
   // anchored — the "$derived picks which loader to call" half of this task.
   type FetchPlan =
     | { kind: 'day' | 'week'; target: number }
+    | { kind: 'range'; target: number; days: WeekViewDays }
     | { kind: 'month'; year: number; monthNum: number }
     | { kind: 'year'; year: number }
     | { kind: 'bigyear'; year: number };
@@ -315,7 +353,11 @@
     // start isn't the browser's local midnight (spec §5's anchor-survival
     // guarantee depends on this value reaching Day view unmodified).
     if (view === 'day') return { kind: 'day', target: anchorMs };
-    if (view === 'week') return { kind: 'week', target: weekStart(new Date(anchorMs)) };
+    if (view === 'week') {
+      return weekStartsToday
+        ? { kind: 'range', target: weekStartMs, days: weekViewDays }
+        : { kind: 'week', target: weekStartMs };
+    }
     if (view === 'month') {
       const d = new Date(anchorMs);
       return { kind: 'month', year: d.getFullYear(), monthNum: d.getMonth() + 1 };
@@ -337,10 +379,14 @@
   let yearReq = 0;
   let bigYearReq = 0;
 
-  async function loadWeek(kind: 'day' | 'week', target: number) {
+  async function loadWeek(kind: 'day' | 'week' | 'range', target: number, days?: WeekViewDays) {
     const req = ++weekReq;
     try {
-      const w = kind === 'day' ? await getDay(target) : await getWeek(target);
+      const w = kind === 'day'
+        ? await getDay(target)
+        : kind === 'range'
+          ? await getRange(target, days ?? 7)
+          : await getWeek(target);
       if (req !== weekReq) return; // superseded while we were awaiting
       week = w;
       error = null;
@@ -393,6 +439,7 @@
     if (plan.kind === 'month') return loadMonth(plan.year, plan.monthNum);
     if (plan.kind === 'year') return loadYear(plan.year);
     if (plan.kind === 'bigyear') return loadBigYear(plan.year);
+    if (plan.kind === 'range') return loadWeek(plan.kind, plan.target, plan.days);
     return loadWeek(plan.kind, plan.target);
   }
 
@@ -538,7 +585,9 @@
     }
     const d = new Date(anchorMs);
     if (view === 'day') d.setDate(d.getDate() + dir);
-    else if (view === 'week') d.setDate(d.getDate() + dir * 7);
+    else if (view === 'week') {
+      d.setDate(d.getDate() + dir * (weekStartsToday ? weekViewDays : 7));
+    }
     else if (view === 'month') {
       // A bare `setMonth` overflows for a day-of-month the target month
       // doesn't have — Jan 31 `+1` rolls past February into Mar 3, not Feb
@@ -1215,7 +1264,8 @@
   }}
 >
   <Header
-    {status} {anchorMs} {weekStartMs} {busy} {error} {calendars} {view} {listMode}
+    {status} {anchorMs} {weekStartMs} {weekStartsToday} weekDays={weekViewDays}
+    {busy} {error} {calendars} {view} {listMode}
     onToggleList={toggleList}
     onPrev={() => step(-1)}
     onNext={() => step(1)}
@@ -1224,8 +1274,9 @@
     onsettingschange={(s) => {
       defaultCalendarId = s.defaultCalendarId;
       setClockFormat(s.timeFormat);
-      setWeekStartDay(s.weekStart);
       setSecondZone(s.secondTimezone);
+      weekViewChoices += 1;
+      applyWeekSettings(s, true);
       // The weather toggle lives in the same modal; refetching on every
       // settings change is one cache read, and it is what makes flipping
       // the switch change the headers now rather than within the hour.

--- a/ui/src/lib/AllDayBand.svelte
+++ b/ui/src/lib/AllDayBand.svelte
@@ -4,8 +4,8 @@
   import type { Rect } from './position';
   import { gutterWidth } from './secondzone.svelte';
 
-  let { lanes, events, overflow, onopen }:
-    { lanes: Lane[]; events: UiEvent[]; overflow: number[];
+  let { lanes, events, overflow, columns = 7, onopen }:
+    { lanes: Lane[]; events: UiEvent[]; overflow: number[]; columns?: number;
       /** Same contract as `EventBlock`'s, and wired to the same
        *  `WeekGrid.openPopover`. Required rather than optional: every
        *  `is_all_day` event is routed here by `commands::assemble_week`, so a
@@ -33,7 +33,7 @@
 {#if lanes.length || overflow.length}
   <div class="band" style="--gutter:{gutterWidth()}">
     <div class="label">ALL-DAY</div>
-    <div class="rows">
+    <div class="rows" style="--cols:{columns}">
       {#each lanes as lane}
         {@const ev = events[lane.idx]}
         <button
@@ -72,7 +72,7 @@
   /* No gap: a gap here is subtracted from every column, so the band's columns
      drift out of step with the grid below it — by Sunday the chips sit a chip's
      width off their days. The separation lives inside the chip instead. */
-  .rows { display: grid; grid-template-columns: repeat(7, 1fr); }
+  .rows { display: grid; grid-template-columns: repeat(var(--cols), 1fr); }
 
   /* A <button>, like EventBlock, rather than a <div> with a click handler
      bolted on: the role, the tab stop and Enter/Space all come for free and

--- a/ui/src/lib/Header.svelte
+++ b/ui/src/lib/Header.svelte
@@ -12,7 +12,8 @@
   import type { ChangeNotice, DeclineNotice, PendingInvite } from './invites';
 
   let {
-    status, anchorMs, weekStartMs, busy, error, calendars, view, onpick,
+    status, anchorMs, weekStartMs, weekStartsToday = false, weekDays = 7,
+    busy, error, calendars, view, onpick,
     onsettingschange,
     listMode, onToggleList,
     onPrev, onNext, onToday, onSearch, onSignIn, onSync, oncalendarchange,
@@ -24,8 +25,14 @@
     /** The date every view is rendered against — `App`'s own anchor. Day and
      *  Month are built from this one directly. */
     anchorMs: number;
-    /** The Monday of `anchorMs`'s week, which is what Week view renders. */
+    /** The first day Week view renders: a configured weekday boundary or the
+     *  rolling range's anchored/current day. */
     weekStartMs: number;
+    /** Whether Week view is the rolling range rather than a weekday-aligned
+     *  calendar week. Used to name navigation by what it actually moves. */
+    weekStartsToday?: boolean;
+    /** Total columns in that rolling range. Ignored for fixed weeks. */
+    weekDays?: 3 | 5 | 7;
     busy: boolean;
     error: string | null;
     calendars: Calendar[];
@@ -98,7 +105,9 @@
   const NAV_UNIT: Record<View, string> = {
     day: 'day', week: 'week', month: 'month', year: 'year', bigyear: 'year',
   };
-  const unit = $derived(NAV_UNIT[view]);
+  const unit = $derived(
+    view === 'week' && weekStartsToday ? `${weekDays} days` : NAV_UNIT[view]
+  );
   const connected = $derived((status?.accounts.length ?? 0) > 0);
   /** Accounts whose Google sign-in is dead — the backend has stopped syncing
    *  them and re-consent is the only fix, so this is the one failure with a

--- a/ui/src/lib/SettingsModal.svelte
+++ b/ui/src/lib/SettingsModal.svelte
@@ -14,7 +14,7 @@
     setDisplayTimezone, setFallbackReminders, setNotificationsEnabled,
     setSecondTimezone, setSyncInterval, setTimeFormat, setTrayIcon,
     setWeatherEnabled, setWeekStart,
-    type AppSettings,
+    setWeekStartsToday, setWeekViewDays, type AppSettings, type WeekViewDays,
   } from './settings';
   import { formatClock, type TimeFormat } from './timefmt';
   import type { WeekStartDay } from './weekstart';
@@ -91,9 +91,13 @@
    * repaints the calendar behind the modal — `App` owns the rune, and this
    * modal deliberately does not reach past its own props to set it.
    */
-  /** The three days, and what to call them. Google Calendar's own three —
-   *  see `settings::WeekStart` for why not seven. */
-  const WEEK_STARTS: { id: WeekStartDay; label: string }[] = [
+  type WeekStartChoice = WeekStartDay | 'today';
+
+  /** The rolling option plus Google Calendar's three concrete starts. Today
+   *  applies only to Week view; the concrete value remains the row alignment
+   *  for Month, Year and Big Year. */
+  const WEEK_STARTS: { id: WeekStartChoice; label: string }[] = [
+    { id: 'today', label: 'Today' },
     { id: 'monday', label: 'Monday' },
     { id: 'sunday', label: 'Sunday' },
     { id: 'saturday', label: 'Saturday' },
@@ -180,9 +184,20 @@
     }
   }
 
-  async function saveWeekStart(start: WeekStartDay) {
+  async function saveWeekStart(start: WeekStartChoice) {
     try {
-      settings = await setWeekStart(start);
+      settings = start === 'today'
+        ? await setWeekStartsToday(true)
+        : await setWeekStart(start);
+      onsettingschange?.(settings);
+    } catch (e) {
+      note = { text: String(e), kind: 'error' };
+    }
+  }
+
+  async function saveWeekViewDays(days: WeekViewDays) {
+    try {
+      settings = await setWeekViewDays(days);
       onsettingschange?.(settings);
     } catch (e) {
       note = { text: String(e), kind: 'error' };
@@ -561,14 +576,14 @@
       </p>
 
       <div class="row">
-        <label class="lab" for="week-start">Weeks start on</label>
+        <label class="lab" for="week-start">Week view starts on</label>
         <div class="inline">
           <select
             id="week-start"
             disabled={!settings}
-            value={settings?.weekStart ?? 'monday'}
+            value={settings?.weekStartsToday ? 'today' : (settings?.weekStart ?? 'monday')}
             onchange={(e) =>
-              saveWeekStart((e.currentTarget as HTMLSelectElement).value as WeekStartDay)}
+              saveWeekStart((e.currentTarget as HTMLSelectElement).value as WeekStartChoice)}
           >
             {#each WEEK_STARTS as w (w.id)}
               <option value={w.id}>{w.label}</option>
@@ -576,9 +591,31 @@
           </select>
         </div>
       </div>
-      <p class="hint">
-        Week, Month, Year and Big Year all start their rows on this day.
-      </p>
+      {#if settings?.weekStartsToday}
+        <div class="row">
+          <label class="lab" for="week-view-days">Days shown</label>
+          <div class="inline">
+            <select
+              id="week-view-days"
+              value={settings.weekViewDays}
+              onchange={(e) =>
+                saveWeekViewDays(Number((e.currentTarget as HTMLSelectElement).value) as WeekViewDays)}
+            >
+              {#each [3, 5, 7] as const as days (days)}
+                <option value={days}>{days} days</option>
+              {/each}
+            </select>
+          </div>
+        </div>
+        <p class="hint">
+          Includes today as the first day. Month, Year and Big Year keep their
+          rows aligned to {WEEK_STARTS.find((w) => w.id === settings?.weekStart)?.label ?? 'Monday'}.
+        </p>
+      {:else}
+        <p class="hint">
+          Week, Month, Year and Big Year all start their rows on this day.
+        </p>
+      {/if}
 
       <div class="row">
         <label class="lab" for="display-tz">Time zone</label>

--- a/ui/src/lib/WeekGrid.svelte
+++ b/ui/src/lib/WeekGrid.svelte
@@ -842,6 +842,7 @@
   lanes={week.all_day}
   events={week.all_day_events}
   overflow={week.overflow}
+  columns={week.days.length}
   onopen={openPopover}
 />
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -67,6 +67,10 @@ export function weekStart(d: Date): number {
 export const getWeek = (weekStartMs: number) =>
   invoke<WeekPayload>('get_week', { weekStartMs });
 
+/** A rolling Week-view range beginning on the supplied day. */
+export const getRange = (dayStartMs: number, dayCount: 3 | 5 | 7) =>
+  invoke<WeekPayload>('get_range', { dayStartMs, dayCount });
+
 export const getDay = (dayStartMs: number) =>
   invoke<WeekPayload>('get_day', { dayStartMs });
 

--- a/ui/src/lib/settings.ts
+++ b/ui/src/lib/settings.ts
@@ -3,6 +3,9 @@ import { invoke } from '@tauri-apps/api/core';
 import type { TimeFormat } from './timefmt';
 import type { WeekStartDay } from './weekstart';
 
+/** Total columns in the rolling Week view, including today. */
+export type WeekViewDays = 3 | 5 | 7;
+
 /**
  * The preferences the settings modal edits.
  *
@@ -41,6 +44,11 @@ export type AppSettings = {
   /** The day a week begins on. Read by the grids through the
    *  `weekstartstore.svelte.ts` rune, for the same reason `timeFormat` is. */
   weekStart: WeekStartDay;
+  /** Whether Week view begins on the current day instead of the fixed
+   *  `weekStart`. Month, Year and Big Year continue using the fixed day. */
+  weekStartsToday: boolean;
+  /** Number of columns in that rolling Week view, including today. */
+  weekViewDays: WeekViewDays;
   /** Whether the system tray icon is shown. On by default — the tray is where
    *  Quit lives. Turning it off is for setups where something else carries
    *  those actions, like Omarchy 4's bar widget. */
@@ -98,6 +106,15 @@ export const setTimeFormat = (format: TimeFormat) =>
  *  exactly the three variants `settings::WeekStart` has. */
 export const setWeekStart = (start: WeekStartDay) =>
   invoke<AppSettings>('set_week_start', { start });
+
+/** Enters or leaves the rolling Week view without changing the concrete day
+ *  used to align Month, Year and Big Year. */
+export const setWeekStartsToday = (on: boolean) =>
+  invoke<AppSettings>('set_week_starts_today', { on });
+
+/** Stores the rolling Week view's total column count. */
+export const setWeekViewDays = (days: WeekViewDays) =>
+  invoke<AppSettings>('set_week_view_days', { days });
 
 /** Stores the filmstrip toggle. Nothing is refused: unlike the sync interval
  *  there is no value of a boolean the app has to protect anything from. */

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -3252,4 +3252,61 @@ test.describe('App: the first day of the week', () => {
     const sundayMs = await firstColumn.getAttribute('data-start-ms');
     expect(Number(sundayMs)).toBe(Number(mondayMs) - 24 * 3_600_000);
   });
+
+  test('Today starts a rolling 3, 5, or 7-day Week view on the current day', async ({ page }) => {
+    const day = 24 * 3_600_000;
+    const wednesday = APP_NOW + 2 * day;
+    await page.clock.setFixedTime(wednesday);
+    await openApp(page);
+
+    await page.getByRole('button', { name: 'Menu' }).click();
+    await page.getByRole('button', { name: 'Settings…' }).click();
+    const modal = page.getByRole('dialog', { name: 'Settings' });
+    await modal.locator('#week-start').selectOption({ label: 'Today' });
+
+    const count = modal.locator('#week-view-days');
+    await expect(count).toBeVisible();
+    await expect(count.locator('option')).toHaveText(['3 days', '5 days', '7 days']);
+    await count.selectOption('3');
+    await page.keyboard.press('Escape');
+
+    const columns = page.locator('[data-testid="week-body"] .col');
+    await expect(columns).toHaveCount(3);
+    await expect(columns.first()).toHaveAttribute('data-start-ms', String(wednesday - 12 * 3_600_000));
+    await expect(page.getByRole('button', { name: 'Next 3 days' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Next 3 days' }).click();
+    await expect(columns.first()).toHaveAttribute(
+      'data-start-ms', String(wednesday - 12 * 3_600_000 + 3 * day),
+    );
+
+    // All three supported sizes change the payload, not only the select.
+    await page.getByRole('button', { name: 'Menu' }).click();
+    await page.getByRole('button', { name: 'Settings…' }).click();
+    const reopened = page.getByRole('dialog', { name: 'Settings' });
+    await reopened.locator('#week-view-days').selectOption('5');
+    await expect(columns).toHaveCount(5);
+    await reopened.locator('#week-view-days').selectOption('7');
+    await expect(columns).toHaveCount(7);
+  });
+
+  test('a rolling range follows today across midnight but preserves Month alignment', async ({ page }) => {
+    const day = 24 * 3_600_000;
+    const wednesdayNoon = APP_NOW + 2 * day;
+    await page.clock.setFixedTime(wednesdayNoon);
+    await openApp(page);
+
+    await chooseStart(page, 'Sunday');
+    await chooseStart(page, 'Today');
+    const first = page.locator('[data-testid="week-body"] .col').first();
+    const wednesday = wednesdayNoon - 12 * 3_600_000;
+    await expect(first).toHaveAttribute('data-start-ms', String(wednesday));
+
+    await page.clock.setSystemTime(wednesdayNoon + day);
+    await page.evaluate(() => window.dispatchEvent(new Event('focus')));
+    await expect(first).toHaveAttribute('data-start-ms', String(wednesday + day));
+
+    await page.keyboard.press('3');
+    await expect(monthHeader(page).first()).toHaveText('SUN');
+  });
 });

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -796,6 +796,17 @@ test.describe('AllDayBand', () => {
     await expect(page.locator('.more')).toHaveText('+2 more');
   });
 
+  test('uses the rolling range column count', async ({ page }) => {
+    await page.goto(show('AllDayBand', 'three-days'));
+    const rows = await page.locator('.rows').boundingBox();
+    const spanning = await page.locator('.chip').first().boundingBox();
+    expect(rows).not.toBeNull();
+    expect(spanning).not.toBeNull();
+    // The first fixture chip spans all three days. A band still hard-coded to
+    // seven columns gives it only 3/7 of the row; the real range fills it.
+    expect(spanning!.width / rows!.width).toBeGreaterThan(0.9);
+  });
+
   test('renders nothing when there is nothing to show', async ({ page }) => {
     await page.goto(show('AllDayBand', 'empty'));
     await expect(page.locator('.band')).toHaveCount(0);

--- a/ui/tests/fixtures.spec.ts
+++ b/ui/tests/fixtures.spec.ts
@@ -287,7 +287,7 @@ const weeks: [string, WeekPayload][] = [
   //
   // `corners` is not here, and that is a ruling rather than an oversight — see
   // `BAND_NOT_SWEPT` below.
-  ...(['populated', 'overflow', 'empty'] as const).map(
+  ...(['populated', 'three-days', 'overflow', 'empty'] as const).map(
     (n) => [`band:${n}`, bandAsWeek(FIXTURES.AllDayBand[n])] as [string, WeekPayload],
   ),
 ];
@@ -375,11 +375,11 @@ test.describe('the hand-written week fixtures describe payloads assemble_days co
     expect(weeks.length).toBeGreaterThanOrEqual(15);
     let checked = 0;
     for (const [name, w] of weeks) {
-      // `assemble_days(events, start_ms, n, tz)` has exactly two callers in the
-      // app: `get_day` at `n = 1` (lib.rs:104) and `assemble_week` at `n = 7`
-      // (commands.rs:365). No other column count is reachable, so a fixture
-      // with three days — or none — is one nothing can serve.
-      expect([1, 7], `${name} has ${w.days.length} day columns`).toContain(w.days.length);
+      // `assemble_days(events, start_ms, n, tz)` serves Day at `n = 1`, fixed
+      // Week at `n = 7`, and rolling Week ranges at `n = 3`, `5`, or `7`.
+      // No other column count is reachable, so a fixture with two days — or
+      // none — is one nothing can serve.
+      expect([1, 3, 5, 7], `${name} has ${w.days.length} day columns`).toContain(w.days.length);
 
       for (const [d, col] of w.days.entries()) {
         // `DayColumn { start_ms: bounds[d], end_ms: bounds[d + 1], .. }`
@@ -403,7 +403,7 @@ test.describe('the hand-written week fixtures describe payloads assemble_days co
       }
     }
     // Every fixture contributed all of its columns. A `days: []` is already
-    // caught by the `[1, 7]` check above; this catches a loop that skipped one.
+    // caught by the allowed-count check above; this catches a loop that skipped one.
     expect(checked).toBe(weeks.reduce((n, [, w]) => n + w.days.length, 0));
   });
 
@@ -705,7 +705,7 @@ test.describe('the hand-written week fixtures describe payloads assemble_days co
     }
     // Eleven today: two in `populated`, two in `popover-all-day`, one in
     // `filmstrip`, one in `app:writable`, one in `app:cross-zone`, and two each
-    // in `band:populated` and `band:overflow`.
+    // in `band:populated`, `band:three-days`, and `band:overflow`.
     expect(checked).toBeGreaterThan(0);
   });
 });

--- a/ui/tests/fixtures.ts
+++ b/ui/tests/fixtures.ts
@@ -104,8 +104,8 @@ const day = (offset: number, events: UiEvent[], p: Placed[]) => ({
  *  is what every component fixture in this file wants. The App-level write
  *  fixtures need one at `APP_MON` instead, so that a click on empty grid space
  *  lands on the same date the app actually opened on. */
-const emptyWeekAt = (weekStartMs: number): WeekPayload => ({
-  days: Array.from({ length: 7 }, (_, i) => ({
+const emptyWeekAt = (weekStartMs: number, dayCount = 7): WeekPayload => ({
+  days: Array.from({ length: dayCount }, (_, i) => ({
     start_ms: weekStartMs + i * 24 * H,
     end_ms: weekStartMs + (i + 1) * 24 * H,
     events: [] as UiEvent[],
@@ -123,21 +123,22 @@ const emptyWeek = (): WeekPayload => emptyWeekAt(MON);
  * projection of, so `fixtures.spec.ts`'s lane sweep can hold it to the same
  * invariants as every other payload.
  *
- * Exact rather than a contortion: `WeekGrid` hands `AllDayBand` these three
- * fields and nothing else, unchanged —
+ * Exact rather than a contortion: `WeekGrid` hands `AllDayBand` these fields
+ * unchanged —
  *
- *     lanes={week.all_day} events={week.all_day_events} overflow={week.overflow}
+ *     lanes={week.all_day} events={week.all_day_events}
+ *     overflow={week.overflow} columns={week.days.length}
  *
- * (`WeekGrid.svelte:344-349`) — so a props fixture *is* three fields of a week
+ * (`WeekGrid.svelte:344-349`) — so a props fixture *is* these fields of a week
  * payload with the rest of the week dropped. Putting them back on an otherwise
- * empty seven-day week restores exactly what was dropped and invents nothing:
- * the day columns the sweep needs for its column-bound checks are the same
- * seven every other fixture here has.
+ * empty range restores exactly what was dropped and invents nothing. The
+ * optional column count preserves a rolling three-, five-, or seven-day
+ * range; older fixtures omit it and therefore remain seven-day weeks.
  */
 export const bandAsWeek = (
-  p: { lanes: Lane[]; events: UiEvent[]; overflow: number[] },
+  p: { lanes: Lane[]; events: UiEvent[]; overflow: number[]; columns?: number },
 ): WeekPayload => ({
-  ...emptyWeek(),
+  ...emptyWeekAt(MON, p.columns ?? 7),
   all_day: p.lanes,
   all_day_events: p.events,
   overflow: p.overflow,
@@ -286,8 +287,8 @@ export const weekLabel = (weekStartMs: number) =>
  * flight for different weeks, the grid has to say out loud which one painted
  * it, or a stale repaint is indistinguishable from a correct one.
  */
-export const labelledWeek = (weekStartMs: number): WeekPayload => ({
-  days: Array.from({ length: 7 }, (_, i) => ({
+export const labelledWeek = (weekStartMs: number, dayCount = 7): WeekPayload => ({
+  days: Array.from({ length: dayCount }, (_, i) => ({
     start_ms: weekStartMs + i * 24 * H,
     end_ms: weekStartMs + (i + 1) * 24 * H,
     events: i === 0
@@ -1780,6 +1781,16 @@ export const FIXTURES: Record<string, Record<string, any>> = {
       overflow: [],
       onopen: noop,
     },
+    'three-days': (() => {
+      const w = populatedWeek();
+      return {
+        lanes: w.all_day,
+        events: w.all_day_events,
+        overflow: [],
+        columns: 3,
+        onopen: noop,
+      };
+    })(),
     // A band that really overflows, described the way `pack_lanes` would
     // actually have produced it.
     //

--- a/ui/tests/harness/tauri.ts
+++ b/ui/tests/harness/tauri.ts
@@ -15,6 +15,7 @@ import type { Calendar } from '../../src/lib/calendars';
 import type { EventDetail } from '../../src/lib/eventdetail';
 import type { TimeFormat } from '../../src/lib/timefmt';
 import type { WeekStartDay } from '../../src/lib/weekstart';
+import type { WeekViewDays } from '../../src/lib/settings';
 import {
   labelledWeek, weekLabel, APP_FIVE_MIN_AGO, APP_NOW, APP_SERIES_ID, APP_SERIES_OCCURRENCE,
   APP_ONE_OFF_ID, APP_ONE_OFF_START, APP_GUESTS_ID, APP_SOLO_SERIES_ID,
@@ -377,7 +378,7 @@ const SIGNED_IN_CALENDARS: Calendar[] = [
     access_role: 'reader', provider: 'google' },
 ];
 
-function getWeek(scenario: string, weekStartMs: number): Promise<WeekPayload> {
+function getWeek(scenario: string, weekStartMs: number, dayCount = 7): Promise<WeekPayload> {
   if (failWeekOnce !== null) {
     const message = failWeekOnce;
     failWeekOnce = null;
@@ -409,7 +410,7 @@ function getWeek(scenario: string, weekStartMs: number): Promise<WeekPayload> {
     }
     return Promise.resolve(crossZoneWeek());
   }
-  return Promise.resolve(labelledWeek(weekStartMs));
+  return Promise.resolve(labelledWeek(weekStartMs, dayCount));
 }
 
 const DAY_MS = 24 * 3_600_000;
@@ -513,6 +514,8 @@ type StubSettings = {
   defaultCalendarId: number | null;
   timeFormat: TimeFormat;
   weekStart: WeekStartDay;
+  weekStartsToday: boolean;
+  weekViewDays: WeekViewDays;
   displayTimezone: string | null;
   secondTimezone: string | null;
   weatherEnabled: boolean;
@@ -537,6 +540,8 @@ const DEFAULT_SETTINGS: StubSettings = {
   timeFormat: '24h',
   // The week omacal has always drawn, so every golden holds.
   weekStart: 'monday',
+  weekStartsToday: false,
+  weekViewDays: 7,
   displayTimezone: null,
   // Off, the backend's fresh-install default — and what keeps every
   // committed gutter golden describing a 44px ruler with one clock.
@@ -667,6 +672,8 @@ export function installTauriStub(scenario: string): Harness {
         return [];
       case 'get_week':
         return getWeek(scenario, args.weekStartMs);
+      case 'get_range':
+        return getWeek(scenario, args.dayStartMs, args.dayCount);
       case 'get_day':
         return getDay(args.dayStartMs);
       case 'get_month':
@@ -783,7 +790,15 @@ export function installTauriStub(scenario: string): Harness {
         settings = saveSettings({ ...settings, listMode: args.on as boolean });
         return { ...settings };
       case 'set_week_start':
-        settings = saveSettings({ ...settings, weekStart: args.start as WeekStartDay });
+        settings = saveSettings({
+          ...settings, weekStart: args.start as WeekStartDay, weekStartsToday: false,
+        });
+        return { ...settings };
+      case 'set_week_starts_today':
+        settings = saveSettings({ ...settings, weekStartsToday: args.on as boolean });
+        return { ...settings };
+      case 'set_week_view_days':
+        settings = saveSettings({ ...settings, weekViewDays: args.days as WeekViewDays });
         return { ...settings };
       case 'set_time_format':
         settings = saveSettings({ ...settings, timeFormat: args.format as TimeFormat });


### PR DESCRIPTION
## Summary

- Add a Today start option for Week view with 3, 5, or 7 visible days.
- Page navigation by the selected range and follow today across midnight.
- Preserve the fixed weekday alignment for Month, Year, and Big Year.

## Screenshot

Five-day range with synthetic data:

![Today-based five-day range](https://raw.githubusercontent.com/jondkinney/omacal/pr-screenshots/docs/pr-screenshots/rolling-today.jpg)

## Testing

- `cargo test --workspace --no-fail-fast`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `npm --prefix ui run check`
- `npm --prefix ui run test:ui -- --project=chromium`
