### PR TITLE
fix(keyboard): make confirmation dialogs predictable

### DIFF
--- a/ui/src/lib/ConfirmPanel.svelte
+++ b/ui/src/lib/ConfirmPanel.svelte
@@ -37,34 +37,7 @@
   // open rather than reused, so one placement is all this needs.
   let pos = $state<{ top: number; left: number }>({ top: 0, left: 0 });
 
-  /** A confirmation with only Cancel and one action has deliberately asymmetric
-   *  keyboard behavior: focus begins on the safe choice, Space activates that
-   *  focused button normally, and Enter accepts the action. Panels with scope
-   *  or notification choices keep their existing first-choice behavior. */
-  function cancelActionPair(root: HTMLElement | undefined) {
-    if (!root) return undefined;
-
-    const hasBodyChoices = [...root.querySelectorAll<HTMLElement>('[data-choice]:not(:disabled)')]
-      .some((choice) => !choice.closest('[data-confirm-actions]'));
-    if (hasBodyChoices) return undefined;
-
-    const buttons = [...root.querySelectorAll<HTMLButtonElement>(
-      '[data-confirm-actions] button:not(:disabled)',
-    )];
-    if (buttons.length !== 2) return undefined;
-
-    const cancel = buttons.find((button) => button.hasAttribute('data-cancel'));
-    const action = buttons.find((button) => button.hasAttribute('data-default-choice-action'));
-    return cancel && action ? { cancel, action } : undefined;
-  }
-
   function handlePanelKey(event: KeyboardEvent) {
-    const pair = cancelActionPair(panelEl);
-    if (pair && event.key === 'Enter') {
-      event.preventDefault();
-      pair.action.click();
-      return;
-    }
     if (panelEl) handleChoiceKey(panelEl, event);
   }
 
@@ -77,11 +50,10 @@
         viewport,
       );
     }
-    // A simple Cancel/Action question begins on its safe choice. More involved
-    // questions begin on their first/default scope or notification choice.
-    const pair = cancelActionPair(panelEl);
-    if (pair) pair.cancel.focus();
-    else focusInitialChoice(panelEl);
+    // A panel can nominate a meaningful scope or notification choice. Without
+    // one, focus falls back to Cancel: native Enter then activates exactly the
+    // button the user can see is focused, including the safe choice.
+    focusInitialChoice(panelEl);
   });
 
   // Escape closes this panel. `escapeCloses` carries the whole reason it is a

--- a/ui/src/lib/ConfirmPanel.svelte
+++ b/ui/src/lib/ConfirmPanel.svelte
@@ -3,6 +3,7 @@
   import { onMount, type Snippet } from 'svelte';
   import { escapeCloses } from './dismiss.svelte';
   import { placePopover, type Rect } from './position';
+  import { focusInitialChoice, handleChoiceKey } from './choicefocus';
 
   let {
     anchor,
@@ -45,13 +46,10 @@
         viewport,
       );
     }
-    // The **safe** control, whichever panel this is. `role="dialog"` plus
-    // `aria-modal` oblige focus to start inside, and the safe end of a dialog
-    // with a write behind it is the one that changes nothing: a stray Return
-    // on a panel the user did not mean to open closes it instead of mailing a
-    // guest list. Found rather than bound, so a caller cannot forget to pass
-    // it and silently land focus on the destructive button.
-    panelEl?.querySelector<HTMLButtonElement>('[data-cancel]')?.focus();
+    // These panels are questions, so focus begins on their first/default
+    // answer. That makes Enter accept it immediately while Tab remains the
+    // native route through Cancel and the other actions.
+    focusInitialChoice(panelEl);
   });
 
   // Escape closes this panel. `escapeCloses` carries the whole reason it is a
@@ -72,10 +70,11 @@
   tabindex="-1"
   aria-label={label}
   style="top:{pos.top}px; left:{pos.left}px"
+  onkeydown={(event) => panelEl && handleChoiceKey(panelEl, event)}
 >
   <h2>{title}</h2>
   {@render body()}
-  <div class="actions">{@render actions()}</div>
+  <div class="actions" data-choice-group>{@render actions()}</div>
 </div>
 
 <style>

--- a/ui/src/lib/ConfirmPanel.svelte
+++ b/ui/src/lib/ConfirmPanel.svelte
@@ -37,6 +37,37 @@
   // open rather than reused, so one placement is all this needs.
   let pos = $state<{ top: number; left: number }>({ top: 0, left: 0 });
 
