### PR TITLE
feat(today): scroll the current time into view

### DIFF
--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -63,6 +63,11 @@
   // button, and Month's own `ondaypick` ever assign it.
   let anchorMs = $state(dayStart(Date.now()));
   let view = $state<View>('week');
+  /** Monotonic request carried to whichever time-oriented view is mounted.
+   *  A counter rather than a boolean makes a second `T` while already on
+   *  today observable—the anchor does not change in that case, but the user
+   *  still explicitly asked to reveal the current time again. */
+  let revealNowRequest = $state(0);
 
   // Year and Big Year read a bare calendar year rather than a millisecond
   // anchor — there is no single day inside them for `anchorMs` to name — so
@@ -486,7 +491,9 @@
   }
 
   function goToday() {
-    anchorMs = dayStart(Date.now());
+    const today = dayStart(Date.now());
+    anchorMs = today;
+    revealNowRequest += 1;
   }
 
   // The chokepoint both the switcher's buttons and the number keys go
@@ -1255,7 +1262,8 @@
   {#if view === 'month'}
     {#if month}
       {#if listMode}
-        <Filmstrip days={daysFromMonth(month)} {weather} onopen={openGridEvent} />
+        <Filmstrip days={daysFromMonth(month)} {weather} {revealNowRequest}
+                   onopen={openGridEvent} />
       {:else}
         <MonthGrid {month} onopen={openGridEvent} ondaypick={handleDayPick} oncreate={newEventOnDay} />
       {/if}
@@ -1285,9 +1293,11 @@
     {/if}
   {:else if week}
     {#if listMode}
-      <Filmstrip days={daysFromWeek(week)} {weather} onopen={openGridEvent} />
+      <Filmstrip days={daysFromWeek(week)} {weather} {revealNowRequest}
+                 onopen={openGridEvent} />
     {:else}
-      <WeekGrid {week} {weather} {formPreview} oncreate={newEventAt} onedit={openEdit} ondelete={askDelete}
+      <WeekGrid {week} {weather} {formPreview} {revealNowRequest}
+                oncreate={newEventAt} onedit={openEdit} ondelete={askDelete}
                 oncopy={copyOccurrence}
         onmove={moveOccurrence} onresponded={refreshAfterWrite} />
     {/if}

--- a/ui/src/lib/Filmstrip.svelte
+++ b/ui/src/lib/Filmstrip.svelte
@@ -9,13 +9,15 @@
   import { dateKey, type DayWeather } from './weather';
   import type { ListDay } from './filmstrip';
 
-  let { days, weather = null, onopen }: {
+  let { days, weather = null, revealNowRequest = 0, onopen }: {
     /** Already grouped, ordered and emptied of blank days by `filmstrip.ts`.
      *  This component draws a list; it does not decide what is in one. */
     days: ListDay[];
     /** The forecast by ISO date, or null for none — same contract as
      *  `WeekGrid`'s: a heading with no sky is just a heading. */
     weather?: Map<string, DayWeather> | null;
+    /** The explicit Today request counter shared with the clock grid. */
+    revealNowRequest?: number;
     /** Same contract as `MonthGrid`'s and `BigYearRibbon`'s: the clicked event
      *  plus an anchor rect, handed straight up to `App.openGridEvent` and so to
      *  `openOccurrence`.
@@ -68,19 +70,53 @@
    *  which the template reads as "no marker in this section".
    *
    *  A `ListDay` carries only its midnight, so "today" is `startMs`'s
-   *  24-hour window; DST puts the boundary an hour out twice a year, which
-   *  for a marker between rows is a miss of nothing. */
+   *  24-hour window. */
   function markerIndex(d: ListDay, now: number): number {
     if (now < d.startMs || now >= d.startMs + 24 * 3_600_000) return -1;
     const i = d.events.findIndex((ev) => !ev.is_all_day && ev.start_ms > now);
     return i === -1 ? d.events.length : i;
   }
+
+  let stripEl: HTMLDivElement | undefined = $state();
+  let handledRevealNowRequest: number | null = null;
+  const NOW_VIEWPORT_FRACTION = 0.45;
+
+  // A list has no hour geometry to calculate against, so centre the rendered
+  // NOW row itself. As in WeekGrid, a Today request waits for the newly-loaded
+  // period rather than being consumed by the old one, and repeated requests
+  // remain meaningful while the anchor already names today.
+  $effect(() => {
+    if (!stripEl) return;
+    const request = revealNowRequest;
+    if (handledRevealNowRequest === null) {
+      handledRevealNowRequest = request;
+      return;
+    }
+    const revealRequested = request !== handledRevealNowRequest;
+    if (!revealRequested) return;
+    const today = days.find(
+      (d) => nowMs >= d.startMs && nowMs < d.startMs + 24 * 3_600_000,
+    );
+    if (!today) return;
+    const el = stripEl;
+    requestAnimationFrame(() => {
+      const marker = el.querySelector<HTMLElement>('.nowrow');
+      if (!marker) return;
+      const viewport = el.getBoundingClientRect();
+      const markerTop = marker.getBoundingClientRect().top - viewport.top + el.scrollTop;
+      el.scrollTop = Math.max(
+        0,
+        markerTop - el.clientHeight * NOW_VIEWPORT_FRACTION,
+      );
+      if (revealRequested) handledRevealNowRequest = request;
+    });
+  });
 </script>
 
 <!-- **No drag handlers anywhere below, and that is the feature** (spec §6): a
      list has no geometry to drop onto, so they are absent rather than disabled.
      Creating still works through `n` and through the form. -->
-<div class="strip">
+<div class="strip" bind:this={stripEl}>
   {#if days.length === 0}
     <!-- Spec §3: a period with nothing in it says so, plainly, rather than
          rendering as blank. Empty days being skipped is exactly what makes an

--- a/ui/src/lib/WeekGrid.svelte
+++ b/ui/src/lib/WeekGrid.svelte
@@ -16,7 +16,7 @@
     SNAP_MS, beganDrag, colsMoved, edgeAt, spanForMove, spanForResize, spanForSweep,
   } from './drag';
 
-  let { week, weather = null, formPreview = null, oncreate, onedit, ondelete, oncopy, onmove, onresponded }: {
+  let { week, weather = null, formPreview = null, revealNowRequest = 0, oncreate, onedit, ondelete, oncopy, onmove, onresponded }: {
     week: WeekPayload;
     /** The forecast by ISO date (`weather.ts`), or null for none — off, not
      *  yet fetched, or failed all look the same here: a header with no sky,
@@ -26,6 +26,9 @@
      *  ghost so the user watches the event land while typing its times —
      *  create and edit alike. Null draws nothing. */
     formPreview?: { startMs: number; endMs: number } | null;
+    /** Incremented by App for every explicit Today action, including when the
+     *  anchor already names today and therefore no payload navigation occurs. */
+    revealNowRequest?: number;
     /** A click on empty space in a day column, at the half hour it landed in,
      *  or a **sweep** across it, which names an `endMs` as well.
      *  `rect` is the anchor to put the form beside — the column at the height
@@ -129,26 +132,49 @@
     return d.getTime();
   });
 
-  // Opening at midnight puts the working day off-screen. Scroll once on mount so
-  // the current time sits about a third down — near enough to read what is next
-  // without losing what just happened. Weeks without today open at 08:00.
+  // Opening at midnight puts the working day off-screen. Preserve the existing
+  // once-on-mount placement at one third of the viewport; weeks without today
+  // open at 08:00. An explicit Today request instead puts now at 45%, and
+  // repeats even when the anchor was already today—which is why it cannot be
+  // inferred from a `week` prop change.
   //
   // Deliberately once, not on every week change: navigating away and back should
   // keep where you were looking, which is what every desktop calendar does.
   let bodyEl: HTMLDivElement | undefined = $state();
   let hasScrolled = false;
+  let handledRevealNowRequest: number | null = null;
+  const INITIAL_VIEWPORT_FRACTION = 1 / 3;
+  const NOW_VIEWPORT_FRACTION = 0.45;
 
   $effect(() => {
-    if (!bodyEl || hasScrolled || week.days.length === 0) return;
+    if (!bodyEl || week.days.length === 0) return;
     const el = bodyEl;
-    const today = week.days.find((d) => d.start_ms === todayStart);
+    const now = Date.now();
+    const today = week.days.find((d) => now >= d.start_ms && now < d.end_ms);
+    if (handledRevealNowRequest === null) handledRevealNowRequest = revealNowRequest;
+    const revealRequested = revealNowRequest !== handledRevealNowRequest;
+
+    // When Today also navigated from another period, its request reaches this
+    // component before the new payload can. Leave it pending until the payload
+    // containing now arrives; handling it against the old week would scroll an
+    // unrelated 08:00 into view and consume the user's request.
+    if (revealRequested && !today) return;
+    if (!revealRequested && hasScrolled) return;
+
     const frac = today
-      ? (Date.now() - today.start_ms) / (today.end_ms - today.start_ms)
+      ? (now - today.start_ms) / (today.end_ms - today.start_ms)
       : hourFrac(gutterDay, 8);
     hasScrolled = true;
+    if (revealRequested) handledRevealNowRequest = revealNowRequest;
     // After layout: scrollHeight is meaningless until the columns have height.
     requestAnimationFrame(() => {
-      el.scrollTop = Math.max(0, frac * el.scrollHeight - el.clientHeight / 3);
+      const viewportFraction = revealRequested
+        ? NOW_VIEWPORT_FRACTION
+        : INITIAL_VIEWPORT_FRACTION;
+      el.scrollTop = Math.max(
+        0,
+        frac * el.scrollHeight - el.clientHeight * viewportFraction,
+      );
     });
   });
 

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -544,8 +544,53 @@ test.describe('App', () => {
     await page.keyboard.press('l');
     await page.keyboard.press('l');
     expect(await col.getAttribute('data-start-ms')).not.toBe(opened);
+    await page.getByTestId('week-body').evaluate((el) => { el.scrollTop = 0; });
     await page.keyboard.press('t');
     expect(await col.getAttribute('data-start-ms')).toBe(opened);
+    // The reveal request must wait for today's payload rather than being
+    // consumed by the week that was still mounted when T was pressed.
+    await expect.poll(() => page.evaluate(() => {
+      const viewport = document.querySelector<HTMLElement>('[data-testid="week-body"]')!;
+      const marker = viewport.querySelector<HTMLElement>('.now')!;
+      const box = viewport.getBoundingClientRect();
+      const position = (marker.getBoundingClientRect().top - box.top) / box.height;
+      return Math.abs(position - 0.45);
+    })).toBeLessThan(0.07);
+  });
+
+  test('Today recenters NOW in Week and Day, even when already on today', async ({ page }) => {
+    await page.clock.setFixedTime(APP_MON + 16 * 3_600_000);
+    await page.goto(app('connected'));
+
+    const hideNow = () => page.getByTestId('week-body').evaluate((el) => { el.scrollTop = 0; });
+    const nowPosition = () => page.evaluate(() => {
+      const viewport = document.querySelector<HTMLElement>('[data-testid="week-body"]')!;
+      const marker = viewport.querySelector<HTMLElement>('.now')!;
+      const box = viewport.getBoundingClientRect();
+      return (marker.getBoundingClientRect().top - box.top) / box.height;
+    });
+    const expectCentered = async () => {
+      await expect.poll(async () => Math.abs((await nowPosition()) - 0.45))
+        .toBeLessThan(0.07);
+    };
+
+    // Already on today's week: changing the anchor alone would be a no-op, so
+    // this proves the key itself carries an explicit reveal request.
+    await hideNow();
+    await page.keyboard.press('t');
+    await expectCentered();
+
+    // The header button is the same action, including on a second invocation.
+    await hideNow();
+    await page.getByRole('button', { name: 'Today', exact: true }).click();
+    await expectCentered();
+
+    // Day uses the same clock grid with one column and keeps the same contract.
+    await page.keyboard.press('1');
+    await expect(page.locator('.col')).toHaveCount(1);
+    await hideNow();
+    await page.keyboard.press('t');
+    await expectCentered();
   });
 
   // Own spec, guarding the keyboard trap (not in the brief's five): the event
@@ -2083,6 +2128,36 @@ test.describe('App', () => {
     await page.keyboard.press('f');
     await expect(page.locator('.ev')).toHaveCount(1);
     await expect(rows(page)).toHaveCount(0);
+  });
+
+  test('Today reveals the NOW row in list view', async ({ page }) => {
+    await page.clock.setFixedTime(APP_MON + 20 * 3_600_000);
+    await page.setViewportSize({ width: 900, height: 260 });
+    await opened(page);
+    await page.keyboard.press('f');
+
+    const strip = page.locator('.strip');
+    const marker = strip.locator('.nowrow');
+    await expect(marker).toHaveCount(1);
+    await strip.evaluate((el) => {
+      (el as HTMLElement).style.flex = 'none';
+      (el as HTMLElement).style.height = '30px';
+      el.scrollTop = 0;
+    });
+    await expect.poll(async () => {
+      const viewport = await strip.boundingBox();
+      const now = await marker.boundingBox();
+      return !!viewport && !!now && now.y > viewport.y + viewport.height;
+    }).toBe(true);
+
+    await page.keyboard.press('t');
+    await expect.poll(async () => {
+      const viewport = await strip.boundingBox();
+      const now = await marker.boundingBox();
+      return !!viewport && !!now
+        && now.y >= viewport.y
+        && now.y + now.height <= viewport.y + viewport.height;
+    }).toBe(true);
   });
 
   test('the control and the key are the same switch', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Center the current time when Today is pressed in Week or Day view.
- Honor repeated Today presses even when the calendar is already on today.
- Reveal the NOW marker in list view too.

## Testing

- `npm --prefix ui run check`
- `npm --prefix ui run test:ui -- --project=chromium`