### PR TITLE
feat(keyboard): open settings with Ctrl+Comma

### DIFF
--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -255,6 +255,10 @@
    *  landing creates on a calendar the user has stopped choosing. */
   let defaultCalendarId = $state<number | null>(null);
 
+  /** Bound into Header so the application-wide preferences chord opens the
+   *  same SettingsModal as the menu item. */
+  let settingsOpen = $state(false);
+
   /** Whether the keyboard-shortcut sheet is up. A session flag and not a
    *  setting: it is a thing you look at, not a thing you configure. */
   let helpOpen = $state(false);
@@ -1152,9 +1156,20 @@
   };
 
   function handleKeydown(e: KeyboardEvent) {
+    // The conventional preferences chord is application-wide, but it never
+    // stacks Settings over another modal. Claimed before `isTypingTarget` so
+    // the shortcut itself remains global; an open form/search/popover is what
+    // prevents the second dialog, not which child happened to hold focus.
+    if ((e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey && e.key === ',') {
+      e.preventDefault();
+      if (!document.querySelector('[role="dialog"][aria-modal="true"]')) {
+        settingsOpen = true;
+      }
+      return;
+    }
     if (isTypingTarget(e)) return;
-    // The one modifier chord omacal claims: Ctrl+V (⌘V), paste the copied
-    // event. Ahead of the modifier bail-out below, and narrower than it
+    // Ctrl+V (⌘V) pastes the copied event. Ahead of the modifier bail-out
+    // below, and narrower than it
     // looks — an empty buffer passes the chord through untouched, so V means
     // nothing new until a copy has meant something first. Copy's half lives
     // in `EventPopover`, the only place that knows a popover is open in
@@ -1215,6 +1230,7 @@
   }}
 >
   <Header
+    bind:settingsOpen
     {status} {anchorMs} {weekStartMs} {busy} {error} {calendars} {view} {listMode}
     onToggleList={toggleList}
     onPrev={() => step(-1)}

--- a/ui/src/lib/Header.svelte
+++ b/ui/src/lib/Header.svelte
@@ -18,6 +18,7 @@
     onPrev, onNext, onToday, onSearch, onSignIn, onSync, oncalendarchange,
     onWhatsNew, onRestart, onUpdate,
     invites = [], declines = [], changes = [], oninvitesanswered = () => {},
+    settingsOpen = $bindable(false),
     open = $bindable(false),
   }: {
     status: AppStatus | null;
@@ -75,6 +76,9 @@
     /** Bound through to `CalendarPopover` — lets `App` open the picker
      *  straight after a sign-in, from outside the popover's own trigger. */
     open?: boolean;
+    /** Parent-drivable so the application-wide Ctrl+, chord opens the same
+     *  modal as the menu item, without duplicating Settings outside Header. */
+    settingsOpen?: boolean;
   } = $props();
 
   // The title names the month of whatever unit is actually on screen. Week's
@@ -167,7 +171,6 @@
   /** The hamburger's menu. Everything that used to sit in the header and is
    *  used rarely now lives here (spec §1). */
   let menuOpen = $state(false);
-  let settingsOpen = $state(false);
   let tasksOpen = $state(false);
 
   function openSettings() {

--- a/ui/src/lib/shortcuts.ts
+++ b/ui/src/lib/shortcuts.ts
@@ -95,18 +95,18 @@ export const SHORTCUT_TEXT: Record<ShortcutId, string> = {
 };
 
 /**
- * The two modifier chords, beside the table rather than in it.
+ * The modifier chords, beside the table rather than in it.
  *
  * Not rows of `SHORTCUTS`, and the reason is the invariant that table
  * exists for: every row there is dispatched from `App`'s one bare-key
  * handler through `SHORTCUT_ACTIONS`, and the exhaustive `Record` is what
- * proves each documented key does something. These two are genuinely not
+ * proves each documented key does something. These are genuinely not
  * dispatched there — copy lives in `EventPopover`, the only component that
- * knows a popover is open in every view, and paste is a chord `App` handles
- * before its bare-key path. Forcing them into the table would mean either a
- * lying no-op handler or teaching the dispatcher about scopes it does not
- * have; a second export in the same file keeps them one screen away from
- * the keys they must not drift from, which is the practical half of the
+ * knows a popover is open in every view, while paste and Settings are chords
+ * `App` handles before its bare-key path. Forcing them into the table would
+ * mean either a lying no-op handler or teaching the dispatcher about scopes it
+ * does not have; a second export in the same file keeps them one screen away
+ * from the keys they must not drift from, which is the practical half of the
  * invariant.
  *
  * `MOD` follows the platform so the sheet shows the key the reader will
@@ -116,6 +116,7 @@ export const MOD_LABEL =
   typeof navigator !== 'undefined' && /Mac/.test(navigator.platform) ? '⌘' : 'Ctrl';
 
 export const CHORDS: { label: string; text: string; hint?: string }[] = [
+  { label: `${MOD_LABEL} ,`, text: 'Open settings' },
   { label: `${MOD_LABEL} C`, text: 'Copy the event',
     hint: 'with its popover open — click the event first' },
   { label: `${MOD_LABEL} V`, text: 'Paste as a new event',

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -4,7 +4,7 @@
 // stubbed IPC layer (tests/harness/tauri.ts).
 
 import { test, expect, type Page } from '@playwright/test';
-import { SHORTCUT_LIST, SHORTCUT_TEXT } from '../src/lib/shortcuts';
+import { CHORDS, SHORTCUT_LIST, SHORTCUT_TEXT } from '../src/lib/shortcuts';
 import {
   APP_MON, APP_NOW, weekLabel,
   APP_SOLO_SERIES_ID,
@@ -3085,6 +3085,20 @@ test.describe('App: the keyboard sheet', () => {
     await expect(sheet(page)).toHaveCount(0);
   });
 
+  test('Ctrl+Comma opens General settings and Escape closes it', async ({ page }) => {
+    await openApp(page);
+    await page.keyboard.press('Control+Comma');
+
+    const settings = page.getByRole('dialog', { name: 'Settings' });
+    await expect(settings).toBeVisible();
+    await expect(settings.getByRole('tab', { name: 'General' })).toHaveAttribute(
+      'aria-selected', 'true',
+    );
+
+    await page.keyboard.press('Escape');
+    await expect(settings).toHaveCount(0);
+  });
+
   /**
    * **Every row, read from the table itself.** A sheet that hardcoded its own
    * list would pass a test that hardcoded the same list, and the two would
@@ -3109,6 +3123,12 @@ test.describe('App: the keyboard sheet', () => {
         sheet(page).locator('.what', { hasText: literal(SHORTCUT_TEXT[s.id]) }),
         `${s.id} is listed under a key but not described`,
       ).toHaveCount(1);
+    }
+    for (const c of CHORDS) {
+      await expect(
+        sheet(page).locator('dt', { hasText: literal(c.label) }),
+      ).toHaveCount(1);
+      await expect(sheet(page).locator('.what', { hasText: literal(c.text) })).toHaveCount(1);
     }
   });
 


### PR DESCRIPTION
## Summary

- Open General settings with `Ctrl + ,`
- Keep the shortcut global without stacking Settings over another modal.
- Include the chord in the keyboard shortcut sheet.

## Testing

- `npm --prefix ui run check`
- `npm --prefix ui run test:ui -- --project=chromium`