### PR TITLE
feat(settings): configure the default event duration

### DIFF
--- a/src-tauri/src/errors.rs
+++ b/src-tauri/src/errors.rs
@@ -152,6 +152,9 @@ const SAFE_EXACT: &[&str] = &[
     // value the user cannot read a reason for is barely better. Pinned by
     // `an_interval_below_the_floor_is_refused_and_nothing_is_stored`.
     crate::settings::INTERVAL_TOO_SHORT,
+    // src-tauri/src/settings.rs — the default event duration cannot describe
+    // a zero-length event. Fixed literal, raised before the settings write.
+    crate::settings::EVENT_DURATION_TOO_SHORT,
     // src-tauri/src/events.rs — `split_series`' refusal to split a series that
     // ends after a fixed number of occurrences. Fixed literal, no
     // interpolation, raised with `bail!` before either write and propagated by
@@ -338,6 +341,9 @@ mod tests {
              you now have two overlapping series and should delete one",
             crate::events::CONFLICT_GUESTS,
             crate::settings::INTERVAL_TOO_SHORT,
+            // Fixed literal raised before the settings write, with no
+            // interpolation or context added on the command path.
+            crate::settings::EVENT_DURATION_TOO_SHORT,
             // Checked against the doc-comment rule: a fixed literal raised
             // only after Google's insert succeeded, no interpolation, and
             // `create_event`'s `.map_err(user_facing)` adds no context.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1359,6 +1359,7 @@ pub fn run() {
             settings::set_list_mode,
             settings::set_fallback_reminders,
             settings::set_default_calendar,
+            settings::set_default_event_duration,
             settings::set_time_format,
             settings::set_week_start,
             events::event_detail,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -16,6 +16,7 @@ const NOTIFICATIONS_KEY: &str = "notifications_enabled";
 const LIST_MODE_KEY: &str = "list_mode";
 const FALLBACK_KEY: &str = "fallback_reminder_minutes";
 const DEFAULT_CALENDAR_KEY: &str = "default_calendar_id";
+const DEFAULT_EVENT_DURATION_KEY: &str = "default_event_duration_minutes";
 const TIME_FORMAT_KEY: &str = "time_format";
 const WEEK_START_KEY: &str = "week_start";
 const TRAY_ICON_KEY: &str = "tray_icon";
@@ -186,6 +187,9 @@ pub struct AppSettings {
     /// an id a create cannot land on) has to exist regardless — and a
     /// write-time check would only duplicate it with a second rule to drift.
     pub default_calendar_id: Option<i64>,
+    /// Minutes a new timed event lasts when the user names only its start.
+    /// Sixty preserves the existing behavior for installs without this row.
+    pub default_event_duration_minutes: u32,
     /// Whether the system tray icon is shown. **On by default** — the tray is
     /// where Quit lives, and an app that hides its only quit affordance on a
     /// fresh install has made a decision nobody asked it to. Turning it off
@@ -303,6 +307,11 @@ pub async fn read_settings(pool: &SqlitePool) -> AppSettings {
         default_calendar_id: read(pool, DEFAULT_CALENDAR_KEY)
             .await
             .and_then(|v| v.parse().ok()),
+        default_event_duration_minutes: read(pool, DEFAULT_EVENT_DURATION_KEY)
+            .await
+            .and_then(|v| v.parse::<u32>().ok())
+            .filter(|&minutes| minutes > 0)
+            .unwrap_or(60),
         // `== "12h"` rather than `!= "24h"`, the same polarity `list_mode`
         // takes and for the same reason: absent, garbage, and a value written
         // by some future version all land on the format the app has always
@@ -337,6 +346,9 @@ pub async fn read_settings(pool: &SqlitePool) -> AppSettings {
 pub const INTERVAL_TOO_SHORT: &str =
     "omacal will not sync more often than once a minute — Google's quota is finite and a \
      desktop app has no business polling faster than that";
+
+pub const EVENT_DURATION_TOO_SHORT: &str =
+    "the default meeting duration must be at least one minute";
 
 #[tauri::command]
 pub async fn get_settings(state: tauri::State<'_, AppState>) -> Result<AppSettings, String> {
@@ -571,6 +583,30 @@ pub async fn set_default_calendar(
     Ok(read_settings(&state.pool).await)
 }
 
+/// Stores the length used when a new event names a start but no explicit end.
+/// Zero is refused rather than repaired: a saved preference must be the value
+/// the user entered, and a zero-length event cannot be created.
+#[tauri::command]
+pub async fn set_default_event_duration(
+    state: tauri::State<'_, AppState>,
+    minutes: u32,
+) -> Result<AppSettings, String> {
+    set_default_event_duration_impl(&state.pool, minutes)
+        .await
+        .map_err(|e| crate::errors::user_facing(&e))
+}
+
+async fn set_default_event_duration_impl(
+    pool: &SqlitePool,
+    minutes: u32,
+) -> anyhow::Result<AppSettings> {
+    if minutes == 0 {
+        anyhow::bail!(EVENT_DURATION_TOO_SHORT);
+    }
+    write(pool, DEFAULT_EVENT_DURATION_KEY, &minutes.to_string()).await?;
+    Ok(read_settings(pool).await)
+}
+
 /// Stores the filmstrip toggle. Nothing is refused and nothing is clamped —
 /// unlike the sync interval, there is no value of a boolean the app has to
 /// protect Google's quota from.
@@ -636,6 +672,11 @@ mod tests {
         );
         assert_eq!(s.default_calendar_id, None, "no choice made is the old rule, not an id");
         assert_eq!(
+            s.default_event_duration_minutes,
+            60,
+            "new events remain one hour long until somebody chooses otherwise",
+        );
+        assert_eq!(
             s.time_format,
             TimeFormat::H24,
             "the clock the app has always drawn, so no installed copy changes under its user"
@@ -659,6 +700,31 @@ mod tests {
 
         write(&p, DEFAULT_CALENDAR_KEY, "").await.unwrap();
         assert_eq!(read_settings(&p).await.default_calendar_id, None);
+    }
+
+    #[tokio::test]
+    async fn the_default_event_duration_round_trips_and_refuses_zero() {
+        let p = pool().await;
+
+        let s = set_default_event_duration_impl(&p, 45).await.unwrap();
+        assert_eq!(s.default_event_duration_minutes, 45);
+        assert_eq!(read_settings(&p).await.default_event_duration_minutes, 45);
+
+        assert!(set_default_event_duration_impl(&p, 0).await.is_err());
+        assert_eq!(
+            read_settings(&p).await.default_event_duration_minutes,
+            45,
+            "a refused duration must leave the stored choice alone",
+        );
+
+        for stored in ["", "0", "-1", "half an hour"] {
+            write(&p, DEFAULT_EVENT_DURATION_KEY, stored).await.unwrap();
+            assert_eq!(
+                read_settings(&p).await.default_event_duration_minutes,
+                60,
+                "{stored:?} is not a usable duration and must fall back",
+            );
+        }
     }
 
     /// `[]` stored is a real choice — the feature off — and must read back as

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -254,6 +254,10 @@
    *  that call this copy is stale until a restart, and the form would keep
    *  landing creates on a calendar the user has stopped choosing. */
   let defaultCalendarId = $state<number | null>(null);
+  /** Length for a new event whose opener names only its start. Sixty is the
+   *  backend's fresh-install default while the initial settings read is in
+   *  flight. */
+  let defaultEventDurationMinutes = $state(60);
 
   /** Whether the keyboard-shortcut sheet is up. A session flag and not a
    *  setting: it is a thing you look at, not a thing you configure. */
@@ -264,6 +268,7 @@
     getSettings()
       .then((s) => {
         defaultCalendarId = s.defaultCalendarId;
+        defaultEventDurationMinutes = s.defaultEventDurationMinutes;
         setClockFormat(s.timeFormat);
         setWeekStartDay(s.weekStart);
         setSecondZone(s.secondTimezone);
@@ -770,7 +775,10 @@
         : keyboardAnchor(),
       initial: pastedValue(
         copiedEvent,
-        blankValue(Date.now(), calendarId, onPointedDay ? pointedDayMs : createDayMs()),
+        blankValue(
+          Date.now(), calendarId, onPointedDay ? pointedDayMs : createDayMs(),
+          defaultEventDurationMinutes,
+        ),
       ),
     };
   }
@@ -817,7 +825,9 @@
     form = {
       mode: 'create',
       anchor: keyboardAnchor(),
-      initial: blankValue(Date.now(), createCalendarId, createDayMs()),
+      initial: blankValue(
+        Date.now(), createCalendarId, createDayMs(), defaultEventDurationMinutes,
+      ),
     };
   }
 
@@ -826,8 +836,8 @@
    *
    * `endMs` arrives only from a **sweep** — a drag across empty grid, which
    * names both ends. A click names only the moment it landed on, and leaves the
-   * duration to `blankValueAt`'s own hour; passing one there would move
-   * the decision out of the form module and into the grid.
+   * duration to the stored preference; passing one there would replace the
+   * preference with a value invented by the grid.
    *
    * Nothing is created here either way. The form does the creating, through the
    * path it has always used, which is why a sweep needs no command of its own —
@@ -836,18 +846,24 @@
    */
   function newEventAt(startMs: number, rect: Rect, endMs?: number) {
     form = {
-      mode: 'create', anchor: rect, initial: blankValueAt(startMs, createCalendarId, endMs),
+      mode: 'create',
+      anchor: rect,
+      initial: blankValueAt(
+        startMs, createCalendarId, endMs, defaultEventDurationMinutes,
+      ),
     };
   }
 
   /** Month and Big Year: the grid names a date and no time, so the form takes
-   *  the same default hour `n` would have used — the next half hour, moved to
-   *  the day that was clicked. */
+   *  the same start and duration `n` would have used — the next half hour,
+   *  moved to the day that was clicked. */
   function newEventOnDay(dayStartMs: number, rect: Rect) {
     form = {
       mode: 'create',
       anchor: rect,
-      initial: blankValue(Date.now(), createCalendarId, dayStartMs),
+      initial: blankValue(
+        Date.now(), createCalendarId, dayStartMs, defaultEventDurationMinutes,
+      ),
     };
   }
 
@@ -1223,6 +1239,7 @@
     onSearch={() => (searchOpen = true)}
     onsettingschange={(s) => {
       defaultCalendarId = s.defaultCalendarId;
+      defaultEventDurationMinutes = s.defaultEventDurationMinutes;
       setClockFormat(s.timeFormat);
       setWeekStartDay(s.weekStart);
       setSecondZone(s.secondTimezone);

--- a/ui/src/lib/SettingsModal.svelte
+++ b/ui/src/lib/SettingsModal.svelte
@@ -11,6 +11,7 @@
   import { listAccounts, signOut, type Account } from './accounts';
   import {
     getSettings, listTimezones, minutesOf, msOfMinutes, setDefaultCalendar,
+    setDefaultEventDuration,
     setDisplayTimezone, setFallbackReminders, setNotificationsEnabled,
     setSecondTimezone, setSyncInterval, setTimeFormat, setTrayIcon,
     setWeatherEnabled, setWeekStart,
@@ -57,6 +58,7 @@
   /** What is in the interval box, in minutes, as a string — a form value, not a
    *  number, so a half-typed "1" is not read as one minute mid-keystroke. */
   let intervalText = $state('');
+  let durationText = $state('');
   let note = $state<{ text: string; kind: 'info' | 'error' } | null>(null);
   /** The interval row's own feedback, rendered beside the field it is about.
    *  Not the shared `note` below: that one sits at the bottom of a modal
@@ -64,12 +66,14 @@
    *  General tab had enough content to scroll — reported as "no visual clue
    *  it saved" (2026-08-17), which for every practical purpose it was. */
   let intervalNote = $state<{ text: string; kind: 'info' | 'error' } | null>(null);
+  let durationNote = $state<{ text: string; kind: 'info' | 'error' } | null>(null);
 
   $effect(() => {
     getSettings()
       .then((s) => {
         settings = s;
         intervalText = String(minutesOf(s.syncIntervalMs));
+        durationText = String(s.defaultEventDurationMinutes);
       })
       .catch((e) => (note = { text: String(e), kind: 'error' }));
   });
@@ -254,6 +258,24 @@
     } catch (e) {
       note = { text: String(e), kind: 'error' };
       settings = settings ? { ...settings } : null;
+    }
+  }
+
+  async function saveDefaultEventDuration() {
+    const minutes = Number(durationText);
+    if (!Number.isSafeInteger(minutes) || minutes < 1 || minutes > 0xffff_ffff) {
+      durationNote = { text: 'Enter a positive whole number of minutes.', kind: 'error' };
+      return;
+    }
+
+    durationNote = null;
+    try {
+      settings = await setDefaultEventDuration(minutes);
+      durationText = String(settings.defaultEventDurationMinutes);
+      onsettingschange?.(settings);
+      durationNote = { text: 'Saved.', kind: 'info' };
+    } catch (e) {
+      durationNote = { text: String(e), kind: 'error' };
     }
   }
 
@@ -490,7 +512,12 @@
             }}
           />
           <span class="unit">minutes</span>
-          <button type="button" onclick={saveInterval} disabled={!settings}>Save</button>
+          <button
+            type="button"
+            aria-label="Save sync interval"
+            onclick={saveInterval}
+            disabled={!settings}
+          >Save</button>
           {#if intervalNote}
             <span
               class="rownote"
@@ -532,6 +559,45 @@
       <p class="hint">
         Only calendars omacal can write to are offered; if the choice ever
         stops being writable, creates fall back to your primary.
+      </p>
+
+      <div class="row">
+        <label class="lab" for="default-event-duration">Default meeting duration</label>
+        <div class="inline">
+          <input
+            id="default-event-duration"
+            type="number"
+            min="1"
+            step="1"
+            disabled={!settings}
+            bind:value={durationText}
+            oninput={() => (durationNote = null)}
+            onkeydown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                saveDefaultEventDuration();
+              }
+            }}
+          />
+          <span class="unit">minutes</span>
+          <button
+            type="button"
+            aria-label="Save default meeting duration"
+            disabled={!settings}
+            onclick={saveDefaultEventDuration}
+          >Save</button>
+          {#if durationNote}
+            <span
+              class="rownote"
+              class:err={durationNote.kind === 'error'}
+              data-testid="duration-note"
+            >{durationNote.text}</span>
+          {/if}
+        </div>
+      </div>
+      <p class="hint">
+        Used when a new event has a start time but no end time selected yet.
+        Dragging a range still uses the range you chose.
       </p>
 
       <div class="row">

--- a/ui/src/lib/eventform.ts
+++ b/ui/src/lib/eventform.ts
@@ -203,12 +203,8 @@ export type Guest = {
 
 const MIN_MS = 60_000;
 const HALF_HOUR_MS = 30 * MIN_MS;
-/** How long a brand-new event is until somebody says otherwise (an hour —
- *  30 minutes until 2026-08-20, by request). The *snap* stays the half hour:
- *  a new event still starts on the next half-hour boundary, it just runs an
- *  hour from there. `ALL_DAY_START`/`ALL_DAY_END` below must keep describing
- *  this same duration — their comment says why. */
-const DEFAULT_EVENT_MS = 60 * MIN_MS;
+/** How long a brand-new event is when no stored preference is available. */
+const DEFAULT_EVENT_MINUTES = 60;
 
 /**
  * The civil times an **all-day** value carries in its (hidden) time fields.
@@ -226,9 +222,8 @@ const DEFAULT_EVENT_MS = 60 * MIN_MS;
  * day, because `end_date` is the inclusive last day: the span came out zero and
  * Save refused a form with nothing on it visibly wrong.
  *
- * An hour apart (`DEFAULT_EVENT_MS`), matching the duration `blankValueAt`
- * gives a new event, so a day becoming timed and a fresh event created on it
- * agree about how long "an event" is by default.
+ * An hour apart, preserving the longstanding all-day-to-timed conversion.
+ * New events may use the duration selected in General settings instead.
  */
 const ALL_DAY_START = '09:00';
 const ALL_DAY_END = '10:00';
@@ -475,7 +470,8 @@ export const nextHalfHour = (nowMs: number): number =>
 
 /**
  * A form value for a brand-new event starting at `startMs`, on `calendarId`,
- * running until `endMs` — or an hour, when nothing names an end.
+ * running until `endMs` — or the requested default duration, when nothing
+ * names an end.
  *
  * The counterpart to `blankValue`: there the *clock* names the time, here the
  * *grid* does. A click on empty space in Day or Week view already knows which
@@ -483,11 +479,10 @@ export const nextHalfHour = (nowMs: number): number =>
  * the event away from where the user pointed.
  *
  * **`endMs` is optional because a click genuinely does not name one.** A click
- * names a moment and the duration is this module's default; a sweep names both
- * ends and the grid's answer is the one that must survive. Defaulting here
- * rather than at each call site keeps "an event is an hour" in the one
- * file that also decides what an all-day event's times become when it is
- * untoggled (see `ALL_DAY_START`), so the two cannot drift apart.
+ * names a moment and the duration is the caller's stored default; a sweep
+ * names both ends and the grid's answer is the one that must survive. Defaulting here
+ * rather than at each call site keeps the fallback and the duration arithmetic
+ * in one place.
  *
  * `endDate` is read off the end instant rather than copied from the start date,
  * which is the whole reason this is one function and not two lines at each call
@@ -496,7 +491,7 @@ export const nextHalfHour = (nowMs: number): number =>
  * wrong.
  *
  * Both instants are kept as well as read, because a create has the same
- * boundary as an edit: an hour from 02:30 lands on a 02:30 that is *later*
+ * boundary as an edit: an hour from 02:30 can land on a 02:30 that is *later*
  * across a fall-back, and re-parsing the pair `dateOf`/`timeOf` just produced
  * puts the end at or before the start — a form that opens already
  * refusing to save with no field on it visibly wrong. See `sourceStartMs`.
@@ -504,8 +499,10 @@ export const nextHalfHour = (nowMs: number): number =>
 export function blankValueAt(
   startMs: number,
   calendarId: number | null,
-  endMs: number = startMs + DEFAULT_EVENT_MS,
+  endMs?: number,
+  durationMinutes: number = DEFAULT_EVENT_MINUTES,
 ): EventFormValue {
+  endMs ??= startMs + durationMinutes * MIN_MS;
   return {
     title: '',
     date: dateOf(startMs),
@@ -537,8 +534,8 @@ export function blankValueAt(
 }
 
 /**
- * A form value for a brand-new event: the next half hour, an hour long,
- * on `calendarId`.
+ * A form value for a brand-new event: the next half hour, using the requested
+ * default duration, on `calendarId`.
  *
  * `dayStartMs` is the day the user was looking at when they asked for a new
  * event. Passing one that is not today keeps the *time* — the next half hour —
@@ -585,10 +582,11 @@ export function blankValue(
   nowMs: number,
   calendarId: number | null,
   dayStartMs?: number,
+  durationMinutes: number = DEFAULT_EVENT_MINUTES,
 ): EventFormValue {
-  const at = blankValueAt(nextHalfHour(nowMs), calendarId);
+  const at = blankValueAt(nextHalfHour(nowMs), calendarId, undefined, durationMinutes);
   if (dayStartMs === undefined) return at;
-  return blankValueAt(toMs(dateOf(dayStartMs), at.start), calendarId);
+  return blankValueAt(toMs(dateOf(dayStartMs), at.start), calendarId, undefined, durationMinutes);
 }
 
 /**

--- a/ui/src/lib/settings.ts
+++ b/ui/src/lib/settings.ts
@@ -34,6 +34,8 @@ export type AppSettings = {
    *  `null` for the old rule — primary, else first writable. Stored
    *  unvalidated; `offerableCalendarId` guards staleness at every use. */
   defaultCalendarId: number | null;
+  /** Minutes used when a new timed event has a start but no explicit end. */
+  defaultEventDurationMinutes: number;
   /** Whether the app draws `13:30` or `1:30 PM`. Read by `timefmt.ts` through
    *  the `clock.svelte.ts` rune rather than as a prop — six components print a
    *  time and none of them owns the preference. */
@@ -134,6 +136,10 @@ export const setSecondTimezone = (tz: string | null) =>
 
 export const setDefaultCalendar = (id: number | null) =>
   invoke<AppSettings>('set_default_calendar', { id });
+
+/** Stores the free-form default length for new timed events, in minutes. */
+export const setDefaultEventDuration = (minutes: number) =>
+  invoke<AppSettings>('set_default_event_duration', { minutes });
 
 /** Minutes, as the General tab shows them. Stored in milliseconds because
  *  that is what `sync_loop` compares against a clock. */

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -1519,6 +1519,24 @@ test.describe('App', () => {
     await expect(newForm(page).getByLabel('Calendar')).toHaveValue('8');
   });
 
+  test('a default meeting duration chosen in Settings is used by n immediately', async ({ page }) => {
+    await writable(page);
+    await page.getByRole('button', { name: 'Menu' }).click();
+    await page.getByRole('button', { name: 'Settings…' }).click();
+    const modal = page.getByRole('dialog', { name: 'Settings' });
+    await modal.getByRole('spinbutton', { name: 'Default meeting duration' }).fill('45');
+    await modal.getByRole('button', { name: 'Save default meeting duration' }).click();
+    await page.keyboard.press('Escape');
+
+    await page.keyboard.press('n');
+    await newForm(page).getByLabel('Title', { exact: true }).fill('Short review');
+    await newForm(page).getByRole('button', { name: 'Create', exact: true }).click();
+
+    const [args] = await callsTo(page, 'create_event');
+    expect(args.fields.when.kind).toBe('timed');
+    expect(args.fields.when.endMs - args.fields.when.startMs).toBe(45 * 60_000);
+  });
+
   /**
    * The picker wears the chosen calendar's colour (2026-08-10, by request):
    * names identify calendars to a reader who knows them, colour to everyone.

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -1229,6 +1229,29 @@ test.describe('Header', () => {
     expect(calls[0].args.id).toBe(2);
   });
 
+  test('General saves a manually entered default meeting duration', async ({ page }) => {
+    await page.goto(show('Header', 'connected'));
+    const modal = await openSettings(page);
+    const duration = modal.getByRole('spinbutton', { name: 'Default meeting duration' });
+    await expect(duration).toHaveValue('60');
+
+    await duration.fill('45');
+    await modal.getByRole('button', { name: 'Save default meeting duration' }).click();
+
+    const calls = await page.evaluate(
+      () => (window as any).__harness.calls.filter(
+        (c: any) => c.cmd === 'set_default_event_duration'),
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args.minutes).toBe(45);
+
+    await page.keyboard.press('Escape');
+    const again = await openSettings(page);
+    await expect(
+      again.getByRole('spinbutton', { name: 'Default meeting duration' }),
+    ).toHaveValue('45');
+  });
+
   test('General shows the stored sync interval, in minutes', async ({ page }) => {
     // Until now this was settable only by running `sqlite3` against the
     // database by hand, and both platform guides documented it that way.
@@ -1241,7 +1264,7 @@ test.describe('Header', () => {
     await page.goto(show('Header', 'connected'));
     const modal = await openSettings(page);
     await modal.getByLabel('Sync every').fill('15');
-    await modal.getByRole('button', { name: 'Save' }).click();
+    await modal.getByRole('button', { name: 'Save sync interval' }).click();
 
     // **Beside the button, not the modal-bottom note.** The shared note sits
     // below every tab's content in a modal that scrolls, so "Saved." landed
@@ -1275,7 +1298,7 @@ test.describe('Header', () => {
     await page.goto(show('Header', 'connected'));
     const modal = await openSettings(page);
     await modal.getByLabel('Sync every').fill('0');
-    await modal.getByRole('button', { name: 'Save' }).click();
+    await modal.getByRole('button', { name: 'Save sync interval' }).click();
 
     await expect(page.getByTestId('interval-note')).toContainText('will not sync more often');
     // And nothing was stored: reopening shows what was there before.

--- a/ui/tests/eventform.spec.ts
+++ b/ui/tests/eventform.spec.ts
@@ -355,6 +355,15 @@ test.describe('blankValue', () => {
     expect(v.endDate).toBe('2026-08-05');
     expect(spanOf(v)).toBe(60 * MINUTES);
   });
+
+  test('a caller can choose the default duration, while an explicit range still wins', () => {
+    const start = at(2026, 8, 5, 10, 0);
+    expect(spanOf(blankValueAt(start, 1, undefined, 45))).toBe(45 * MINUTES);
+    expect(spanOf(blankValue(start, 1, undefined, 75))).toBe(75 * MINUTES);
+
+    const sweptEnd = start + 20 * MINUTES;
+    expect(spanOf(blankValueAt(start, 1, sweptEnd, 45))).toBe(20 * MINUTES);
+  });
 });
 
 test.describe('endAfterStart on an all-day value', () => {

--- a/ui/tests/harness/tauri.ts
+++ b/ui/tests/harness/tauri.ts
@@ -511,6 +511,7 @@ type StubSettings = {
   listMode: boolean;
   fallbackReminderMinutes: number[];
   defaultCalendarId: number | null;
+  defaultEventDurationMinutes: number;
   timeFormat: TimeFormat;
   weekStart: WeekStartDay;
   displayTimezone: string | null;
@@ -531,6 +532,7 @@ const DEFAULT_SETTINGS: StubSettings = {
   // The backend's own shipped default (fallback spec §3).
   fallbackReminderMinutes: [60, 10],
   defaultCalendarId: null,
+  defaultEventDurationMinutes: 60,
   listMode: false,
   // The clock the app has always drawn, so every existing spec and every
   // committed screenshot golden goes on describing the same pixels.
@@ -790,6 +792,9 @@ export function installTauriStub(scenario: string): Harness {
         return { ...settings };
       case 'set_default_calendar':
         settings = saveSettings({ ...settings, defaultCalendarId: (args.id as number | null) ?? null });
+        return { ...settings };
+      case 'set_default_event_duration':
+        settings = saveSettings({ ...settings, defaultEventDurationMinutes: args.minutes as number });
         return { ...settings };
       case 'set_fallback_reminders': {
         const minutes = args.minutes as number[];


### PR DESCRIPTION
## Summary

- Add a General setting for the default meeting duration in minutes.
- Use it for keyboard-created and clicked new events while preserving explicit grid sweeps.
- Validate the value in both the UI and backend.

## Screenshot

Synthetic settings fixture:

![Default meeting duration](https://raw.githubusercontent.com/jondkinney/omacal/pr-screenshots/docs/pr-screenshots/default-event-duration.png)

## Testing

- `cargo test -p omacal --lib`
- `npm --prefix ui run check`
- `npm --prefix ui run test:ui -- --project=chromium`