### PR TITLE
fix(clock): use the selected format in notifications

### DIFF
--- a/src-tauri/src/invites.rs
+++ b/src-tauri/src/invites.rs
@@ -34,7 +34,7 @@ const MONTHS: [&str; 12] =
 /// `Wed, Aug 19` for an instant read in `tz` — a reminder fires minutes ahead
 /// and says only the hour, but an invitation may be for weeks away, so the
 /// day is the headline. Unknown zones fall back to UTC, the same policy as
-/// `notify::time_in_zone`.
+/// `notify::time_in_zone_with_format`.
 fn date_in_words(ms: i64, tz: &str) -> String {
     let ts = jiff::Timestamp::from_millisecond(ms).unwrap_or(jiff::Timestamp::UNIX_EPOCH);
     let z = ts.in_tz(tz).unwrap_or_else(|_| ts.in_tz("UTC").expect("UTC always resolves"));
@@ -61,14 +61,18 @@ pub(crate) fn offers_accept(c: &InviteCandidate) -> bool {
 /// The "Click to accept" line appears only when the click actually does that:
 /// an action-less announcement (CalDAV, a read-only calendar, macOS's
 /// button-less transport) must not instruct anyone to click.
-pub(crate) fn invite_notification(c: &InviteCandidate, display_tz: &str) -> Notification {
+pub(crate) fn invite_notification_with_format(
+    c: &InviteCandidate,
+    display_tz: &str,
+    time_format: crate::settings::TimeFormat,
+) -> Notification {
     let when = if c.is_all_day {
         format!("{} · All day", date_in_words(c.start_utc, &c.calendar_timezone))
     } else {
         format!(
             "{} · {}",
             date_in_words(c.start_utc, display_tz),
-            crate::notify::time_in_zone(c.start_utc, display_tz)
+            crate::notify::time_in_zone_with_format(c.start_utc, display_tz, time_format)
         )
     };
 
@@ -108,6 +112,14 @@ pub(crate) fn invite_notification(c: &InviteCandidate, display_tz: &str) -> Noti
         // invite still deserves to be seen, and dismissal is one right-click.
         sticky: true,
     }
+}
+
+/// A 24-hour wrapper for tests whose subject is invitation wording or actions
+/// rather than the clock. The live pass has no default and always supplies
+/// the stored preference.
+#[cfg(test)]
+pub(crate) fn invite_notification(c: &InviteCandidate, display_tz: &str) -> Notification {
+    invite_notification_with_format(c, display_tz, crate::settings::TimeFormat::H24)
 }
 
 /// One pass over the ledger: seed what predates the watch, announce what is
@@ -154,7 +166,11 @@ pub(crate) async fn run_pass(
         if !c.calendar_selected {
             continue;
         }
-        if let Err(e) = notifier.post(&invite_notification(&c, display_tz)) {
+        if let Err(e) = notifier.post(&invite_notification_with_format(
+            &c,
+            display_tz,
+            settings.time_format,
+        )) {
             tracing::warn!(%e, event_id = c.event_id, "could not announce an invitation");
         }
         omacal_store::record_invite_notice(pool, c.event_id, true, now_ms).await?;
@@ -632,6 +648,20 @@ mod tests {
         assert_eq!(fake.posted().len(), 1);
     }
 
+    #[tokio::test]
+    async fn the_pass_applies_the_stored_clock_format_to_invitation_notifications() {
+        let pool = seeded_pool().await;
+        seeded_and_swallowed(&pool).await;
+        sqlx::query("INSERT INTO settings (key, value) VALUES ('time_format', '12h')")
+            .execute(&pool).await.unwrap();
+        upsert_event(&pool, &invite("new-1", NOW + HOUR)).await.unwrap();
+
+        let fake = RecordingNotifier::default();
+        run_pass(&pool, false, NOW, SOFIA, &fake).await.unwrap();
+
+        assert!(fake.posted()[0].body.starts_with("Mon, Aug 10 · 1:00 PM"));
+    }
+
     /// `run_once`'s trade, inherited deliberately: a refusing transport logs
     /// and records rather than retrying the same announcement forever.
     #[tokio::test]
@@ -742,6 +772,16 @@ mod tests {
         assert_eq!(n.title, "Invitation: NVP sync meeting");
         // 2026-08-10T10:00Z is Monday 13:00 in Sofia.
         assert!(n.body.starts_with("Mon, Aug 10 · 13:00 · from ana@x.com"), "{}", n.body);
+    }
+
+    #[test]
+    fn a_timed_invitation_uses_the_selected_twelve_hour_clock() {
+        let n = invite_notification_with_format(
+            &candidate(),
+            SOFIA,
+            crate::settings::TimeFormat::H12,
+        );
+        assert!(n.body.starts_with("Mon, Aug 10 · 1:00 PM · from ana@x.com"), "{}", n.body);
     }
 
     #[test]

--- a/src-tauri/src/notify.rs
+++ b/src-tauri/src/notify.rs
@@ -2,7 +2,7 @@
 //!
 //! Two halves, split so only one of them is untestable.
 //!
-//! [`notification_for`] decides *what a reminder says* — title, body, which
+//! [`notification_for_format`] decides *what a reminder says* — title, body, which
 //! actions. It is a pure function of a [`Due`] and a zone, so every rule about
 //! wording and about when a *Join* button appears is tested without anything
 //! being posted anywhere.
@@ -16,6 +16,7 @@
 //! stated here rather than hidden, per spec §3.
 
 use omacal_core::remind::Due;
+use crate::settings::TimeFormat;
 
 /// What a posted notification says.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -154,11 +155,15 @@ pub(crate) const NO_TITLE: &str = "(no title)";
 /// midnight in the *calendar's* zone, which rendered in the display zone is
 /// some arbitrary hour of the previous or next day — an actively misleading
 /// thing to print.
-pub(crate) fn notification_for(d: &Due, tz: &str) -> Notification {
+pub(crate) fn notification_for_format(
+    d: &Due,
+    tz: &str,
+    time_format: TimeFormat,
+) -> Notification {
     let when = if d.is_all_day {
         "All day".to_string()
     } else {
-        time_in_zone(d.key.occurrence_ms, tz)
+        time_in_zone_with_format(d.key.occurrence_ms, tz, time_format)
     };
 
     let body = match &d.location {
@@ -194,12 +199,28 @@ pub(crate) fn notification_for(d: &Due, tz: &str) -> Notification {
     }
 }
 
-/// `HH:MM` for an instant, read in `tz`. Falls back to UTC for an unknown zone
-/// rather than panicking, the same policy as `omacal_core::zone::date_in_zone`.
-pub(crate) fn time_in_zone(ms: i64, tz: &str) -> String {
+/// A clock time for an instant, read in `tz`. Falls back to UTC for an unknown
+/// zone rather than panicking, the same policy as
+/// `omacal_core::zone::date_in_zone`.
+pub(crate) fn time_in_zone_with_format(ms: i64, tz: &str, time_format: TimeFormat) -> String {
     let ts = jiff::Timestamp::from_millisecond(ms).unwrap_or(jiff::Timestamp::UNIX_EPOCH);
     let z = ts.in_tz(tz).unwrap_or_else(|_| ts.in_tz("UTC").expect("UTC always resolves"));
-    format!("{:02}:{:02}", z.hour(), z.minute())
+    match time_format {
+        TimeFormat::H24 => format!("{:02}:{:02}", z.hour(), z.minute()),
+        TimeFormat::H12 => {
+            let hour = z.hour();
+            let dial = if hour % 12 == 0 { 12 } else { hour % 12 };
+            format!("{dial}:{:02} {}", z.minute(), if hour < 12 { "AM" } else { "PM" })
+        }
+    }
+}
+
+/// The pre-preference spelling retained only for the tests whose subject is
+/// notification content other than the clock. Production has no default: it
+/// must pass the stored preference to `notification_for_format`.
+#[cfg(test)]
+pub(crate) fn notification_for(d: &Due, tz: &str) -> Notification {
+    notification_for_format(d, tz, TimeFormat::H24)
 }
 
 /// The category ids registered once with the macOS notification centre.
@@ -468,6 +489,23 @@ mod tests {
 
         let utc = notification_for(&due(Some("Standup"), None, None), "UTC");
         assert_eq!(utc.body, "09:00", "the zone argument must actually be used");
+    }
+
+    #[test]
+    fn the_body_uses_the_selected_twelve_hour_clock() {
+        let noon = notification_for_format(
+            &due(Some("Standup"), None, None),
+            SOFIA,
+            crate::settings::TimeFormat::H12,
+        );
+        assert_eq!(noon.body, "12:00 PM");
+
+        let morning = notification_for_format(
+            &due(Some("Standup"), None, None),
+            "UTC",
+            crate::settings::TimeFormat::H12,
+        );
+        assert_eq!(morning.body, "9:00 AM");
     }
 
     /// An absolute time rather than "in 10 minutes", and deliberately: a missed

--- a/src-tauri/src/notify_loop.rs
+++ b/src-tauri/src/notify_loop.rs
@@ -216,7 +216,11 @@ pub(crate) async fn run_once(
             continue;
         }
 
-        if let Err(e) = notifier.post(&crate::notify::notification_for(&d, tz)) {
+        if let Err(e) = notifier.post(&crate::notify::notification_for_format(
+            &d,
+            tz,
+            settings.time_format,
+        )) {
             // Logged and dropped. Never a banner, never a retry — see this
             // function's own doc comment for why the reminder is still
             // recorded below.
@@ -410,6 +414,20 @@ mod tests {
             vec![(1, T0900Z, 10)],
             "posting without recording re-posts on the next pass"
         );
+    }
+
+    #[tokio::test]
+    async fn the_pass_applies_the_stored_clock_format_to_notifications() {
+        let pool = seeded("UTC", "[]").await;
+        sqlx::query("INSERT INTO settings (key, value) VALUES ('time_format', '12h')")
+            .execute(&pool).await.unwrap();
+        omacal_store::upsert_event(&pool, &event("e1", T0900Z, T0900Z + HOUR, own(10)))
+            .await.unwrap();
+
+        let fake = crate::notify::RecordingNotifier::default();
+        pass_with(&pool, T0900Z - 10 * MINUTE, &fake).await;
+
+        assert_eq!(fake.posted()[0].body, "12:00 PM");
     }
 
     /// A fire-time still ahead is scheduled, not posted. `due_reminders` hands


### PR DESCRIPTION
## Summary

- Apply the stored 12/24-hour preference to event reminders.
- Use the same preference for invitation notifications.
- Keep all-day notification wording unchanged.

## Testing

- `cargo test -p omacal --lib`