+  /** A confirmation with only Cancel and one action has deliberately asymmetric
+   *  keyboard behavior: focus begins on the safe choice, Space activates that
+   *  focused button normally, and Enter accepts the action. Panels with scope
+   *  or notification choices keep their existing first-choice behavior. */
+  function cancelActionPair(root: HTMLElement | undefined) {
+    if (!root) return undefined;
+
+    const hasBodyChoices = [...root.querySelectorAll<HTMLElement>('[data-choice]:not(:disabled)')]
+      .some((choice) => !choice.closest('[data-confirm-actions]'));
+    if (hasBodyChoices) return undefined;
+
+    const buttons = [...root.querySelectorAll<HTMLButtonElement>(
+      '[data-confirm-actions] button:not(:disabled)',
+    )];
+    if (buttons.length !== 2) return undefined;
+
+    const cancel = buttons.find((button) => button.hasAttribute('data-cancel'));
+    const action = buttons.find((button) => button.hasAttribute('data-default-choice-action'));
+    return cancel && action ? { cancel, action } : undefined;
+  }
+
+  function handlePanelKey(event: KeyboardEvent) {
+    const pair = cancelActionPair(panelEl);
+    if (pair && event.key === 'Enter') {
+      event.preventDefault();
+      pair.action.click();
+      return;
+    }
+    if (panelEl) handleChoiceKey(panelEl, event);
+  }
+
   onMount(() => {
     if (panelEl) {
       const viewport = { width: window.innerWidth, height: window.innerHeight };
@@ -46,10 +77,11 @@
         viewport,
       );
     }
-    // These panels are questions, so focus begins on their first/default
-    // answer. That makes Enter accept it immediately while Tab remains the
-    // native route through Cancel and the other actions.
-    focusInitialChoice(panelEl);
+    // A simple Cancel/Action question begins on its safe choice. More involved
+    // questions begin on their first/default scope or notification choice.
+    const pair = cancelActionPair(panelEl);
+    if (pair) pair.cancel.focus();
+    else focusInitialChoice(panelEl);
   });
 
   // Escape closes this panel. `escapeCloses` carries the whole reason it is a
@@ -70,11 +102,11 @@
   tabindex="-1"
   aria-label={label}
   style="top:{pos.top}px; left:{pos.left}px"
-  onkeydown={(event) => panelEl && handleChoiceKey(panelEl, event)}
+  onkeydown={handlePanelKey}
 >
   <h2>{title}</h2>
   {@render body()}
-  <div class="actions" data-choice-group>{@render actions()}</div>
+  <div class="actions" data-choice-group data-confirm-actions>{@render actions()}</div>
 </div>
 
 <style>

--- a/ui/src/lib/DeleteConfirm.svelte
+++ b/ui/src/lib/DeleteConfirm.svelte
@@ -47,12 +47,14 @@
            no last occurrence to count to, and a number that is only right for the
            rules that happen to end is worse than no number in a dialog with no
            undo. -->
-      <div class="scope" role="radiogroup" aria-label="Delete">
+      <div class="scope" role="radiogroup" aria-label="Delete" data-choice-group>
         <label>
           <input
             type="radio"
             name="delete-scope"
             aria-label="This event"
+            data-choice
+            data-initial-choice
             checked={scope === 'this'}
             onchange={() => (scope = 'this')}
           />
@@ -63,6 +65,7 @@
             type="radio"
             name="delete-scope"
             aria-label="This and following"
+            data-choice
             checked={scope === 'following'}
             onchange={() => (scope = 'following')}
           />
@@ -76,6 +79,7 @@
             type="radio"
             name="delete-scope"
             aria-label="All events"
+            data-choice
             checked={scope === 'all'}
             onchange={() => (scope = 'all')}
           />
