### PR TITLE
feat(events): add custom weekly recurrence endings

### DIFF
--- a/crates/omacal-core/src/recur.rs
+++ b/crates/omacal-core/src/recur.rs
@@ -200,6 +200,32 @@ mod tests {
     }
 
     #[test]
+    fn a_custom_weekly_pattern_yields_each_selected_day_and_no_others() {
+        let s = Series {
+            dtstart_ms: MON_0900_SOFIA, dtstart_tz: "Europe/Sofia",
+            duration_ms: 30 * 60_000, is_all_day: false,
+            recurrence: &weekly(&["RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR"]),
+        };
+        let out = expand(
+            &s,
+            MON_0900_SOFIA - HOUR,
+            MON_0900_SOFIA + 7 * DAY,
+            50,
+        )
+        .unwrap()
+        .intervals;
+        let starts = out.iter().map(|interval| interval.start_ms).collect::<Vec<_>>();
+        assert_eq!(
+            starts,
+            [
+                MON_0900_SOFIA,
+                MON_0900_SOFIA + 2 * DAY,
+                MON_0900_SOFIA + 4 * DAY,
+            ]
+        );
+    }
+
+    #[test]
     fn every_instance_keeps_the_series_duration() {
         let s = Series {
             dtstart_ms: MON_0900_SOFIA, dtstart_tz: "Europe/Sofia",

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -45,14 +45,18 @@ pub struct EventDetail {
     /// the UI.
     ///
     /// Deliberately not derivable from `recurrence` on the TypeScript side.
-    /// That function decides by *exact string equality* against what
-    /// [`crate::write::rrule_for`] authors, and the point of exact equality is
-    /// that one authority decides what omacal can express — a second copy of
-    /// the table in the UI drifts the moment either side gains an option, and
-    /// the failure mode is silent: a rule the app cannot express gets treated
-    /// as one it can, and the next save overwrites "every 2nd Tuesday" with
-    /// "weekly" for the whole guest list.
+    /// The Rust authority matches base rules exactly and admits only one
+    /// strictly parsed extension: plain weekly `BYDAY`, whose every fact is
+    /// represented by `weekly_days`, plus COUNT/UNTIL endings represented by
+    /// `repeat_end`. A second copy in the UI could drift and
+    /// silently turn "every 2nd Tuesday" into "weekly" on the next save.
     pub repeat: String,
+    /// The Sunday-first weekday codes in a plain weekly `BYDAY` rule. Empty
+    /// for bare weekly (whose day is DTSTART) and for every other cadence.
+    pub weekly_days: Vec<String>,
+    /// Whether the representable recurrence is unbounded, ends on a calendar
+    /// date, or stops after a fixed number of occurrences.
+    pub repeat_end: crate::write::RepeatEnd,
     pub color: Option<String>,
     pub organizer_email: Option<String>,
     pub self_response: Option<String>,
@@ -155,6 +159,9 @@ pub(crate) async fn event_detail_impl(state: &AppState, id: i64) -> anyhow::Resu
         None => (None, None),
     };
 
+    let recurrence_controls = crate::write::recurrence_controls_from_rrule(
+        event.recurrence.as_deref(), event.is_all_day, &event.start_tz,
+    );
     Ok(EventDetail {
         id: event.id,
         calendar_id: event.calendar_id,
@@ -168,7 +175,9 @@ pub(crate) async fn event_detail_impl(state: &AppState, id: i64) -> anyhow::Resu
         end_date,
         is_all_day: event.is_all_day,
         is_recurring,
-        repeat: crate::write::repeat_from_rrule(event.recurrence.as_deref()),
+        repeat: recurrence_controls.repeat,
+        weekly_days: recurrence_controls.weekly_days,
+        repeat_end: recurrence_controls.repeat_end,
         recurrence: event.recurrence,
         color: event.color_hex,
         organizer_email: event.organizer_email,
@@ -740,7 +749,8 @@ pub async fn create_event(
     fields: crate::write::EventInput,
     send_updates: String,
 ) -> Result<EventDetail, String> {
-    create_impl(&state, calendar_id, crate::write::fields_from_input(fields), &send_updates)
+    let fields = crate::write::fields_from_input(fields)?;
+    create_impl(&state, calendar_id, fields, &send_updates)
         .await
         .map_err(|e| crate::errors::user_facing(&e))
         .inspect(|_| crate::upcoming::refresh_soon(state.pool.clone(), state.demo))
@@ -1253,12 +1263,13 @@ pub async fn update_event(
     fields: crate::write::EventInput,
     send_updates: String,
 ) -> Result<EventDetail, String> {
+    let fields = crate::write::fields_from_input(fields)?;
     update_impl(
         &state,
         id,
         &scope,
         occurrence_start_ms,
-        crate::write::fields_from_input(fields),
+        fields,
         &send_updates,
     )
     .await
@@ -3442,8 +3453,8 @@ mod tests {
     /// *show*, this tells it whether the Repeat control may be used at all.
     ///
     /// Computed here rather than in TypeScript on purpose — `repeat_from_rrule`
-    /// decides by exact string equality against what `rrule_for` authors, and a
-    /// second copy of that table in the UI would drift. Three different rules
+    /// owns both the exact base rules and the strict plain-weekly grammar, and
+    /// a second copy of either in the UI would drift. Three different rules
     /// producing three different answers is what makes this test able to fail:
     /// a stub returning any one constant is caught by the other two.
     #[tokio::test]
@@ -3457,6 +3468,12 @@ mod tests {
 
         // A rule `rrule_for` authors, matched exactly.
         assert_eq!(detail_for(Some("RRULE:FREQ=WEEKLY")).await.repeat, "weekly");
+        let patterned = detail_for(Some("RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR")).await;
+        assert_eq!(patterned.repeat, "weekly");
+        assert_eq!(patterned.weekly_days, ["MO", "WE", "FR"]);
+        let counted = detail_for(Some("RRULE:FREQ=DAILY;COUNT=8")).await;
+        assert_eq!(counted.repeat, "daily");
+        assert_eq!(counted.repeat_end, crate::write::RepeatEnd::After { count: 8 });
         // A rule it does not, and could not: the form must refuse to overwrite it.
         assert_eq!(
             detail_for(Some("RRULE:FREQ=WEEKLY;INTERVAL=2")).await.repeat,
@@ -3590,7 +3607,8 @@ mod tests {
         let mut expected = [
             "id", "calendar_id", "title", "description", "location",
             "conference_uri", "start_ms", "end_ms", "start_date", "end_date",
-            "is_all_day", "is_recurring", "recurrence", "repeat", "color",
+            "is_all_day", "is_recurring", "recurrence", "repeat", "weekly_days",
+            "repeat_end", "color",
             "organizer_email", "self_response", "can_respond", "can_edit",
             "attendees", "reminders", "calendar_default_reminders",
         ];

--- a/src-tauri/src/write.rs
+++ b/src-tauri/src/write.rs
@@ -409,6 +409,20 @@ pub(crate) struct EventInput {
     /// Absent when the user did not touch Repeat.
     #[serde(default)]
     pub repeat: Option<String>,
+    /// The selected days for a custom weekly cadence, as iCalendar's
+    /// two-letter weekday codes. Meaningful only when `repeat == "weekly"`.
+    ///
+    /// This is structured rather than an RRULE fragment on purpose: serde
+    /// rejects an unknown code at the command boundary, and the builder below
+    /// owns ordering, de-duplication and iCalendar syntax. An empty list falls
+    /// back to ordinary weekly rather than clearing recurrence.
+    #[serde(default)]
+    pub weekly_days: Option<Vec<WeekdayCode>>,
+    /// How a repeating series stops. Absent and `never` both mean an
+    /// unbounded rule; the explicit variant is useful on the read side and
+    /// keeps the TypeScript union symmetric with [`RepeatEnd`].
+    #[serde(default)]
+    pub repeat_end: Option<RepeatEnd>,
     /// Absent when the user did not touch the guest list — see
     /// [`EventFields::guests`], which this becomes unchanged. `#[serde(default)]`
     /// so every payload written before this field existed still deserializes,
@@ -421,6 +435,68 @@ pub(crate) struct EventInput {
     /// editing (a drag).
     #[serde(default)]
     pub reminders: Option<RemindersInput>,
+}
+/// A weekday as the UI names it and iCalendar writes it. The explicit serde
+/// names are the command-boundary contract; accepting a free-form `String`
+/// here would let a typo become an invalid RRULE sent to Google.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+pub(crate) enum WeekdayCode {
+    #[serde(rename = "SU")]
+    Su,
+    #[serde(rename = "MO")]
+    Mo,
+    #[serde(rename = "TU")]
+    Tu,
+    #[serde(rename = "WE")]
+    We,
+    #[serde(rename = "TH")]
+    Th,
+    #[serde(rename = "FR")]
+    Fr,
+    #[serde(rename = "SA")]
+    Sa,
+}
+
+/// The two RFC 5545 termination forms omacal can author, plus the ordinary
+/// unbounded case. Internally tagged so malformed combinations (a date on an
+/// `after`, a count on an `on`) fail at the command boundary rather than being
+/// guessed at while building an RRULE.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum RepeatEnd {
+    Never,
+    On { date: String },
+    After { count: u32 },
+}
+
+impl Default for RepeatEnd {
+    fn default() -> Self {
+        Self::Never
+    }
+}
+
+impl WeekdayCode {
+    const ALL: [Self; 7] = [Self::Su, Self::Mo, Self::Tu, Self::We, Self::Th, Self::Fr, Self::Sa];
+
+    fn text(self) -> &'static str {
+        match self {
+            Self::Su => "SU",
+            Self::Mo => "MO",
+            Self::Tu => "TU",
+            Self::We => "WE",
+            Self::Th => "TH",
+            Self::Fr => "FR",
+            Self::Sa => "SA",
+        }
+    }
+
+    fn index(self) -> usize {
+        Self::ALL.iter().position(|candidate| *candidate == self).unwrap_or(0)
+    }
+
+    fn from_text(text: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|day| day.text() == text)
+    }
 }
 
 /// [`When`] as the UI sends it. A separate type for the same reason
@@ -452,22 +528,34 @@ pub(crate) enum WhenInput {
 /// `"never"` maps to `Some(None)` — clear the rule — because [`rrule_for`]
 /// returns `None` for it. That is the one case worth staring at: an absent
 /// `repeat` and a `repeat` of `"never"` must not collapse together.
-pub(crate) fn fields_from_input(input: EventInput) -> EventFields {
-    EventFields {
+pub(crate) fn fields_from_input(input: EventInput) -> Result<EventFields, String> {
+    let when = match input.when {
+        WhenInput::Timed { start_ms, end_ms } => When::Timed { start_ms, end_ms },
+        WhenInput::AllDay { start_date, end_date } => When::AllDay { start_date, end_date },
+    };
+    let recurrence = input
+        .repeat
+        .as_deref()
+        .map(|repeat| {
+            rrule_for_input(
+                repeat,
+                input.weekly_days.as_deref(),
+                input.repeat_end.as_ref(),
+                &when,
+                &input.tz,
+            )
+        })
+        .transpose()?;
+    Ok(EventFields {
         summary: input.summary,
         location: input.location,
         description: input.description,
-        when: match input.when {
-            WhenInput::Timed { start_ms, end_ms } => When::Timed { start_ms, end_ms },
-            WhenInput::AllDay { start_date, end_date } => {
-                When::AllDay { start_date, end_date }
-            }
-        },
+        when,
         tz: input.tz,
-        recurrence: input.repeat.map(|r| rrule_for(&r)),
+        recurrence,
         guests: input.guests,
         reminders: input.reminders,
-    }
+    })
 }
 
 /// The rule omacal writes for each Repeat option. `never` is `None`.
@@ -483,6 +571,221 @@ pub(crate) fn rrule_for(repeat: &str) -> Option<String> {
         }
         .to_string(),
     )
+}
+
+/// The RRULE for a command payload. `rrule_for` remains the dropdown's base
+/// vocabulary; this adds the two structured refinements the form can author:
+/// a weekly day pattern and an optional COUNT/UNTIL termination.
+fn rrule_for_input(
+    repeat: &str,
+    weekly_days: Option<&[WeekdayCode]>,
+    repeat_end: Option<&RepeatEnd>,
+    when: &When,
+    tz: &str,
+) -> Result<Option<String>, String> {
+    let Some(mut rule) = rrule_for(repeat) else {
+        if matches!(repeat_end, Some(end) if end != &RepeatEnd::Never) {
+            return Err("a repeat ending needs a repeating schedule".into());
+        }
+        return Ok(None);
+    };
+
+    if repeat == "weekly" {
+        if let Some(days) = weekly_days {
+            // Canonical Sunday-first order and no duplicates, independent of
+            // click or NLP order. Besides producing stable rules, this gives
+            // the read side one finite, fully representable grammar to recognise.
+            let mut selected = [false; 7];
+            for day in days {
+                selected[day.index()] = true;
+            }
+            let days = WeekdayCode::ALL
+                .into_iter()
+                .filter(|day| selected[day.index()])
+                .map(WeekdayCode::text)
+                .collect::<Vec<_>>();
+            if !days.is_empty() {
+                rule.push_str(";BYDAY=");
+                rule.push_str(&days.join(","));
+            }
+        }
+    }
+
+    match repeat_end.unwrap_or(&RepeatEnd::Never) {
+        RepeatEnd::Never => {}
+        RepeatEnd::After { count } => {
+            if *count == 0 {
+                return Err("a repeating event must occur at least once".into());
+            }
+            rule.push_str(&format!(";COUNT={count}"));
+        }
+        RepeatEnd::On { date } => {
+            let end: jiff::civil::Date = date
+                .parse()
+                .map_err(|_| format!("{date} is not a valid repeat end date"))?;
+            let start_text = match when {
+                When::Timed { start_ms, .. } => date_in_zone(*start_ms, tz),
+                When::AllDay { start_date, .. } => start_date.clone(),
+            };
+            let start: jiff::civil::Date = start_text
+                .parse()
+                .map_err(|_| format!("{start_text} is not a valid event start date"))?;
+            if end < start {
+                return Err("the repeat end date cannot be before the event starts".into());
+            }
+
+            let until = match when {
+                When::AllDay { .. } => end.strftime("%Y%m%d").to_string(),
+                When::Timed { .. } => end
+                    .at(23, 59, 59, 0)
+                    .in_tz(tz)
+                    .map_err(|_| format!("unknown time zone {tz}"))?
+                    .timestamp()
+                    .in_tz("UTC")
+                    .expect("UTC always resolves")
+                    .strftime("%Y%m%dT%H%M%SZ")
+                    .to_string(),
+            };
+            rule.push_str(";UNTIL=");
+            rule.push_str(&until);
+        }
+    }
+    Ok(Some(rule))
+}
+
+fn parse_weekdays(list: &str) -> Option<Vec<WeekdayCode>> {
+    if list.is_empty() { return None; }
+    let mut selected = [false; 7];
+    for raw in list.split(',') {
+        let day = WeekdayCode::from_text(raw)?;
+        if selected[day.index()] {
+            return None;
+        }
+        selected[day.index()] = true;
+    }
+    Some(
+        WeekdayCode::ALL
+            .into_iter()
+            .filter(|day| selected[day.index()])
+            .collect(),
+    )
+}
+
+fn basic_date(value: &str) -> Option<jiff::civil::Date> {
+    if value.len() != 8 || !value.bytes().all(|b| b.is_ascii_digit()) { return None; }
+    format!("{}-{}-{}", &value[..4], &value[4..6], &value[6..8]).parse().ok()
+}
+
+fn basic_utc_timestamp(value: &str) -> Option<jiff::Timestamp> {
+    let b = value.as_bytes();
+    if b.len() != 16 || b[8] != b'T' || b[15] != b'Z'
+        || !b[..8].iter().chain(&b[9..15]).all(|c| c.is_ascii_digit())
+    {
+        return None;
+    }
+    format!(
+        "{}-{}-{}T{}:{}:{}Z",
+        &value[..4], &value[4..6], &value[6..8],
+        &value[9..11], &value[11..13], &value[13..15],
+    )
+    .parse()
+    .ok()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RecurrenceControls {
+    pub repeat: String,
+    pub weekly_days: Vec<String>,
+    pub repeat_end: RepeatEnd,
+}
+
+/// Reads exactly the recurrence grammar the editor can write: one of its five
+/// cadences, an optional weekly BYDAY list, and at most one COUNT or UNTIL.
+/// Parts may arrive in any order because other calendar clients reorder them;
+/// unknown, duplicate, contradictory or value-type-mismatched parts make the
+/// whole rule custom. That all-or-nothing rule is what prevents a title-only
+/// save from simplifying somebody else's recurrence behind their back.
+pub(crate) fn recurrence_controls_from_rrule(
+    rule: Option<&str>,
+    is_all_day: bool,
+    tz: &str,
+) -> RecurrenceControls {
+    let custom = || RecurrenceControls {
+        repeat: "custom".into(), weekly_days: vec![], repeat_end: RepeatEnd::Never,
+    };
+    let Some(rule) = rule else {
+        return RecurrenceControls {
+            repeat: "never".into(), weekly_days: vec![], repeat_end: RepeatEnd::Never,
+        };
+    };
+    let Some(body) = rule.strip_prefix("RRULE:") else { return custom(); };
+
+    let mut freq: Option<&str> = None;
+    let mut byday: Option<&str> = None;
+    let mut count: Option<&str> = None;
+    let mut until: Option<&str> = None;
+    for part in body.split(';') {
+        let Some((key, value)) = part.split_once('=') else { return custom(); };
+        if value.is_empty() { return custom(); }
+        let slot = match key {
+            "FREQ" => &mut freq,
+            "BYDAY" => &mut byday,
+            "COUNT" => &mut count,
+            "UNTIL" => &mut until,
+            _ => return custom(),
+        };
+        if slot.replace(value).is_some() { return custom(); }
+    }
+    if count.is_some() && until.is_some() { return custom(); }
+
+    let days = match byday {
+        Some(list) => match parse_weekdays(list) {
+            Some(days) => days,
+            None => return custom(),
+        },
+        None => vec![],
+    };
+    let repeat = match (freq, byday) {
+        (Some("DAILY"), None) => "daily",
+        (Some("WEEKLY"), None) => "weekly",
+        (Some("WEEKLY"), Some(_)) => {
+            if days == [WeekdayCode::Mo, WeekdayCode::Tu, WeekdayCode::We,
+                        WeekdayCode::Th, WeekdayCode::Fr] {
+                "weekdays"
+            } else {
+                "weekly"
+            }
+        }
+        (Some("MONTHLY"), None) => "monthly",
+        (Some("YEARLY"), None) => "yearly",
+        _ => return custom(),
+    };
+
+    let repeat_end = if let Some(raw) = count {
+        match raw.parse::<u32>().ok().filter(|n| *n > 0) {
+            Some(count) => RepeatEnd::After { count },
+            None => return custom(),
+        }
+    } else if let Some(raw) = until {
+        if is_all_day {
+            match basic_date(raw) {
+                Some(date) => RepeatEnd::On { date: date.to_string() },
+                None => return custom(),
+            }
+        } else {
+            let Some(ts) = basic_utc_timestamp(raw) else { return custom(); };
+            let Ok(local) = ts.in_tz(tz) else { return custom(); };
+            RepeatEnd::On { date: local.date().to_string() }
+        }
+    } else {
+        RepeatEnd::Never
+    };
+
+    RecurrenceControls {
+        repeat: repeat.into(),
+        weekly_days: days.into_iter().map(|day| day.text().to_string()).collect(),
+        repeat_end,
+    }
 }
 
 /// The `UNTIL` value that ends a series immediately before `before_ms`.
@@ -613,28 +916,12 @@ pub(crate) fn has_count(rule: &str) -> bool {
         .any(|part| part.split('=').next().unwrap_or_default().eq_ignore_ascii_case("COUNT"))
 }
 
-/// Which Repeat option, if any, represents `rule` exactly.
-///
-/// Exact string equality against what [`rrule_for`] authors, deliberately —
-/// not a parse. A rule carrying `INTERVAL`, `COUNT`, `UNTIL`, `EXDATE` or a
-/// `BYDAY` we did not write is `custom`, and the UI must then refuse to
-/// overwrite it. Being generous here (parsing `FREQ` and ignoring the rest)
-/// is exactly how "every 2nd Tuesday" becomes "weekly" behind the user's back.
-///
-/// Called once, on the read side: `events::event_detail_impl` puts the answer
-/// on `EventDetail::repeat` so the Repeat control has it without re-deriving
-/// it. No write command needs it — a write is told which option the user
-/// picked and maps it forward through [`rrule_for`].
-pub(crate) fn repeat_from_rrule(rule: Option<&str>) -> String {
-    let Some(rule) = rule else {
-        return "never".into();
-    };
-    for candidate in ["daily", "weekdays", "weekly", "monthly", "yearly"] {
-        if rrule_for(candidate).as_deref() == Some(rule) {
-            return candidate.into();
-        }
-    }
-    "custom".into()
+/// Which Repeat option represents `rule` completely. Kept as a small wrapper
+/// for callers/tests interested in only that one field; the full read side
+/// uses [`recurrence_controls_from_rrule`] once and takes all three controls.
+#[cfg(test)]
+pub(crate) fn repeat_from_rrule(rule: Option<&str>, is_all_day: bool, tz: &str) -> String {
+    recurrence_controls_from_rrule(rule, is_all_day, tz).repeat
 }
 
 #[cfg(test)]
@@ -976,6 +1263,8 @@ mod tests {
             },
             tz: "Europe/Sofia".into(),
             repeat: None,
+            weekly_days: None,
+            repeat_end: None,
             guests: None,
             reminders: None,
         }
@@ -998,9 +1287,129 @@ mod tests {
     fn every_rule_we_author_reads_back_as_itself() {
         for r in ["daily", "weekdays", "weekly", "monthly", "yearly"] {
             let rule = rrule_for(r).unwrap();
-            assert_eq!(repeat_from_rrule(Some(&rule)), r, "round trip failed for {r}");
+            assert_eq!(repeat_from_rrule(Some(&rule), false, "UTC"), r, "round trip failed for {r}");
         }
-        assert_eq!(repeat_from_rrule(None), "never");
+        assert_eq!(repeat_from_rrule(None, false, "UTC"), "never");
+    }
+
+    #[test]
+    fn every_nonempty_weekday_pattern_round_trips_without_losing_a_day() {
+        for mask in 1_u8..128 {
+            let days = WeekdayCode::ALL
+                .into_iter()
+                .enumerate()
+                .filter_map(|(i, day)| (mask & (1 << i) != 0).then_some(day))
+                .collect::<Vec<_>>();
+            let rule = rrule_for_input(
+                "weekly", Some(&days), None, &base().when, "UTC",
+            ).unwrap().unwrap();
+            let expected = days.iter().map(|day| day.text().to_string()).collect::<Vec<_>>();
+            let controls = recurrence_controls_from_rrule(Some(&rule), false, "UTC");
+            assert_eq!(controls.weekly_days, expected, "{rule}");
+            // Monday–Friday is also the existing "Every weekday" preset.
+            // The labels may alias, but the selected days must never change.
+            let expected_repeat = if rule == "RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR" {
+                "weekdays"
+            } else {
+                "weekly"
+            };
+            assert_eq!(controls.repeat, expected_repeat, "{rule}");
+        }
+    }
+
+    #[test]
+    fn weekly_days_are_canonical_and_duplicate_clicks_cannot_duplicate_byday() {
+        let rule = rrule_for_input(
+            "weekly",
+            Some(&[WeekdayCode::Fr, WeekdayCode::Mo, WeekdayCode::Fr, WeekdayCode::We]),
+            None,
+            &base().when,
+            "UTC",
+        ).unwrap();
+        assert_eq!(rule.as_deref(), Some("RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR"));
+    }
+
+    #[test]
+    fn the_weekly_pattern_wire_shape_is_typed_and_builds_byday() {
+        let input: EventInput = serde_json::from_value(serde_json::json!({
+            "when": { "kind": "timed", "startMs": 1_785_398_400_000_i64,
+                      "endMs": 1_785_400_200_000_i64 },
+            "tz": "UTC",
+            "repeat": "weekly",
+            "weeklyDays": ["FR", "MO", "WE"]
+        }))
+        .unwrap();
+        assert_eq!(
+            fields_from_input(input).unwrap().recurrence,
+            Some(Some("RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR".into()))
+        );
+
+        let invalid = serde_json::from_value::<EventInput>(serde_json::json!({
+            "when": { "kind": "timed", "startMs": 1_i64, "endMs": 2_i64 },
+            "tz": "UTC", "repeat": "weekly", "weeklyDays": ["XX"]
+        }));
+        assert!(invalid.is_err(), "an unknown weekday must fail before a write");
+    }
+
+    #[test]
+    fn repeat_endings_build_valid_rules_and_read_back_without_loss() {
+        let counted: EventInput = serde_json::from_value(serde_json::json!({
+            "when": { "kind": "timed", "startMs": 1_785_398_400_000_i64,
+                      "endMs": 1_785_400_200_000_i64 },
+            "tz": "Europe/Sofia", "repeat": "weekly",
+            "weeklyDays": ["MO", "WE", "FR"],
+            "repeatEnd": { "kind": "after", "count": 8 }
+        })).unwrap();
+        let counted_rule = fields_from_input(counted).unwrap().recurrence.unwrap().unwrap();
+        assert_eq!(counted_rule, "RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR;COUNT=8");
+        let controls = recurrence_controls_from_rrule(
+            Some(&counted_rule), false, "Europe/Sofia",
+        );
+        assert_eq!(controls.repeat, "weekly");
+        assert_eq!(controls.weekly_days, ["MO", "WE", "FR"]);
+        assert_eq!(controls.repeat_end, RepeatEnd::After { count: 8 });
+
+        let timed: EventInput = serde_json::from_value(serde_json::json!({
+            "when": { "kind": "timed", "startMs": 1_785_398_400_000_i64,
+                      "endMs": 1_785_400_200_000_i64 },
+            "tz": "Europe/Sofia", "repeat": "daily",
+            "repeatEnd": { "kind": "on", "date": "2026-08-10" }
+        })).unwrap();
+        let timed_rule = fields_from_input(timed).unwrap().recurrence.unwrap().unwrap();
+        assert_eq!(timed_rule, "RRULE:FREQ=DAILY;UNTIL=20260810T205959Z");
+        assert_eq!(
+            recurrence_controls_from_rrule(Some(&timed_rule), false, "Europe/Sofia").repeat_end,
+            RepeatEnd::On { date: "2026-08-10".into() },
+        );
+
+        let all_day: EventInput = serde_json::from_value(serde_json::json!({
+            "when": { "kind": "allDay", "startDate": "2026-08-03",
+                      "endDate": "2026-08-04" },
+            "tz": "Not/AZone", "repeat": "monthly",
+            "repeatEnd": { "kind": "on", "date": "2026-12-31" }
+        })).unwrap();
+        let all_day_rule = fields_from_input(all_day).unwrap().recurrence.unwrap().unwrap();
+        assert_eq!(all_day_rule, "RRULE:FREQ=MONTHLY;UNTIL=20261231");
+        assert_eq!(
+            recurrence_controls_from_rrule(Some(&all_day_rule), true, "Not/AZone").repeat_end,
+            RepeatEnd::On { date: "2026-12-31".into() },
+        );
+    }
+
+    #[test]
+    fn invalid_repeat_endings_are_refused_before_any_write() {
+        for end in [
+            serde_json::json!({ "kind": "after", "count": 0 }),
+            serde_json::json!({ "kind": "on", "date": "2026-02-31" }),
+            serde_json::json!({ "kind": "on", "date": "2026-01-01" }),
+        ] {
+            let input: EventInput = serde_json::from_value(serde_json::json!({
+                "when": { "kind": "allDay", "startDate": "2026-08-03",
+                          "endDate": "2026-08-04" },
+                "tz": "UTC", "repeat": "daily", "repeatEnd": end,
+            })).unwrap();
+            assert!(fields_from_input(input).is_err(), "accepted {end}");
+        }
     }
 
     /// The property that stops a silent overwrite: a rule the dropdown cannot
@@ -1011,11 +1420,15 @@ mod tests {
         for exotic in [
             "RRULE:FREQ=MONTHLY;BYDAY=-1FR",
             "RRULE:FREQ=WEEKLY;INTERVAL=2",
-            "RRULE:FREQ=DAILY;COUNT=5",
-            "RRULE:FREQ=WEEKLY;BYDAY=MO,WE",
-            "RRULE:FREQ=WEEKLY;UNTIL=20261231T000000Z",
+            "RRULE:FREQ=WEEKLY;BYDAY=MO,MO",
+            "RRULE:FREQ=WEEKLY;BYDAY=1MO",
+            "RRULE:FREQ=WEEKLY;BYDAY=MO,WE;WKST=SU",
+            "RRULE:FREQ=WEEKLY;BYDAY=XX",
+            "RRULE:FREQ=DAILY;COUNT=0",
+            "RRULE:FREQ=DAILY;COUNT=5;UNTIL=20261231T000000Z",
+            "RRULE:FREQ=DAILY;UNTIL=20261231",
         ] {
-            assert_eq!(repeat_from_rrule(Some(exotic)), "custom", "{exotic}");
+            assert_eq!(repeat_from_rrule(Some(exotic), false, "UTC"), "custom", "{exotic}");
         }
     }
 
@@ -1165,16 +1578,16 @@ mod tests {
     fn an_absent_repeat_and_an_explicit_never_are_different_things() {
         let mut input = sample_input();
         input.repeat = None;
-        assert_eq!(fields_from_input(input).recurrence, None);
+        assert_eq!(fields_from_input(input).unwrap().recurrence, None);
 
         let mut input = sample_input();
         input.repeat = Some("never".into());
-        assert_eq!(fields_from_input(input).recurrence, Some(None));
+        assert_eq!(fields_from_input(input).unwrap().recurrence, Some(None));
 
         let mut input = sample_input();
         input.repeat = Some("weekly".into());
         assert_eq!(
-            fields_from_input(input).recurrence,
+            fields_from_input(input).unwrap().recurrence,
             Some(Some("RRULE:FREQ=WEEKLY".into()))
         );
     }
@@ -1196,7 +1609,7 @@ mod tests {
         )
         .expect("the timed payload the UI sends must deserialize");
         assert_eq!(
-            fields_from_input(timed).when,
+            fields_from_input(timed).unwrap().when,
             When::Timed { start_ms: 1_785_398_400_000, end_ms: 1_785_400_200_000 }
         );
 
@@ -1207,7 +1620,7 @@ mod tests {
         )
         .expect("the all-day payload the UI sends must deserialize");
         assert_eq!(
-            fields_from_input(all_day).when,
+            fields_from_input(all_day).unwrap().when,
             When::AllDay { start_date: "2026-08-10".into(), end_date: "2026-08-11".into() }
         );
     }
@@ -1223,7 +1636,7 @@ mod tests {
         )
         .expect("the reminders payload the UI sends must deserialize");
         assert_eq!(
-            fields_from_input(input).reminders,
+            fields_from_input(input).unwrap().reminders,
             Some(RemindersInput {
                 use_default: false,
                 overrides: vec![ReminderInput { method: "popup".into(), minutes: 15 }],

--- a/ui/src/lib/EventForm.svelte
+++ b/ui/src/lib/EventForm.svelte
@@ -12,9 +12,10 @@
   import SaveConfirm from './SaveConfirm.svelte';
   import type { SendUpdates } from './eventdetail';
   import {
-    CUSTOM_REPEAT, REPEAT_OPTIONS, addGuest, endAfterStart, isAddress, mailableGuests,
-    previewSpan, removableGuest, removeGuest, ruleInWords, shiftedEndDate, toEventInput,
-    toggledGuestOptional, timeProblem, toggledAllDay,
+    CUSTOM_REPEAT, REPEAT_OPTIONS, WEEKDAY_OPTIONS, addGuest, endAfterStart, isAddress,
+    mailableGuests, normalizedWeeklyDays, previewSpan, removableGuest, removeGuest, ruleInWords,
+    repeatEndProblem, shiftedEndDate, toEventInput, toggledGuestOptional, toggledWeeklyDay, timeProblem,
+    toggledAllDay, weekdayCodeForDate,
     type EventFormResult, type EventFormValue, type Scope,
   } from './eventform';
 
@@ -119,6 +120,8 @@
     // `value.guests` with `initial.guests`, and that union is only honest
     // while `initial.guests` stays exactly what the form opened with.
     guests: [...initial.guests],
+    weeklyDays: [...initial.weeklyDays],
+    repeatEnd: { ...initial.repeatEnd },
   });
   let scope = $state<Scope>('this');
 
@@ -153,7 +156,7 @@
   let error = $state<string | null>(null);
   /** Which time input the current `error` is about, so it can be marked rather
    *  than only described. Cleared with `error` on any input. */
-  let invalidField = $state<'start' | 'end' | 'guest' | null>(null);
+  let invalidField = $state<'start' | 'end' | 'guest' | 'repeatEnd' | null>(null);
 
   /** What is in the add-a-guest box. Not part of `value`: an address nobody has
    *  pressed Add on is not on the guest list, and a save must not quietly
@@ -290,10 +293,42 @@
    *  never asked for. Bound one-way plus `onchange` rather than `bind:value`,
    *  because both fields have to move in the same update. */
   function moveStartDate(next: string) {
-    value.endDate = shiftedEndDate(value.date, next, value.endDate);
+    const previousDate = value.date;
+    const previousDay = weekdayCodeForDate(value.date);
+    const nextDay = weekdayCodeForDate(next);
+    value.endDate = shiftedEndDate(previousDate, next, value.endDate);
+    if (value.repeatEnd.kind === 'on') {
+      value.repeatEnd = {
+        kind: 'on',
+        date: shiftedEndDate(previousDate, next, value.repeatEnd.date),
+      };
+    }
     value.date = next;
+    // Keep the hidden default on the date the form now shows. Once a weekly
+    // pattern is visible, a one-day pattern follows a moved DTSTART; a
+    // multi-day pattern keeps its choices and includes the new first day so
+    // the series cannot begin with a stray occurrence outside its cadence.
+    if (value.repeat !== 'weekly'
+        || (value.weeklyDays.length === 1 && value.weeklyDays[0] === previousDay)) {
+      value.weeklyDays = [nextDay];
+    } else if (!value.weeklyDays.includes(nextDay)) {
+      value.weeklyDays = normalizedWeeklyDays([...value.weeklyDays, nextDay]);
+    }
   }
 
+  function chooseRepeatEnd(kind: string) {
+    if (kind === 'on') {
+      value.repeatEnd = value.repeatEnd.kind === 'on'
+        ? value.repeatEnd
+        : { kind: 'on', date: value.date };
+    } else if (kind === 'after') {
+      value.repeatEnd = value.repeatEnd.kind === 'after'
+        ? value.repeatEnd
+        : { kind: 'after', count: 10 };
+    } else {
+      value.repeatEnd = { kind: 'never' };
+    }
+  }
   function save() {
     error = null;
     invalidField = null;
@@ -321,6 +356,12 @@
       error = value.isAllDay
         ? 'The last day cannot be before the first day.'
         : 'The end time must be after the start time.';
+      return;
+    }
+    const repeatProblem = repeatEndProblem(value);
+    if (repeatProblem) {
+      error = repeatProblem;
+      invalidField = 'repeatEnd';
       return;
     }
     const result = { calendarId: value.calendarId, scope, fields: toEventInput(value, initial) };
@@ -603,6 +644,58 @@
         {/each}
       </select>
     </label>
+    {#if value.repeat === 'weekly'}
+      <div class="weekdayfield">
+        <span class="lab">Repeat on</span>
+        <div class="weekdayrow" role="group" aria-label="Repeat on">
+          {#each WEEKDAY_OPTIONS as day (day.code)}
+            <button
+              type="button"
+              class:active={value.weeklyDays.includes(day.code)}
+              aria-label={day.name}
+              aria-pressed={value.weeklyDays.includes(day.code)}
+              title={day.name}
+              onclick={() => (value = toggledWeeklyDay(value, day.code))}
+            >{day.short}</button>
+          {/each}
+        </div>
+      </div>
+    {/if}
+    {#if value.repeat !== 'never' && value.repeat !== CUSTOM_REPEAT}
+      <div class="repeatendfield">
+        <span class="lab">Ends</span>
+        <div class="repeatendrow">
+          <select
+            aria-label="Repeat ends"
+            value={value.repeatEnd.kind}
+            onchange={(e) => chooseRepeatEnd(e.currentTarget.value)}
+          >
+            <option value="never">Never</option>
+            <option value="on">On date</option>
+            <option value="after">After</option>
+          </select>
+          {#if value.repeatEnd.kind === 'on'}
+            <input
+              type="date"
+              aria-label="Repeat end date"
+              aria-invalid={invalidField === 'repeatEnd' ? 'true' : undefined}
+              bind:value={value.repeatEnd.date}
+            />
+          {:else if value.repeatEnd.kind === 'after'}
+            <label class="aftercount">
+              <input
+                type="number"
+                step="1"
+                aria-label="Number of occurrences"
+                aria-invalid={invalidField === 'repeatEnd' ? 'true' : undefined}
+                bind:value={value.repeatEnd.count}
+              />
+              <span>occurrences</span>
+            </label>
+          {/if}
+        </div>
+      </div>
+    {/if}
     {#if isCustom}
       <p class="hint">
         omacal cannot write this rule. Choosing any other option replaces it.
@@ -835,6 +928,23 @@
   textarea { resize: vertical; line-height: 1.45; }
   .title { font-size: 13px; }
 
+  .weekdayfield { display: flex; flex-direction: column; gap: 4px; }
+  .weekdayrow { display: grid; grid-template-columns: repeat(7, 1fr); gap: 4px; }
+  .weekdayrow button { min-width: 0; height: 28px; padding: 0; border-radius: 999px;
+                       border: 1px solid var(--hairline); color: var(--muted);
+                       background: color-mix(in srgb, var(--text) 3%, transparent);
+                       font: 600 11px/1 inherit; cursor: pointer; }
+  .weekdayrow button:hover { color: var(--text); border-color: var(--muted); }
+  .weekdayrow button.active { color: var(--on-accent); border-color: var(--accent);
+                              background: var(--accent); }
+
+  .repeatendfield { display: flex; flex-direction: column; gap: 4px; }
+  .repeatendrow { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1.5fr);
+                  align-items: center; gap: 6px; }
+  .repeatendrow > select:only-child { grid-column: 1 / -1; }
+  .aftercount { display: flex; align-items: center; gap: 5px; min-width: 0;
+                color: var(--muted); font-size: 10px; }
+  .aftercount input { width: 58px; flex: none; }
   .allday { display: flex; align-items: center; gap: 6px; font-size: 11.5px; color: var(--muted); cursor: pointer; }
   .allday input { width: auto; }
 

--- a/ui/src/lib/eventdetail.ts
+++ b/ui/src/lib/eventdetail.ts
@@ -8,6 +8,17 @@ export type Attendee = {
   is_self: boolean;
 };
 
+/** iCalendar's weekday vocabulary, shared by the weekly picker and the
+ * command boundary. Sunday-first display order is defined in `eventform.ts`. */
+export type WeekdayCode = 'SU' | 'MO' | 'TU' | 'WE' | 'TH' | 'FR' | 'SA';
+
+/** The finite endings RFC 5545 allows on a recurrence. `never` means the
+ * series is unbounded; `on` is an inclusive calendar date. */
+export type RepeatEnd =
+  | { kind: 'never' }
+  | { kind: 'on'; date: string }
+  | { kind: 'after'; count: number };
+
 export type EventDetail = {
   id: number;
   calendar_id: number;
@@ -48,18 +59,22 @@ export type EventDetail = {
    *  cannot represent back to the user in words. Display only — never parse it
    *  to decide what the app can express; that is `repeat`'s job. */
   recurrence: string | null;
-  /** Which Repeat option represents `recurrence` exactly, or `'custom'` for a
+  /** Which Repeat option represents `recurrence` completely, or `'custom'` for a
    *  rule this app cannot express.
    *
-   *  Computed on the Rust side by `write::repeat_from_rrule`, which decides by
-   *  *exact string equality* against the rules `write::rrule_for` authors.
-   *  Never re-derive it here: the whole point of exact equality is that one
-   *  authority decides what omacal can express, and a second copy of the table
-   *  in TypeScript drifts the moment either side gains an option. It fails
+   *  Computed on the Rust side by `write::repeat_from_rrule`, which matches
+   *  base rules exactly and strictly parses only plain weekly BYDAY rules.
+   *  Never re-derive it here: one authority decides what omacal can express,
+   *  and a second copy in TypeScript drifts the moment either side gains an
+   *  option. It fails
    *  silently when it does — an unrepresentable rule read as a representable
    *  one means the next save rewrites "every 2nd Tuesday" as "weekly", and
    *  mails the whole guest list about it. */
   repeat: string;
+  /** Weekdays from an exactly representable weekly `BYDAY` rule. Empty for a
+   *  plain weekly rule, whose day comes from DTSTART. */
+  weekly_days: WeekdayCode[];
+  repeat_end: RepeatEnd;
   color: string | null;
   organizer_email: string | null;
   self_response: string | null;
@@ -103,7 +118,8 @@ export type Occurrence = {
  * What `create_event` takes on the Rust side (`write::EventInput`) — the
  * UI's own vocabulary, not an RRULE: `repeat` is one of `'never'`,
  * `'daily'`, `'weekdays'`, `'weekly'`, `'monthly'`, `'yearly'`, mapped to an
- * actual rule by `write::rrule_for`. Omit it entirely to create a one-off
+ * actual rule by `write::rrule_for` (refined by `weeklyDays` for BYDAY).
+ * Omit it entirely to create a one-off
  * event; `'never'` and "omitted" are the same thing on a create, since there
  * is no existing rule to leave alone.
  */
@@ -114,6 +130,10 @@ export type EventInput = {
   when: WhenInput;
   tz: string;
   repeat?: string;
+  /** Present with `repeat: 'weekly'` when the user chose the weekly pattern. */
+  weeklyDays?: WeekdayCode[];
+  /** Present when the repeat controls were created or changed. */
+  repeatEnd?: RepeatEnd;
   /**
    * The guest list the event should end up with, or **absent** when the user
    * did not touch it.

--- a/ui/src/lib/eventform.ts
+++ b/ui/src/lib/eventform.ts
@@ -7,7 +7,10 @@
 // three-state `repeat` — are testable as functions rather than only through a
 // rendered form.
 
-import type { EventDetail, EventInput, SendUpdates, WhenInput } from './eventdetail';
+import type {
+  EventDetail, EventInput, RepeatEnd, SendUpdates, WeekdayCode, WhenInput,
+} from './eventdetail';
+export type { RepeatEnd, WeekdayCode } from './eventdetail';
 
 /** Which occurrences an edit applies to. Mirrors `update_event`'s own scopes. */
 export type Scope = 'this' | 'all' | 'following';
@@ -45,8 +48,9 @@ export type EventFormResult = {
  * This is a *label* table, not a second copy of the mapping: no rule text
  * appears here, and nothing in this file decides whether a given RRULE is one
  * of these — that answer arrives already made, on `EventDetail.repeat`, from
- * `write::repeat_from_rrule`. See that field's own comment for why there is
- * exactly one authority for it.
+ * `write::repeat_from_rrule`. That Rust function also strictly recognises the
+ * plain weekly BYDAY shape represented by `weeklyDays`; the UI never parses
+ * raw recurrence to make this decision.
  */
 export const REPEAT_OPTIONS: Array<[key: string, label: string]> = [
   ['never', 'Does not repeat'],
@@ -60,6 +64,20 @@ export const REPEAT_OPTIONS: Array<[key: string, label: string]> = [
 /** The value `write::repeat_from_rrule` answers for a rule omacal cannot
  *  express. Not in `REPEAT_OPTIONS`: it is never something a user may pick. */
 export const CUSTOM_REPEAT = 'custom';
+
+/** The visual pattern the user asked for: `S M T W R F S`, with `R` for
+ * Thursday so both Tuesdays and Thursdays stay one keystroke/wide button. */
+export const WEEKDAY_OPTIONS: ReadonlyArray<{
+  code: WeekdayCode; short: string; name: string;
+}> = [
+  { code: 'SU', short: 'S', name: 'Sunday' },
+  { code: 'MO', short: 'M', name: 'Monday' },
+  { code: 'TU', short: 'T', name: 'Tuesday' },
+  { code: 'WE', short: 'W', name: 'Wednesday' },
+  { code: 'TH', short: 'R', name: 'Thursday' },
+  { code: 'FR', short: 'F', name: 'Friday' },
+  { code: 'SA', short: 'S', name: 'Saturday' },
+];
 
 /**
  * Everything the form edits, in the shapes its inputs actually hold — dates as
@@ -138,6 +156,12 @@ export type EventFormValue = {
   calendarId: number | null;
   /** A key from `REPEAT_OPTIONS`, or `CUSTOM_REPEAT`. */
   repeat: string;
+  /** The selected days when `repeat === 'weekly'`. Always Sunday-first and
+   *  non-empty for values built by this module. */
+  weeklyDays: WeekdayCode[];
+  /** How the series stops. Kept even while Repeat is Never so switching a
+   * cadence off and back on does not discard what was typed. */
+  repeatEnd: RepeatEnd;
   /** The raw RRULE behind a `custom` repeat, for showing it in words. Display
    *  only — never parsed to decide what the app can express. */
   recurrence: string | null;
@@ -449,6 +473,53 @@ function addDays(date: string, days: number): string {
   return `${at.getUTCFullYear()}-${pad(at.getUTCMonth() + 1)}-${pad(at.getUTCDate())}`;
 }
 
+/** A form date's weekday. Inputs produced by this module are real dates; the
+ * Monday fallback only keeps a half-typed native date from breaking render. */
+export function weekdayCodeForDate(date: string): WeekdayCode {
+  const [y, m, d] = date.split('-').map(Number);
+  const at = new Date(y, m - 1, d, 12);
+  const index = Number.isFinite(at.getTime()) ? at.getDay() : 1;
+  return WEEKDAY_OPTIONS[index]?.code ?? 'MO';
+}
+
+/** Stable Sunday-first order and no duplicates, regardless of click/NLP order. */
+export function normalizedWeeklyDays(days: readonly WeekdayCode[]): WeekdayCode[] {
+  const selected = new Set(days);
+  return WEEKDAY_OPTIONS.map((day) => day.code).filter((day) => selected.has(day));
+}
+
+/** Set comparison in display order. Exported because recurrence's
+ * unchanged-means-absent wire rule depends on the days as well as the select. */
+export function sameWeeklyDays(a: readonly WeekdayCode[], b: readonly WeekdayCode[]): boolean {
+  const left = normalizedWeeklyDays(a);
+  const right = normalizedWeeklyDays(b);
+  return left.length === right.length && left.every((day, i) => day === right[i]);
+}
+
+/** Value equality for the tagged repeat-ending union. */
+export function sameRepeatEnd(a: RepeatEnd, b: RepeatEnd): boolean {
+  if (a.kind !== b.kind) return false;
+  if (a.kind === 'on' && b.kind === 'on') return a.date === b.date;
+  if (a.kind === 'after' && b.kind === 'after') return a.count === b.count;
+  return true;
+}
+
+/** The repeat-ending error a Save must name instead of silently repairing. */
+export function repeatEndProblem(value: EventFormValue): string | null {
+  if (value.repeat === 'never' || value.repeat === CUSTOM_REPEAT
+      || value.repeatEnd.kind === 'never') return null;
+  if (value.repeatEnd.kind === 'after') {
+    return Number.isInteger(value.repeatEnd.count) && value.repeatEnd.count >= 1
+      ? null
+      : 'End after must be at least 1 occurrence.';
+  }
+  const end = utcOf(value.repeatEnd.date);
+  const start = utcOf(value.date);
+  if (!Number.isFinite(end)) return 'Choose a valid repeat end date.';
+  if (end < start) return 'The repeat end date cannot be before the event starts.';
+  return null;
+}
+
 /**
  * Where the end date goes when the start date moves from `from` to `to`.
  *
@@ -465,6 +536,36 @@ export function shiftedEndDate(from: string, to: string, endDate: string): strin
   const span = (utcOf(endDate) - utcOf(from)) / DAY_MS;
   if (!Number.isInteger(span) || span < 0 || !Number.isFinite(utcOf(to))) return endDate;
   return addDays(to, span);
+}
+
+/** Toggle one weekly button. The last selected day cannot be removed. If the
+ * event's first date is no longer in the pattern, move the whole date span to
+ * the next selected day; otherwise DTSTART would create a stray first
+ * occurrence outside the cadence shown by the buttons. */
+export function toggledWeeklyDay(value: EventFormValue, code: WeekdayCode): EventFormValue {
+  const selected = value.weeklyDays.includes(code);
+  if (selected && value.weeklyDays.length === 1) return value;
+  const weeklyDays = normalizedWeeklyDays(selected
+    ? value.weeklyDays.filter((day) => day !== code)
+    : [...value.weeklyDays, code]);
+  if (weeklyDays.includes(weekdayCodeForDate(value.date))) {
+    return { ...value, weeklyDays };
+  }
+  const current = WEEKDAY_OPTIONS.findIndex((day) => day.code === weekdayCodeForDate(value.date));
+  const offsets = weeklyDays.map((day) => {
+    const target = WEEKDAY_OPTIONS.findIndex((candidate) => candidate.code === day);
+    return (target - current + 7) % 7;
+  }).filter((offset) => offset > 0);
+  const nextDate = addDays(value.date, Math.min(...offsets));
+  return {
+    ...value,
+    weeklyDays,
+    date: nextDate,
+    endDate: shiftedEndDate(value.date, nextDate, value.endDate),
+    repeatEnd: value.repeatEnd.kind === 'on'
+      ? { kind: 'on', date: shiftedEndDate(value.date, nextDate, value.repeatEnd.date) }
+      : value.repeatEnd,
+  };
 }
 
 /** The next half-hour boundary strictly after `nowMs`: 09:12 and 09:30 both
@@ -519,6 +620,8 @@ export function blankValueAt(
     description: '',
     calendarId,
     repeat: 'never',
+    weeklyDays: [weekdayCodeForDate(dateOf(startMs))],
+    repeatEnd: { kind: 'never' },
     recurrence: null,
     // Nobody, until the user types somebody in. The guest editor is on this
     // path now; `toEventInput` sends the list only when it differs from this
@@ -717,11 +820,12 @@ export function valueFromDetail(
   startMs: number,
   endMs: number,
 ): EventFormValue {
+  const displayedDate = detail.is_all_day
+    ? occurrenceDate(detail.start_date, detail.start_ms, startMs)
+    : dateOf(startMs);
   return {
     title: detail.title ?? '',
-    date: detail.is_all_day
-      ? occurrenceDate(detail.start_date, detail.start_ms, startMs)
-      : dateOf(startMs),
+    date: displayedDate,
     // Inclusive on both arms, and inclusive already on the all-day one:
     // `end_date` is the last day a person would point at, worked out from the
     // exclusive `end_ms` once, on the Rust side, in the calendar's zone.
@@ -741,6 +845,10 @@ export function valueFromDetail(
     description: detail.description ?? '',
     calendarId: detail.calendar_id,
     repeat: detail.repeat,
+    weeklyDays: detail.weekly_days.length > 0
+      ? normalizedWeeklyDays(detail.weekly_days)
+      : [weekdayCodeForDate(displayedDate)],
+    repeatEnd: { ...detail.repeat_end },
     recurrence: detail.recurrence,
     // **Everyone** — see `EventFormValue.guests` for how this differs from
     // `mailableGuests`.
@@ -1070,13 +1178,37 @@ export const endAfterStart = (value: EventFormValue): boolean => {
  */
 export function toEventInput(value: EventFormValue, initial: EventFormValue): EventInput {
   const blank = (s: string) => (s.trim() === '' ? null : s);
+  const repeatChanged = value.repeat !== initial.repeat
+    || (value.repeat === 'weekly' && !sameWeeklyDays(value.weeklyDays, initial.weeklyDays))
+    || (value.repeat !== 'never' && value.repeat !== CUSTOM_REPEAT
+      && !sameRepeatEnd(value.repeatEnd, initial.repeatEnd));
+  const authoredRepeat = {
+    repeat: value.repeat,
+    ...(value.repeat === 'weekly'
+      ? { weeklyDays: normalizedWeeklyDays(value.weeklyDays) }
+      : {}),
+    ...(value.repeat !== 'never' && value.repeat !== CUSTOM_REPEAT
+      && value.repeatEnd.kind !== 'never'
+      ? { repeatEnd: { ...value.repeatEnd } }
+      : {}),
+  };
+  const repeatFields = value.isEdit
+    ? (repeatChanged
+        ? authoredRepeat
+        : {})
+    : (value.repeat === 'never'
+        ? {}
+        : authoredRepeat);
   return {
     summary: blank(value.title),
     location: blank(value.location),
     description: blank(value.description),
     when: whenOf(value),
     tz: Intl.DateTimeFormat().resolvedOptions().timeZone,
-    ...(value.repeat === initial.repeat ? {} : { repeat: value.repeat }),
+    // A create has no rule to leave untouched. This matters for quick-add and
+    // paste-style seeds whose repeat value is already populated when the full
+    // editor opens: comparing only with `initial` would omit that real choice.
+    ...repeatFields,
     // **Unchanged means absent**, the same three-state `repeat` runs on, and
     // on an edit it is load bearing rather than tidy: `attendees` is a
     // whole-list replace on Google's side, so a payload that carried the list

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -3654,6 +3654,53 @@ test.describe('EventForm', () => {
     await expect(custom).toHaveText('Custom · Every 2 weeks');
   });
 
+  test('Weekly exposes SMTWRFS buttons and saves the pushed day pattern', async ({ page }) => {
+    await open(page, 'create');
+    await page.getByLabel('Repeat', { exact: true }).selectOption('weekly');
+
+    const days = page.getByRole('group', { name: 'Repeat on' });
+    await expect(days.getByRole('button')).toHaveCount(7);
+    await expect(days.getByRole('button', { name: 'Wednesday' })).toHaveAttribute('aria-pressed', 'true');
+    await days.getByRole('button', { name: 'Monday' }).click();
+    await days.getByRole('button', { name: 'Friday' }).click();
+
+    await page.getByRole('button', { name: 'Create' }).click();
+    const [saved] = await saves(page);
+    expect(saved.fields.repeat).toBe('weekly');
+    expect(saved.fields.weeklyDays).toEqual(['MO', 'WE', 'FR']);
+  });
+
+  test('a repeating event can end on a date or after a number of occurrences', async ({ page }) => {
+    await open(page, 'create');
+    await page.getByLabel('Repeat', { exact: true }).selectOption('weekly');
+
+    const ends = page.getByLabel('Repeat ends');
+    await expect(ends).toHaveValue('never');
+    await ends.selectOption('on');
+    await page.getByLabel('Repeat end date').fill('2026-09-30');
+    await page.getByRole('button', { name: 'Create' }).click();
+    let [saved] = await saves(page);
+    expect(saved.fields.repeatEnd).toEqual({ kind: 'on', date: '2026-09-30' });
+
+    await open(page, 'create');
+    await page.getByLabel('Repeat', { exact: true }).selectOption('daily');
+    await page.getByLabel('Repeat ends').selectOption('after');
+    await page.getByLabel('Number of occurrences').fill('12');
+    await page.getByRole('button', { name: 'Create' }).click();
+    [saved] = (await saves(page)).slice(-1);
+    expect(saved.fields.repeatEnd).toEqual({ kind: 'after', count: 12 });
+  });
+
+  test('an invalid repeat ending is named and never saved', async ({ page }) => {
+    await open(page, 'create');
+    await page.getByLabel('Repeat', { exact: true }).selectOption('daily');
+    await page.getByLabel('Repeat ends').selectOption('after');
+    await page.getByLabel('Number of occurrences').fill('0');
+    await page.getByRole('button', { name: 'Create' }).click();
+    await expect(page.getByTestId('form-error')).toContainText('at least 1 occurrence');
+    expect(await saves(page)).toEqual([]);
+  });
+
   test('an event with guests says the choice is on the buttons, not on Save', async ({ page }) => {
     // **This replaces "Saving will notify 4 guests."** That sentence was true
     // when `update_event` was handed `all` unconditionally; spec §3 makes it a
@@ -3744,6 +3791,7 @@ test.describe('EventForm', () => {
     await page.getByRole('button', { name: 'Save' }).click();
     const [saved] = await saves(page);
     expect(saved.fields.repeat).toBe('weekly');
+    expect(saved.fields.weeklyDays).toEqual(['WE']);
   });
 
   /**

--- a/ui/tests/eventform.spec.ts
+++ b/ui/tests/eventform.spec.ts
@@ -3,8 +3,11 @@ import { offerableCalendarId, type Calendar } from '../src/lib/calendars';
 import type { EventDetail } from '../src/lib/eventdetail';
 import {
   addGuest, blankValue, blankValueAt, endAfterStart, isAddress, mailableGuests, pastedValue,
-  previewSpan, removableGuest, removeGuest, ruleInWords, sameGuests, shiftedEndDate,
-  toEventInput, toggledGuestOptional, valueFromDetail, whenOf, type EventFormValue,
+  previewSpan, removableGuest, removeGuest, ruleInWords, sameGuests,
+  repeatEndProblem, sameRepeatEnd, sameWeeklyDays, shiftedEndDate,
+  toEventInput, toggledGuestOptional,
+  toggledWeeklyDay, valueFromDetail, weekdayCodeForDate, whenOf,
+  type EventFormValue,
 } from '../src/lib/eventform';
 
 /** How long a **timed** value is, in ms.
@@ -61,6 +64,93 @@ test.describe('offerableCalendarId', () => {
     // returning a reader here would defeat the whole function.
     expect(offerableCalendarId(3, [cal(3, 'reader'), cal(4, 'freeBusyReader')])).toBeNull();
     expect(offerableCalendarId(null, [])).toBeNull();
+  });
+});
+
+test.describe('custom weekly patterns', () => {
+  const wednesday = (): EventFormValue => ({
+    ...blankValueAt(new Date(2026, 7, 5, 9).getTime(), 1),
+    date: '2026-08-05',
+    endDate: '2026-08-05',
+    weeklyDays: ['WE'],
+  });
+
+  test('a create sends the selected days with weekly, in stable calendar order', () => {
+    const initial = wednesday();
+    const value: EventFormValue = {
+      ...initial, repeat: 'weekly', weeklyDays: ['FR', 'MO', 'WE'],
+    };
+    const sent = toEventInput(value, initial);
+    expect(sent.repeat).toBe('weekly');
+    expect(sent.weeklyDays).toEqual(['MO', 'WE', 'FR']);
+  });
+
+  test('an unchanged edit sends no recurrence, while a day change sends the whole pattern', () => {
+    const initial = { ...wednesday(), isEdit: true, isRecurring: true, repeat: 'weekly' };
+    expect(toEventInput(initial, initial).repeat).toBeUndefined();
+    expect(toEventInput(initial, initial).weeklyDays).toBeUndefined();
+
+    const changed: EventFormValue = { ...initial, weeklyDays: ['MO', 'WE', 'FR'] };
+    const sent = toEventInput(changed, initial);
+    expect(sent.repeat).toBe('weekly');
+    expect(sent.weeklyDays).toEqual(['MO', 'WE', 'FR']);
+  });
+
+  test('the last button stays selected and removing the start day advances DTSTART', () => {
+    const only = wednesday();
+    expect(toggledWeeklyDay(only, 'WE')).toBe(only);
+
+    const two: EventFormValue = { ...only, weeklyDays: ['WE', 'FR'] };
+    const friday = toggledWeeklyDay(two, 'WE');
+    expect(friday.weeklyDays).toEqual(['FR']);
+    expect(friday.date).toBe('2026-08-07');
+    expect(friday.endDate).toBe('2026-08-07');
+    expect(weekdayCodeForDate(friday.date)).toBe('FR');
+    expect(sameWeeklyDays(['FR', 'MO'], ['MO', 'FR'])).toBe(true);
+  });
+});
+
+test.describe('repeat endings', () => {
+  const recurring = (): EventFormValue => ({
+    ...blankValueAt(new Date(2026, 7, 5, 9).getTime(), 1),
+    date: '2026-08-05', endDate: '2026-08-05', repeat: 'weekly', weeklyDays: ['WE'],
+  });
+
+  test('creates COUNT and UNTIL inputs and treats ending-only edits as recurrence changes', () => {
+    const initial = recurring();
+    const counted: EventFormValue = { ...initial, repeatEnd: { kind: 'after', count: 12 } };
+    expect(toEventInput(counted, initial)).toMatchObject({
+      repeat: 'weekly', weeklyDays: ['WE'], repeatEnd: { kind: 'after', count: 12 },
+    });
+
+    const editing: EventFormValue = {
+      ...initial, isEdit: true, isRecurring: true,
+      repeatEnd: { kind: 'on', date: '2026-10-31' },
+    };
+    expect(toEventInput(editing, editing).repeat).toBeUndefined();
+    const unbounded: EventFormValue = { ...editing, repeatEnd: { kind: 'never' } };
+    expect(toEventInput(unbounded, editing)).toMatchObject({ repeat: 'weekly' });
+    expect(toEventInput(unbounded, editing).repeatEnd).toBeUndefined();
+
+    // The hidden old boundary must not travel beside `repeat: never` when a
+    // bounded series is turned off. That pair is contradictory and the
+    // backend deliberately refuses it.
+    const stopped: EventFormValue = { ...editing, repeat: 'never' };
+    expect(toEventInput(stopped, editing).repeat).toBe('never');
+    expect(toEventInput(stopped, editing).repeatEnd).toBeUndefined();
+  });
+
+  test('validates count/date endings and compares tagged values exactly', () => {
+    expect(repeatEndProblem({ ...recurring(), repeatEnd: { kind: 'after', count: 0 } }))
+      .toContain('at least 1');
+    expect(repeatEndProblem({
+      ...recurring(), repeatEnd: { kind: 'on', date: '2026-08-04' },
+    })).toContain('cannot be before');
+    expect(repeatEndProblem({
+      ...recurring(), repeatEnd: { kind: 'on', date: '2026-08-05' },
+    })).toBeNull();
+    expect(sameRepeatEnd({ kind: 'after', count: 4 }, { kind: 'after', count: 4 })).toBe(true);
+    expect(sameRepeatEnd({ kind: 'after', count: 4 }, { kind: 'after', count: 5 })).toBe(false);
   });
 });
 
@@ -473,7 +563,8 @@ const timedDetail = (startMs: number, endMs: number): EventDetail => ({
   id: 1, calendar_id: 1, title: 'Standup', description: null, location: null,
   conference_uri: null, start_ms: startMs, end_ms: endMs,
   start_date: null, end_date: null, is_all_day: false,
-  is_recurring: false, recurrence: null, repeat: 'never', color: null,
+  is_recurring: false, recurrence: null, repeat: 'never', weekly_days: [],
+  repeat_end: { kind: 'never' }, color: null,
   organizer_email: null, self_response: null, can_respond: true, can_edit: true,
   attendees: [],
   reminders: { use_default: true, overrides: [] }, calendar_default_reminders: [],
@@ -1068,7 +1159,8 @@ const allDayDetail = (startDate: string, lastDate: string, startMs: number, endM
   id: 1, calendar_id: 1, title: 'Berlin trip', description: null, location: null,
   conference_uri: null, start_ms: startMs, end_ms: endMs,
   start_date: startDate, end_date: lastDate,
-  is_all_day: true, is_recurring: false, recurrence: null, repeat: 'never', color: null,
+  is_all_day: true, is_recurring: false, recurrence: null, repeat: 'never', weekly_days: [],
+  repeat_end: { kind: 'never' }, color: null,
   organizer_email: null, self_response: null, can_respond: true, can_edit: true,
   attendees: [],
   reminders: { use_default: true, overrides: [] }, calendar_default_reminders: [],

--- a/ui/tests/fixtures.ts
+++ b/ui/tests/fixtures.ts
@@ -431,6 +431,8 @@ const detail = (o: Partial<EventDetail> & { id: number }): EventDetail => ({
   // What `write::repeat_from_rrule` answers for `recurrence: null`, so the two
   // defaults agree. A fixture that sets one must set the other.
   repeat: 'never',
+  weekly_days: [],
+  repeat_end: { kind: 'never' },
   color: '#5b8def',
   organizer_email: null,
   self_response: 'needsAction',

--- a/ui/tests/harness/tauri.ts
+++ b/ui/tests/harness/tauri.ts
@@ -124,7 +124,7 @@ export const CALENDAR_SYNC_REMOVED = 143;
 const RESPOND_STUB_DETAIL = {
   id: 0, title: null, description: null, location: null, conference_uri: null,
   start_ms: 0, end_ms: 0, is_all_day: false, is_recurring: false, color: null,
-  recurrence: null, repeat: 'never',
+  recurrence: null, repeat: 'never', weekly_days: [], repeat_end: { kind: 'never' },
   organizer_email: null, self_response: null, can_respond: true, can_edit: false,
   attendees: [],
 };


### PR DESCRIPTION
## Summary

- add a Sunday-first `SMTWRFS` picker for custom weekly day patterns
- serialize strict `BYDAY` rules and round-trip every non-empty weekday combination without losing a day
- add repeat endings for Never, On date, and After count, including `UNTIL`/`COUNT` validation
- keep unsupported recurrence rules safe from unrelated edits

## Tests

- `npm run check`
- `npx playwright test tests/eventform.spec.ts --grep "selected days with weekly|unchanged edit sends no recurrence|last button stays selected|COUNT and UNTIL|validates count/date endings"`
- `npx playwright test tests/components.spec.ts --project=chromium --grep "SMTWRFS buttons|end on a date|invalid repeat ending"`
- `cargo test -p omacal-core recur::tests::a_custom_weekly_pattern_yields_each_selected_day_and_no_others`
- `cargo test -p omacal --lib write::tests::every_nonempty_weekday_pattern_round_trips_without_losing_a_day`