@@ -107,7 +111,14 @@
 
   {#snippet actions()}
     <button type="button" class="ghost" data-cancel onclick={oncancel}>Cancel</button>
-    <button type="button" class="primary" onclick={() => onconfirm(scope)}>Delete</button>
+    <button
+      type="button"
+      class="primary"
+      data-choice
+      data-default-choice-action
+      data-initial-choice={detail.is_recurring ? undefined : ''}
+      onclick={() => onconfirm(scope)}
+    >Delete</button>
   {/snippet}
 </ConfirmPanel>
 

--- a/ui/src/lib/DeleteConfirm.svelte
+++ b/ui/src/lib/DeleteConfirm.svelte
@@ -116,7 +116,6 @@
       class="primary"
       data-choice
       data-default-choice-action
-      data-initial-choice={detail.is_recurring ? undefined : ''}
       onclick={() => onconfirm(scope)}
     >Delete</button>
   {/snippet}

--- a/ui/src/lib/EventPopover.svelte
+++ b/ui/src/lib/EventPopover.svelte
@@ -11,6 +11,7 @@
   import { occurrenceDate, ruleInWords } from './eventform';
   import { isMachineAddress } from './organizer';
   import { respondToEvent, type Attendee, type EventDetail } from './eventdetail';
+  import { focusInitialChoice, handleChoiceKey } from './choicefocus';
 
   let {
     detail,
@@ -213,12 +214,14 @@
    */
   const joinUrl = $derived(detail.conference_uri ?? meetingUrl(detail.location));
 
-  function ask(response: 'accepted' | 'tentative' | 'declined', e: MouseEvent) {
+  async function ask(response: 'accepted' | 'tentative' | 'declined', e: MouseEvent) {
     if (!detail.is_recurring) {
       respond(response, 'this', e);
       return;
     }
     pending = response;
+    await tick();
+    focusInitialChoice(panelEl);
   }
   /** A `Set`, mirroring `CalendarPopover`: today there is only ever one RSVP
    *  target, so it never holds more than one entry, but a plain boolean
@@ -338,9 +341,15 @@
     note = { text: 'Copied — Ctrl+V pastes it as a new event', kind: 'info' };
     oncopy();
   }
+
+  function onPopoverKey(e: KeyboardEvent) {
+    onCopyKey(e);
+    if (e.defaultPrevented) return;
+    if (panelEl) handleChoiceKey(panelEl, e);
+  }
 </script>
 
-<svelte:window onkeydown={onCopyKey} />
+<svelte:window onkeydown={onPopoverKey} />
 
 <!-- A sibling of `.pop`, not a wrapper around it, so a click inside the
      panel — the guest list included — never reaches this button. -->
@@ -422,10 +431,10 @@
       <!-- The scope, asked exactly when it means something: a response has
            been chosen and this event repeats. `.scope` keeps its class so the
            one-off specs ("no scope controls at all") keep their meaning. -->
-      <div class="scope ask" role="group" aria-label="Apply to">
+      <div class="scope ask" role="group" aria-label="Apply to" data-choice-group>
         <span>{STATUS_WORD[pending]} —</span>
-        <button type="button" onclick={(e) => respond(pending!, 'this', e)}>This one</button>
-        <button type="button" onclick={(e) => respond(pending!, 'all', e)}>All of them</button>
+        <button type="button" data-choice data-initial-choice onclick={(e) => respond(pending!, 'this', e)}>This one</button>
+        <button type="button" data-choice onclick={(e) => respond(pending!, 'all', e)}>All of them</button>
         <button type="button" class="back" aria-label="Cancel" onclick={() => (pending = null)}>✕</button>
       </div>
     {/if}

--- a/ui/src/lib/MoveConfirm.svelte
+++ b/ui/src/lib/MoveConfirm.svelte
@@ -47,12 +47,14 @@
            writes: it ends the old series before this occurrence and creates a
            new one at the new time, which is why it cannot be described as
            "moves some of them". -->
-      <div class="scope" role="radiogroup" aria-label="Move">
+      <div class="scope" role="radiogroup" aria-label="Move" data-choice-group>
         <label>
           <input
             type="radio"
             name="move-scope"
             aria-label="This event"
+            data-choice
+            data-initial-choice
             checked={scope === 'this'}
             onchange={() => (scope = 'this')}
           />
@@ -63,6 +65,7 @@
             type="radio"
             name="move-scope"
             aria-label="This and following"
+            data-choice
             checked={scope === 'following'}
             onchange={() => (scope = 'following')}
           />
@@ -76,6 +79,7 @@
             type="radio"
             name="move-scope"
             aria-label="All events"
+            data-choice
             checked={scope === 'all'}
             onchange={() => (scope = 'all')}
           />
@@ -107,11 +111,15 @@
       <button
         type="button"
         class="ghost"
+        data-choice
         onclick={() => onconfirm({ scope, sendUpdates: 'all' })}
       >Move and notify guests</button>
       <button
         type="button"
         class="primary"
+        data-choice
+        data-default-choice-action
+        data-initial-choice={detail.is_recurring ? undefined : ''}
         onclick={() => onconfirm({ scope, sendUpdates: 'none' })}
       >Move without notifying</button>
     {:else}
@@ -120,6 +128,8 @@
       <button
         type="button"
         class="primary"
+        data-choice
+        data-default-choice-action
         onclick={() => onconfirm({ scope, sendUpdates: 'none' })}
       >Move</button>
     {/if}

--- a/ui/src/lib/SaveConfirm.svelte
+++ b/ui/src/lib/SaveConfirm.svelte
@@ -62,10 +62,10 @@
          same ruling as the drag's, for the same reason: sending mail to other
          people is the deliberate choice, never the default. This is also the
          only path from this form to `sendUpdates=all`. -->
-    <button type="button" class="ghost" onclick={() => onconfirm('all')}>
+    <button type="button" class="ghost" data-choice onclick={() => onconfirm('all')}>
       {verb} and notify guests
     </button>
-    <button type="button" class="primary" onclick={() => onconfirm('none')}>
+    <button type="button" class="primary" data-choice data-initial-choice onclick={() => onconfirm('none')}>
       {verb} without notifying
     </button>
   {/snippet}

--- a/ui/src/lib/SaveConfirm.svelte
+++ b/ui/src/lib/SaveConfirm.svelte
@@ -65,7 +65,7 @@
     <button type="button" class="ghost" data-choice onclick={() => onconfirm('all')}>
       {verb} and notify guests
     </button>
-    <button type="button" class="primary" data-choice data-initial-choice onclick={() => onconfirm('none')}>
+    <button type="button" class="primary" data-choice onclick={() => onconfirm('none')}>
       {verb} without notifying
     </button>
   {/snippet}

--- a/ui/src/lib/choicefocus.ts
+++ b/ui/src/lib/choicefocus.ts
@@ -1,0 +1,58 @@
+/** Keyboard behavior shared by the small follow-up questions that appear
+ * after an action. Callers mark the meaningful answers with `data-choice`,
+ * the answer that should receive focus with `data-initial-choice`, and (for a
+ * radio scope) the action Enter should perform with
+ * `data-default-choice-action`.
+ *
+ * Tab remains entirely native. Arrows stay inside the nearest
+ * `data-choice-group`, so a scope chooser and a notify chooser in the same
+ * dialog do not become one surprising circular list. */
+
+const enabledChoices = (root: ParentNode) =>
+  [...root.querySelectorAll<HTMLElement>('[data-choice]:not(:disabled)')];
+
+export function focusInitialChoice(root: ParentNode | null | undefined): void {
+  if (!root) return;
+  const initial = root.querySelector<HTMLElement>(
+    '[data-initial-choice]:not(:disabled)',
+  ) ?? enabledChoices(root)[0];
+  initial?.focus();
+}
+
+/** Returns true when the event belonged to a choice and was handled. */
+export function handleChoiceKey(root: HTMLElement, event: KeyboardEvent): boolean {
+  const target = event.target instanceof HTMLElement
+    ? event.target.closest<HTMLElement>('[data-choice]')
+    : null;
+  if (!target || !root.contains(target)) return false;
+
+  if (event.key === 'Enter'
+      && target instanceof HTMLInputElement
+      && target.type === 'radio') {
+    const action = root.querySelector<HTMLButtonElement>(
+      '[data-default-choice-action]:not(:disabled)',
+    );
+    if (!action) return false;
+    event.preventDefault();
+    action.click();
+    return true;
+  }
+
+  const delta = event.key === 'ArrowRight' || event.key === 'ArrowDown'
+    ? 1
+    : event.key === 'ArrowLeft' || event.key === 'ArrowUp'
+      ? -1
+      : 0;
+  if (delta === 0) return false;
+
+  const group = target.closest<HTMLElement>('[data-choice-group]') ?? root;
+  const choices = enabledChoices(group);
+  const index = choices.indexOf(target);
+  if (index < 0 || choices.length < 2) return false;
+
+  event.preventDefault();
+  const next = choices[(index + delta + choices.length) % choices.length];
+  if (next instanceof HTMLInputElement && next.type === 'radio') next.click();
+  next.focus();
+  return true;
+}

--- a/ui/src/lib/choicefocus.ts
+++ b/ui/src/lib/choicefocus.ts
@@ -15,7 +15,8 @@ export function focusInitialChoice(root: ParentNode | null | undefined): void {
   if (!root) return;
   const initial = root.querySelector<HTMLElement>(
     '[data-initial-choice]:not(:disabled)',
-  ) ?? enabledChoices(root)[0];
+  ) ?? root.querySelector<HTMLElement>('[data-cancel]:not(:disabled)')
+    ?? enabledChoices(root)[0];
   initial?.focus();
 }
 

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -1975,11 +1975,12 @@ test.describe('App', () => {
     expect(args.occurrenceStartMs).not.toBe(APP_ALLDAY_SERIES_DTSTART);
   });
 
-  test('cancelling the confirmation deletes nothing', async ({ page }) => {
+  test('Space on the focused Cancel button deletes nothing', async ({ page }) => {
     await writable(page);
-    await block(page, 'Standup').click();
+    await block(page, 'Board prep').click();
     await page.getByRole('button', { name: 'Delete' }).click();
-    await confirmPanel(page).getByRole('button', { name: 'Cancel' }).click();
+    await expect(confirmPanel(page).getByRole('button', { name: 'Cancel' })).toBeFocused();
+    await page.keyboard.press('Space');
     await expect(confirmPanel(page)).toHaveCount(0);
     expect(await callsTo(page, 'delete_event_cmd')).toEqual([]);
   });

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -848,7 +848,10 @@ test.describe('App', () => {
       // A one-off: there is no scope to choose, so the chooser is not offered.
       await expect(movePanel(page).getByRole('radiogroup')).toHaveCount(0);
 
-      await movePanel(page).getByRole('button', { name: 'Move without notifying' }).click();
+      await expect(
+        movePanel(page).getByRole('button', { name: 'Move without notifying' }),
+      ).toBeFocused();
+      await page.keyboard.press('Enter');
 
       await expect.poll(() => callsTo(page, 'update_event')).toHaveLength(1);
       const [args] = await callsTo(page, 'update_event');
@@ -947,10 +950,16 @@ test.describe('App', () => {
         movePanel(page).getByRole('button', { name: 'Move and notify guests' }),
       ).toHaveCount(0);
 
-      await movePanel(page).getByRole('button', { name: 'Move', exact: true }).click();
+      await expect(movePanel(page).getByRole('radio', { name: 'This event' })).toBeFocused();
+      await page.keyboard.press('ArrowDown');
+      await expect(
+        movePanel(page).getByRole('radio', { name: 'This and following' }),
+      ).toBeChecked();
+      await page.keyboard.press('Enter');
       await expect.poll(() => callsTo(page, 'update_event')).toHaveLength(1);
       const [args] = await callsTo(page, 'update_event');
       expect(args.sendUpdates).toBe('none');
+      expect(args.scope).toBe('following');
     });
 
     /** Escape closes a confirmation and writes nothing — the same key that

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -1975,12 +1975,12 @@ test.describe('App', () => {
     expect(args.occurrenceStartMs).not.toBe(APP_ALLDAY_SERIES_DTSTART);
   });
 
-  test('Space on the focused Cancel button deletes nothing', async ({ page }) => {
+  test('cancelling the confirmation with Enter deletes nothing', async ({ page }) => {
     await writable(page);
     await block(page, 'Board prep').click();
     await page.getByRole('button', { name: 'Delete' }).click();
     await expect(confirmPanel(page).getByRole('button', { name: 'Cancel' })).toBeFocused();
-    await page.keyboard.press('Space');
+    await page.keyboard.press('Enter');
     await expect(confirmPanel(page)).toHaveCount(0);
     expect(await callsTo(page, 'delete_event_cmd')).toEqual([]);
   });

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -4141,8 +4141,10 @@ test.describe('EventForm', () => {
   test('Save without notifying sends none', async ({ page }) => {
     await open(page, 'with-guests');
     await page.getByRole('button', { name: 'Save', exact: true }).click();
-    await expect(page.getByRole('button', { name: 'Save without notifying' })).toBeFocused();
-    await page.keyboard.press('Enter');
+    await expect(
+      page.getByRole('dialog', { name: 'Save event' }).getByRole('button', { name: 'Cancel' }),
+    ).toBeFocused();
+    await page.getByRole('button', { name: 'Save without notifying' }).click();
 
     const [saved] = await saves(page);
     expect(saved.notify).toBe('none');
@@ -4275,13 +4277,14 @@ test.describe('DeleteConfirm', () => {
     expect(await confirms(page)).toEqual(['following']);
   });
 
-  test('a one-off focuses Cancel while Enter accepts the action', async ({ page }) => {
+  test('a one-off focuses Cancel and Enter cancels without deleting', async ({ page }) => {
     await open(page, 'one-off');
     await expect(
       page.getByRole('dialog', { name: 'Delete event' }).getByRole('button', { name: 'Cancel' }),
     ).toBeFocused();
     await page.keyboard.press('Enter');
-    expect(await confirms(page)).toEqual(['this']);
+    await expect(page.getByRole('dialog', { name: 'Delete event' })).toHaveCount(0);
+    expect(await confirms(page)).toEqual([]);
   });
 
   // Each radio bound to the scope it actually sends, one spec per option, so

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -4275,9 +4275,11 @@ test.describe('DeleteConfirm', () => {
     expect(await confirms(page)).toEqual(['following']);
   });
 
-  test('a one-off focuses Delete so Enter accepts the only option', async ({ page }) => {
+  test('a one-off focuses Cancel while Enter accepts the action', async ({ page }) => {
     await open(page, 'one-off');
-    await expect(page.getByRole('button', { name: 'Delete' })).toBeFocused();
+    await expect(
+      page.getByRole('dialog', { name: 'Delete event' }).getByRole('button', { name: 'Cancel' }),
+    ).toBeFocused();
     await page.keyboard.press('Enter');
     expect(await confirms(page)).toEqual(['this']);
   });

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -2117,6 +2117,20 @@ test.describe('EventPopover', () => {
     await expect(page.locator('.pop')).toBeFocused();
   });
 
+  test('a recurring RSVP focuses its first scope and arrows before Enter accepts', async ({ page }) => {
+    await page.goto(show('recurring'));
+    await page.getByRole('button', { name: 'No', exact: true }).click();
+
+    await expect(page.getByRole('button', { name: 'This one' })).toBeFocused();
+    expect(await page.evaluate(() => (window as any).__lastRespondCall ?? null)).toBeNull();
+
+    await page.keyboard.press('ArrowRight');
+    await expect(page.getByRole('button', { name: 'All of them' })).toBeFocused();
+    await page.keyboard.press('Enter');
+    await expect.poll(() => page.evaluate(() => (window as any).__lastRespondCall?.scope))
+      .toBe('all');
+  });
+
   test('a description containing markup is shown as text', async ({ page }) => {
     await page.goto(show('nasty-description'));
     await expect(page.locator('.desc')).toContainText('<script>alert(1)</script>');
@@ -4126,7 +4140,9 @@ test.describe('EventForm', () => {
    */
   test('Save without notifying sends none', async ({ page }) => {
     await open(page, 'with-guests');
-    await answerNotify(page, 'Save without notifying');
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await expect(page.getByRole('button', { name: 'Save without notifying' })).toBeFocused();
+    await page.keyboard.press('Enter');
 
     const [saved] = await saves(page);
     expect(saved.notify).toBe('none');
@@ -4245,6 +4261,25 @@ test.describe('DeleteConfirm', () => {
     await page.getByRole('radio', { name: 'This and following' }).check();
     await page.getByRole('button', { name: 'Delete' }).click();
     expect(await confirms(page)).toEqual(['following']);
+  });
+
+  test('the first scope is focused, arrows change it, and Enter confirms it', async ({ page }) => {
+    await open(page, 'recurring');
+    await expect(page.getByRole('radio', { name: 'This event' })).toBeFocused();
+
+    await page.keyboard.press('ArrowDown');
+    await expect(page.getByRole('radio', { name: 'This and following' })).toBeFocused();
+    await expect(page.getByRole('radio', { name: 'This and following' })).toBeChecked();
+
+    await page.keyboard.press('Enter');
+    expect(await confirms(page)).toEqual(['following']);
+  });
+
+  test('a one-off focuses Delete so Enter accepts the only option', async ({ page }) => {
+    await open(page, 'one-off');
+    await expect(page.getByRole('button', { name: 'Delete' })).toBeFocused();
+    await page.keyboard.press('Enter');
+    expect(await confirms(page)).toEqual(['this']);
   });
 
   // Each radio bound to the scope it actually sends, one spec per option, so


### PR DESCRIPTION
## Summary

- Focus the first meaningful option in recurring-action follow-ups.
- Let arrow keys move within option groups while Tab stays native.
- Standardize two-button confirmations: Space/Escape cancels and Enter confirms the action.

## Testing

- `npm --prefix ui run check`
- `npm --prefix ui run test:ui -- --project=chromium`