### PR TITLE
feat(keyboard): confirm Backspace event deletion

### DIFF
--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -445,6 +445,39 @@
     );
   }
 
+  /** Backspace on the vim-style event cursor takes the same guarded route as
+   * the popover's Delete button: fetch the current detail for permissions,
+   * preserve the selected occurrence's identity, then open `DeleteConfirm`.
+   * Nothing is deleted by the key itself. */
+  async function deleteSelectedEvent() {
+    if (!listable(view)) return;
+    const event = eventAtCursor(keyboardDays, keyboardCursor);
+    if (!event) return;
+    const el = document.querySelector<HTMLElement>('[data-kbd-selected-event]');
+    const r = el?.getBoundingClientRect();
+    const rect = r
+      ? { top: r.top, left: r.left, width: r.width, height: r.height }
+      : keyboardAnchor();
+
+    busy = true;
+    error = null;
+    try {
+      const detail = await getEventDetail(event.id);
+      const stillSelected = eventAtCursor(keyboardDays, keyboardCursor);
+      if (!stillSelected || stillSelected.id !== event.id
+          || stillSelected.start_ms !== event.start_ms) return;
+      if (!detail.can_edit) {
+        error = 'This calendar is read-only, so this event cannot be deleted.';
+        return;
+      }
+      askDelete({ detail, startMs: event.start_ms, endMs: event.end_ms }, rect);
+    } catch (e) {
+      error = String(e);
+    } finally {
+      busy = false;
+    }
+  }
+
   // A boundary key moves the anchor first, then finishes against the payload
   // that contains the destination. Ordinary header navigation is normalized
   // here too: once a new period arrives, selection follows its anchor rather
@@ -1481,6 +1514,7 @@
     search: () => (searchOpen = true),
     quickCreate: openQuickAdd,
     openSelected: openSelectedEvent,
+    deleteSelected: () => { void deleteSelectedEvent(); },
     create: newEventOnAnchor,
     // `F`, joining the same bare-key family as the rest (spec §1). It is a
     // no-op in Year and Big Year, where the control it duplicates is absent —

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -364,7 +364,10 @@
 
   function navigateSelectedEvent(dir: -1 | 1) {
     if (!listable(view)) return;
-    const moved = moveEvent(keyboardDays, keyboardCursor, dir);
+    const now = Date.now();
+    const moved = moveEvent(
+      keyboardDays, keyboardCursor, dir, { nowMs: now, todayStartMs: dayStart(now) },
+    );
     if (moved.overflow) {
       // `moveEvent` has already scanned every remaining day in this payload,
       // including empty ones. Continue after that edge, not merely after the
@@ -406,7 +409,10 @@
       pendingKeyboardDay = null;
       pendingEventMove = null;
       if (eventDir !== null) {
-        const moved = moveEvent(days, keyboardCursor, eventDir);
+        const now = Date.now();
+        const moved = moveEvent(
+          days, keyboardCursor, eventDir, { nowMs: now, todayStartMs: dayStart(now) },
+        );
         if (!moved.overflow) selectKeyboard(moved.cursor);
       } else {
         revealKeyboardCursor();

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -1383,7 +1383,12 @@
     // not an Element and therefore has no `matches` method.
     if (typeof t.matches === 'function'
         && t.matches('input, textarea, select, [contenteditable="true"]')) return true;
-    return !!t.closest?.('[role="dialog"]');
+    // A disabled control can drop focus to <body> while its dialog remains
+    // open. The dialog still owns the keyboard then; looking only upward from
+    // the event target would let a global `n` create a form behind an RSVP
+    // popover at exactly that moment.
+    return !!t.closest?.('[role="dialog"]')
+      || document.querySelector('[role="dialog"][aria-modal="true"]') !== null;
   }
 
   /**

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -366,7 +366,7 @@
     if (!listable(view)) return;
     const now = Date.now();
     const moved = moveEvent(
-      keyboardDays, keyboardCursor, dir, { nowMs: now, todayStartMs: dayStart(now) },
+      keyboardDays, keyboardCursor, dir, { nowMs: now },
     );
     if (moved.overflow) {
       // `moveEvent` has already scanned every remaining day in this payload,
@@ -411,7 +411,7 @@
       if (eventDir !== null) {
         const now = Date.now();
         const moved = moveEvent(
-          days, keyboardCursor, eventDir, { nowMs: now, todayStartMs: dayStart(now) },
+          days, keyboardCursor, eventDir, { nowMs: now },
         );
         if (!moved.overflow) selectKeyboard(moved.cursor);
       } else {

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -125,6 +125,11 @@
    * rather than a grid so switching between grid and list preserves the same
    * selection, and `o`/Enter always reaches the shared detail popover. */
   let keyboardCursor = $state<KeyboardCursor>(dayCursor(dayStart(Date.now())));
+  /** Visual selection is opt-in. The cursor still tracks payload and view
+   * changes before then, but ordinary mouse users never inherit a permanent
+   * accent ring merely because keyboard navigation exists. */
+  let keyboardActive = $state(false);
+  const visibleKeyboardCursor = $derived(keyboardActive ? keyboardCursor : null);
   /** A `j`/`k` that crossed the loaded payload. The adjacent period is fetched
    * by moving `anchorMs`; once it lands, this finishes the move at its first or
    * last event. One hop is deliberate: an empty Day view remains selected and
@@ -305,7 +310,7 @@
   });
 
   const keyboardStatus = $derived.by(() => {
-    if (!listable(view) || keyboardDays.length === 0) return '';
+    if (!keyboardActive || !listable(view) || keyboardDays.length === 0) return '';
     const day = new Date(keyboardCursor.dayStartMs).toLocaleDateString(undefined, {
       weekday: 'long', month: 'long', day: 'numeric',
     });
@@ -383,7 +388,7 @@
 
   function selectKeyboard(cursor: KeyboardCursor) {
     keyboardCursor = cursor;
-    revealKeyboardCursor();
+    if (keyboardActive) revealKeyboardCursor();
   }
 
   function loadKeyboardDay(startMs: number, eventDir: -1 | 1 | null) {
@@ -395,6 +400,7 @@
 
   function navigateSelectedDay(dir: -1 | 1) {
     if (!listable(view)) return;
+    keyboardActive = true;
     const moved = moveDay(keyboardDays, keyboardCursor, dir);
     if (moved.overflow) {
       loadKeyboardDay(shiftKeyboardDay(keyboardCursor.dayStartMs, dir), null);
@@ -407,6 +413,7 @@
 
   function navigateSelectedEvent(dir: -1 | 1) {
     if (!listable(view)) return;
+    keyboardActive = true;
     const now = Date.now();
     const moved = moveEvent(
       keyboardDays, keyboardCursor, dir, { nowMs: now },
@@ -425,7 +432,7 @@
   }
 
   function openSelectedEvent() {
-    if (!listable(view)) return;
+    if (!keyboardActive || !listable(view)) return;
     const event = eventAtCursor(keyboardDays, keyboardCursor);
     if (!event) return;
     const el = document.querySelector<HTMLElement>('[data-kbd-selected-event]');
@@ -1612,10 +1619,11 @@
   {#if view === 'month'}
     {#if month}
       {#if listMode}
-        <Filmstrip days={daysFromMonth(month)} {weather} {revealNowRequest} {keyboardCursor}
+        <Filmstrip days={daysFromMonth(month)} {weather} {revealNowRequest}
+                   keyboardCursor={visibleKeyboardCursor}
                    onopen={openGridEvent} />
       {:else}
-        <MonthGrid {month} {keyboardCursor} onopen={openGridEvent}
+        <MonthGrid {month} keyboardCursor={visibleKeyboardCursor} onopen={openGridEvent}
                    ondaypick={handleDayPick} oncreate={newEventOnDay} />
       {/if}
     {/if}
@@ -1644,10 +1652,12 @@
     {/if}
   {:else if week}
     {#if listMode}
-      <Filmstrip days={daysFromWeek(week)} {weather} {revealNowRequest} {keyboardCursor}
+      <Filmstrip days={daysFromWeek(week)} {weather} {revealNowRequest}
+                 keyboardCursor={visibleKeyboardCursor}
                  onopen={openGridEvent} />
     {:else}
-      <WeekGrid {week} {weather} {formPreview} {revealNowRequest} {keyboardCursor}
+      <WeekGrid {week} {weather} {formPreview} {revealNowRequest}
+                keyboardCursor={visibleKeyboardCursor}
                 oncreate={newEventAt} onedit={openEdit} ondelete={askDelete}
                 oncopy={copyOccurrence}
         onmove={moveOccurrence} onresponded={refreshAfterWrite} />

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -329,6 +329,23 @@
       const event = document.querySelector<HTMLElement>('[data-kbd-selected-event]');
       if (event) {
         event.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+
+        // An all-day chip sits above, not inside, WeekGrid's hour scrollport.
+        // Revealing the chip therefore cannot move the hours on its own, and
+        // the pane otherwise remains parked wherever the previous timed event
+        // left it until traversal finally reaches a timed block. Entering a
+        // day through its first row means starting at the top of that day, so
+        // move the hour pane immediately. Later all-day rows leave it alone.
+        if (!listMode && (view === 'day' || view === 'week')) {
+          const day = keyboardDays.find((d) => d.startMs === keyboardCursor.dayStartMs);
+          const selected = eventAtCursor(keyboardDays, keyboardCursor);
+          const first = day?.events[0];
+          if (selected?.is_all_day && first
+              && first.id === selected.id && first.start_ms === selected.start_ms) {
+            const hours = document.querySelector<HTMLElement>('[data-testid="week-body"]');
+            if (hours) hours.scrollTop = 0;
+          }
+        }
         return;
       }
       const day = document.querySelector<HTMLElement>('[data-kbd-selected-day]');

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -346,11 +346,29 @@
             const firstTimed = day.events.find((candidate) => !candidate.is_all_day);
             const hours = document.querySelector<HTMLElement>('[data-testid="week-body"]');
             if (hours) {
-              const scrollStart = firstTimed
-                ? Math.max(day.startMs, firstTimed.start_ms - 3_600_000)
-                : day.startMs;
-              hours.scrollTop = (scrollStart - day.startMs)
-                / (day.endMs - day.startMs) * hours.scrollHeight;
+              if (!firstTimed) {
+                hours.scrollTop = 0;
+              } else {
+                const column = hours.querySelector<HTMLElement>(
+                  `.col[data-start-ms="${day.startMs}"]`,
+                );
+                const firstTimedBlock = column?.querySelector<HTMLElement>(
+                  `[data-event-id="${firstTimed.id}"][data-event-start-ms="${firstTimed.start_ms}"]`,
+                );
+                if (firstTimedBlock) {
+                  // Measure the rendered block rather than deriving its position
+                  // from scrollHeight. The scrollport owns top padding while the
+                  // 24-hour column does not, and conflating the two leaves this
+                  // target several pixels adrift (and changes with its padding).
+                  const targetTop = hours.scrollHeight / 24;
+                  const delta = firstTimedBlock.getBoundingClientRect().top
+                    - hours.getBoundingClientRect().top - targetTop;
+                  hours.scrollTop = Math.max(0, Math.min(
+                    hours.scrollHeight - hours.clientHeight,
+                    hours.scrollTop + delta,
+                  ));
+                }
+              }
             }
           }
         }

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -1520,10 +1520,10 @@
     )) return;
     const hit = SHORTCUT_LIST.find((s) => s.key === key || s.aliases?.includes(key));
     if (!hit) return;
-    // Consumed where the table says so. `/` needs it because WebKitGTK runs
-    // the keydown's default insertion after search has focused its field;
-    // `o`/Enter share the flag so the open action cannot also activate the
-    // surface that happened to sit under the selection.
+    // Consumed where the table says so. `/`, `n`, and `q` need it because
+    // WebKitGTK runs the keydown's default insertion after the new panel has
+    // focused its field; `o`/Enter share the flag so the open action cannot
+    // also activate the surface that happened to sit under the selection.
     if (hit.consumes) e.preventDefault();
     SHORTCUT_ACTIONS[hit.id]();
   }

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -1,6 +1,7 @@
 <!-- ui/src/App.svelte -->
 <script lang="ts">
   import { listen } from '@tauri-apps/api/event';
+  import { tick } from 'svelte';
   import { applyPalette, setPalette, type Palette } from './lib/theme';
   import {
     getWeek, getDay, getRange, getMonth, getYear, getBigYear, weekStart,
@@ -19,7 +20,13 @@
     valueFromDetail, type EventFormResult, type EventFormValue, type Scope,
   } from './lib/eventform';
   import type { Rect } from './lib/position';
-  import { daysFromMonth, daysFromWeek, listable } from './lib/filmstrip';
+  import {
+    allDaysFromMonth, allDaysFromWeek, daysFromMonth, daysFromWeek, listable,
+    MONTH_GRID_TIMED_LIMIT, type ListDay,
+  } from './lib/filmstrip';
+  import {
+    dayCursor, eventAtCursor, moveDay, moveEvent, type KeyboardCursor,
+  } from './lib/keyboardnav';
   import { getSettings, setListMode, type AppSettings, type WeekViewDays } from './lib/settings';
   import { setClockFormat } from './lib/clock.svelte';
   import { setSecondZone } from './lib/secondzone.svelte';
@@ -113,6 +120,18 @@
   let month = $state<MonthPayload | null>(null);
   let year = $state<YearPayload | null>(null);
   let bigYear = $state<BigYearPayload | null>(null);
+
+  /** The day/event named by the vim-style navigation keys. It lives in App
+   * rather than a grid so switching between grid and list preserves the same
+   * selection, and `o`/Enter always reaches the shared detail popover. */
+  let keyboardCursor = $state<KeyboardCursor>(dayCursor(dayStart(Date.now())));
+  /** A `j`/`k` that crossed the loaded payload. The adjacent period is fetched
+   * by moving `anchorMs`; once it lands, this finishes the move at its first or
+   * last event. One hop is deliberate: an empty Day view remains selected and
+   * another press advances again instead of silently paging without bound. */
+  let pendingEventMove = $state<-1 | 1 | null>(null);
+  let pendingKeyboardDay = $state<number | null>(null);
+
   let status = $state<AppStatus | null>(null);
   let calendars = $state<Calendar[]>([]);
   let busy = $state(false);
@@ -264,6 +283,141 @@
    * the user asked for something and it will not survive the restart.
    */
   let listMode = $state(false);
+
+  const keyboardDays = $derived.by<ListDay[]>(() => {
+    if (view === 'month' && month) {
+      const days = allDaysFromMonth(month);
+      if (listMode) return days;
+      // Month folds timed rows after three. Keyboard navigation follows what
+      // is actually visible rather than selecting a hidden row behind +N.
+      return days.map((day) => ({
+        ...day,
+        events: [
+          ...day.events.filter((event) => event.is_all_day),
+          ...day.events.filter((event) => !event.is_all_day).slice(0, MONTH_GRID_TIMED_LIMIT),
+        ],
+      }));
+    }
+    if ((view === 'day' || view === 'week') && week) {
+      return allDaysFromWeek(week);
+    }
+    return [];
+  });
+
+  const keyboardStatus = $derived.by(() => {
+    if (!listable(view) || keyboardDays.length === 0) return '';
+    const day = new Date(keyboardCursor.dayStartMs).toLocaleDateString(undefined, {
+      weekday: 'long', month: 'long', day: 'numeric',
+    });
+    const event = eventAtCursor(keyboardDays, keyboardCursor);
+    return event ? `Selected ${event.title} on ${day}` : `Selected ${day}`;
+  });
+
+  function shiftKeyboardDay(startMs: number, dir: -1 | 1): number {
+    const d = new Date(startMs);
+    d.setDate(d.getDate() + dir);
+    d.setHours(0, 0, 0, 0);
+    return d.getTime();
+  }
+
+  /** Keep the visual cursor in the nearest scrollport without moving DOM
+   * focus away from wherever the user is typing or, after opening, away from
+   * the detail dialog. Week columns already fit horizontally, so scrolling a
+   * 1680px-tall column as a day marker is explicitly avoided. */
+  function revealKeyboardCursor() {
+    void tick().then(() => {
+      const event = document.querySelector<HTMLElement>('[data-kbd-selected-event]');
+      if (event) {
+        event.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+        return;
+      }
+      const day = document.querySelector<HTMLElement>('[data-kbd-selected-day]');
+      if (day && !day.classList.contains('col')) {
+        day.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+      }
+    });
+  }
+
+  function selectKeyboard(cursor: KeyboardCursor) {
+    keyboardCursor = cursor;
+    revealKeyboardCursor();
+  }
+
+  function loadKeyboardDay(startMs: number, eventDir: -1 | 1 | null) {
+    pendingKeyboardDay = startMs;
+    pendingEventMove = eventDir;
+    selectKeyboard(dayCursor(startMs));
+    anchorMs = startMs;
+  }
+
+  function navigateSelectedDay(dir: -1 | 1) {
+    if (!listable(view)) return;
+    const moved = moveDay(keyboardDays, keyboardCursor, dir);
+    if (moved.overflow) {
+      loadKeyboardDay(shiftKeyboardDay(keyboardCursor.dayStartMs, dir), null);
+      return;
+    }
+    pendingKeyboardDay = null;
+    pendingEventMove = null;
+    selectKeyboard(moved.cursor);
+  }
+
+  function navigateSelectedEvent(dir: -1 | 1) {
+    if (!listable(view)) return;
+    const moved = moveEvent(keyboardDays, keyboardCursor, dir);
+    if (moved.overflow) {
+      // `moveEvent` has already scanned every remaining day in this payload,
+      // including empty ones. Continue after that edge, not merely after the
+      // selected event's day, or an empty tail would fetch the same week again.
+      const edge = keyboardDays[dir === 1 ? keyboardDays.length - 1 : 0];
+      loadKeyboardDay(shiftKeyboardDay(edge?.startMs ?? keyboardCursor.dayStartMs, dir), dir);
+      return;
+    }
+    pendingKeyboardDay = null;
+    pendingEventMove = null;
+    selectKeyboard(moved.cursor);
+  }
+
+  function openSelectedEvent() {
+    if (!listable(view)) return;
+    const event = eventAtCursor(keyboardDays, keyboardCursor);
+    if (!event) return;
+    const el = document.querySelector<HTMLElement>('[data-kbd-selected-event]');
+    const r = el?.getBoundingClientRect();
+    void openOccurrence(
+      event.id,
+      event.start_ms,
+      event.end_ms,
+      r ? { top: r.top, left: r.left, width: r.width, height: r.height } : keyboardAnchor(),
+    );
+  }
+
+  // A boundary key moves the anchor first, then finishes against the payload
+  // that contains the destination. Ordinary header navigation is normalized
+  // here too: once a new period arrives, selection follows its anchor rather
+  // than remaining invisibly parked in the old payload.
+  $effect(() => {
+    const days = keyboardDays;
+    if (!listable(view) || days.length === 0) return;
+
+    if (pendingKeyboardDay !== null) {
+      if (!days.some((day) => day.startMs === pendingKeyboardDay)) return;
+      const eventDir = pendingEventMove;
+      pendingKeyboardDay = null;
+      pendingEventMove = null;
+      if (eventDir !== null) {
+        const moved = moveEvent(days, keyboardCursor, eventDir);
+        if (!moved.overflow) selectKeyboard(moved.cursor);
+      } else {
+        revealKeyboardCursor();
+      }
+      return;
+    }
+
+    if (days.some((day) => day.startMs === keyboardCursor.dayStartMs)) return;
+    const target = days.find((day) => day.startMs === anchorMs) ?? days[0];
+    selectKeyboard(dayCursor(target.startMs));
+  });
 
   /**
    * How many times the user has decided this, so a slow read cannot undo a fast
@@ -549,6 +703,9 @@
 
   function goToday() {
     const today = dayStart(Date.now());
+    pendingKeyboardDay = null;
+    pendingEventMove = null;
+    selectKeyboard(dayCursor(today));
     anchorMs = today;
     revealNowRequest += 1;
   }
@@ -630,6 +787,9 @@
   // point of this task (spec §5): without it, Day view opens on today
   // instead of the day that was actually clicked.
   function handleDayPick(startMs: number) {
+    pendingKeyboardDay = null;
+    pendingEventMove = null;
+    selectKeyboard(dayCursor(startMs));
     anchorMs = startMs;
     view = 'day';
   }
@@ -1212,15 +1372,18 @@
     await refreshAfterWrite();
   }
 
-  // Keys are dropped when the user is typing (an `input`/`textarea`) or when
-  // focus is inside the event popover — RSVP buttons and a description live
-  // there, and a stray `3` while it has focus must not switch views behind
-  // it. `.pop` is `EventPopover`'s own root class.
+  // Keys are dropped when the user is typing or inside any dialog. The latter
+  // lets event details own Tab, native copy, and Enter on a focused link
+  // without a calendar shortcut firing behind them.
   function isTypingTarget(e: KeyboardEvent): boolean {
     const t = e.target as HTMLElement | null;
     if (!t) return false;
-    if (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA') return true;
-    return !!t.closest?.('.pop');
+    // A synthetic event can be dispatched on `window` itself (and the
+    // WebKit contract spec does exactly that), which is an EventTarget but
+    // not an Element and therefore has no `matches` method.
+    if (typeof t.matches === 'function'
+        && t.matches('input, textarea, select, [contenteditable="true"]')) return true;
+    return !!t.closest?.('[role="dialog"]');
   }
 
   /**
@@ -1244,6 +1407,10 @@
     bigyear: () => pick('bigyear'),
     prev: () => step(-1),
     next: () => step(1),
+    prevDay: () => navigateSelectedDay(-1),
+    nextDay: () => navigateSelectedDay(1),
+    prevEvent: () => navigateSelectedEvent(-1),
+    nextEvent: () => navigateSelectedEvent(1),
     today: goToday,
     // `/` joins the bare-key family rather than inventing a modifier chord: it
     // is the search key everywhere that has one, it collides with nothing
@@ -1252,6 +1419,7 @@
     // to claim. Its `consumes` flag is why — see below.
     search: () => (searchOpen = true),
     quickCreate: openQuickAdd,
+    openSelected: openSelectedEvent,
     create: newEventOnAnchor,
     // `F`, joining the same bare-key family as the rest (spec §1). It is a
     // no-op in Year and Big Year, where the control it duplicates is absent —
@@ -1308,18 +1476,28 @@
     // Lowercased, which is what makes `H` step like `h` — the old `switch`
     // did the same, and digits and punctuation are unaffected (`'?'` and
     // `'/'` lowercase to themselves).
-    const hit = SHORTCUT_LIST.find((s) => s.key === e.key.toLowerCase());
+    const key = e.key.toLowerCase();
+    // Enter on a focused control belongs to that control. The alias opens the
+    // calendar selection only from the calendar surface itself.
+    if (key === 'enter' && (e.target as HTMLElement | null)?.closest?.(
+      'button, a, input, textarea, select, [contenteditable="true"]',
+    )) return;
+    const hit = SHORTCUT_LIST.find((s) => s.key === key || s.aliases?.includes(key));
     if (!hit) return;
-    // Consumed where the table says so, which today is `/` alone: WebKitGTK
-    // runs the keydown's default action — inserting the character — *after*
-    // the overlay has mounted and focused its field, so an unconsumed `/`
-    // lands in the input it just opened and "sync" is searched as "/sync".
+    // Consumed where the table says so. `/` needs it because WebKitGTK runs
+    // the keydown's default insertion after search has focused its field;
+    // `o`/Enter share the flag so the open action cannot also activate the
+    // surface that happened to sit under the selection.
     if (hit.consumes) e.preventDefault();
     SHORTCUT_ACTIONS[hit.id]();
   }
 </script>
 
 <svelte:window onkeydown={handleKeydown} onmousemove={trackPointer} />
+
+{#if keyboardStatus}
+  <p class="kbd-status" aria-live="polite">{keyboardStatus}</p>
+{/if}
 
 <!-- The webview's own context menu — Reload, Back, View Source — is browser
      chrome inside what presents itself as a native app, so it is suppressed
@@ -1380,10 +1558,11 @@
   {#if view === 'month'}
     {#if month}
       {#if listMode}
-        <Filmstrip days={daysFromMonth(month)} {weather} {revealNowRequest}
+        <Filmstrip days={daysFromMonth(month)} {weather} {revealNowRequest} {keyboardCursor}
                    onopen={openGridEvent} />
       {:else}
-        <MonthGrid {month} onopen={openGridEvent} ondaypick={handleDayPick} oncreate={newEventOnDay} />
+        <MonthGrid {month} {keyboardCursor} onopen={openGridEvent}
+                   ondaypick={handleDayPick} oncreate={newEventOnDay} />
       {/if}
     {/if}
   {:else if view === 'year'}
@@ -1411,10 +1590,10 @@
     {/if}
   {:else if week}
     {#if listMode}
-      <Filmstrip days={daysFromWeek(week)} {weather} {revealNowRequest}
+      <Filmstrip days={daysFromWeek(week)} {weather} {revealNowRequest} {keyboardCursor}
                  onopen={openGridEvent} />
     {:else}
-      <WeekGrid {week} {weather} {formPreview} {revealNowRequest}
+      <WeekGrid {week} {weather} {formPreview} {revealNowRequest} {keyboardCursor}
                 oncreate={newEventAt} onedit={openEdit} ondelete={askDelete}
                 oncopy={copyOccurrence}
         onmove={moveOccurrence} onresponded={refreshAfterWrite} />
@@ -1549,4 +1728,6 @@
      drawn to and not just the header's. */
   main { padding: 0 16px 14px; box-sizing: border-box; height: 100%;
          display: flex; flex-direction: column; }
+  .kbd-status { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+                overflow: hidden; clip-path: inset(50%); white-space: nowrap; }
 </style>

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -334,16 +334,24 @@
         // Revealing the chip therefore cannot move the hours on its own, and
         // the pane otherwise remains parked wherever the previous timed event
         // left it until traversal finally reaches a timed block. Entering a
-        // day through its first row means starting at the top of that day, so
-        // move the hour pane immediately. Later all-day rows leave it alone.
+        // day through its first row should also reveal the day ahead: place
+        // its first timed event one hour below the band. Later all-day rows
+        // leave the hour pane alone.
         if (!listMode && (view === 'day' || view === 'week')) {
           const day = keyboardDays.find((d) => d.startMs === keyboardCursor.dayStartMs);
           const selected = eventAtCursor(keyboardDays, keyboardCursor);
           const first = day?.events[0];
           if (selected?.is_all_day && first
               && first.id === selected.id && first.start_ms === selected.start_ms) {
+            const firstTimed = day.events.find((candidate) => !candidate.is_all_day);
             const hours = document.querySelector<HTMLElement>('[data-testid="week-body"]');
-            if (hours) hours.scrollTop = 0;
+            if (hours) {
+              const scrollStart = firstTimed
+                ? Math.max(day.startMs, firstTimed.start_ms - 3_600_000)
+                : day.startMs;
+              hours.scrollTop = (scrollStart - day.startMs)
+                / (day.endMs - day.startMs) * hours.scrollHeight;
+            }
           }
         }
         return;

--- a/ui/src/lib/AllDayBand.svelte
+++ b/ui/src/lib/AllDayBand.svelte
@@ -3,9 +3,12 @@
   import type { Lane, UiEvent } from './api';
   import type { Rect } from './position';
   import { gutterWidth } from './secondzone.svelte';
+  import { cursorNamesEvent, type KeyboardCursor } from './keyboardnav';
 
-  let { lanes, events, overflow, columns = 7, onopen }:
+  let { lanes, events, overflow, columns = 7, dayStarts = [], keyboardCursor = null, onopen }:
     { lanes: Lane[]; events: UiEvent[]; overflow: number[]; columns?: number;
+      dayStarts?: number[];
+      keyboardCursor?: KeyboardCursor | null;
       /** Same contract as `EventBlock`'s, and wired to the same
        *  `WeekGrid.openPopover`. Required rather than optional: every
        *  `is_all_day` event is routed here by `commands::assemble_week`, so a
@@ -28,6 +31,13 @@
     const r = (e.currentTarget as HTMLElement).getBoundingClientRect();
     onopen(event, { top: r.top, left: r.left, width: r.width, height: r.height });
   }
+
+  function isKeyboardSelected(lane: Lane, event: UiEvent): boolean {
+    if (!keyboardCursor) return false;
+    const column = dayStarts.indexOf(keyboardCursor.dayStartMs);
+    return column >= lane.start_col && column <= lane.end_col
+      && cursorNamesEvent(keyboardCursor, keyboardCursor.dayStartMs, event);
+  }
 </script>
 
 {#if lanes.length || overflow.length}
@@ -36,10 +46,13 @@
     <div class="rows" style="--cols:{columns}">
       {#each lanes as lane}
         {@const ev = events[lane.idx]}
+        {@const keyboardSelected = isKeyboardSelected(lane, ev)}
         <button
           class="chip"
           class:cl={lane.cont_left}
           class:cr={lane.cont_right}
+          class:keyboard={keyboardSelected}
+          data-kbd-selected-event={keyboardSelected ? '' : undefined}
           style="
             grid-row:{lane.lane + 1};
             grid-column:{lane.start_col + 1} / {lane.end_col + 2};
@@ -107,6 +120,7 @@
   /* Flat edges mark a span continuing beyond this week. */
   .chip.cl { border-top-left-radius: 0; border-bottom-left-radius: 0; border-left-style: dashed; }
   .chip.cr { border-top-right-radius: 0; border-bottom-right-radius: 0; }
+  .chip.keyboard { outline: 2px solid var(--accent); outline-offset: 1px; }
 
   .more { font-size: 10px; color: var(--muted); opacity: .7; padding: 2px 4px; }
 </style>

--- a/ui/src/lib/EventBlock.svelte
+++ b/ui/src/lib/EventBlock.svelte
@@ -13,6 +13,7 @@
     ongrab,
     preview = null,
     liveSpan = null,
+    keyboardSelected = false,
   }: {
     event: UiEvent;
     placed: Placed;
@@ -40,6 +41,9 @@
      *  from the drag's `landed`, the very value a drop writes, so the label
      *  and the write can never disagree. */
     liveSpan?: { startMs: number; endMs: number } | null;
+    /** Named by App's vim-style cursor. This is visual selection, not DOM
+     * focus; opening it moves focus into the detail dialog. */
+    keyboardSelected?: boolean;
   } = $props();
 
   // What the card *says*: the drag's tentative span while one is in flight,
@@ -123,6 +127,8 @@
 <button
   class="ev {event.response}"
   class:dragging={preview !== null}
+  class:keyboard={keyboardSelected}
+  data-kbd-selected-event={keyboardSelected ? '' : undefined}
   style="
     top:{preview
       ? `calc(${placed.top * 100}% + ${preview.topDeltaPct}% + 1px)`
@@ -174,6 +180,8 @@
      the block is following a pointer and easing would put it behind the
      finger. */
   .ev.dragging { z-index: 50 !important; opacity: 0.85; cursor: grabbing; }
+  .ev.keyboard { outline: 2px solid var(--accent); outline-offset: 1px;
+                 z-index: 25 !important; }
   /* The grab bands, as cursors only — the hit test itself is `drag.ts`'s
      `edgeAt`, on the press's own offset. The `.grip` spans in the template
      exist purely to carry `ns-resize` over those bands: sized by the same

--- a/ui/src/lib/EventBlock.svelte
+++ b/ui/src/lib/EventBlock.svelte
@@ -129,6 +129,8 @@
   class:dragging={preview !== null}
   class:keyboard={keyboardSelected}
   data-kbd-selected-event={keyboardSelected ? '' : undefined}
+  data-event-id={event.id}
+  data-event-start-ms={event.start_ms}
   style="
     top:{preview
       ? `calc(${placed.top * 100}% + ${preview.topDeltaPct}% + 1px)`

--- a/ui/src/lib/EventPopover.svelte
+++ b/ui/src/lib/EventPopover.svelte
@@ -67,9 +67,8 @@
      *  by clicking this: the caller owns the confirmation, which has three
      *  scopes, a guest count and no undo behind it. */
     ondelete: () => void;
-    /** Ctrl+C (⌘C) landed on the popover itself rather than one of its
-     *  focusable copy fields: the caller should remember this occurrence as
-     *  what Ctrl+V will paste. Living here rather
+    /** Ctrl+C (⌘C) landed while this popover was open: the caller should
+     *  remember this occurrence as what Ctrl+V will paste. Living here rather
      *  than in `App`'s key handler because *here* is the only place that
      *  knows a popover is open at all for Day and Week — `WeekGrid` owns that
      *  popover end-to-end, and `App` never sees its occurrence. One listener
@@ -133,10 +132,6 @@
       ? dayOfDate(occurrenceDate(detail.start_date, detail.start_ms, occurrenceStartMs))
       : dayOfInstant(occurrenceStartMs),
   );
-  const whenLine = $derived(
-    detail.is_all_day ? day : `${day} · ${hhmm(occurrenceStartMs)}–${hhmm(occurrenceEndMs)}`,
-  );
-
   // A neutral default so `.pop` renders (and so `offsetWidth`/`offsetHeight`
   // are measurable at all) before `onMount` below can place it for real.
   // `anchor` never changes for this component's lifetime — WeekGrid mounts a
@@ -322,17 +317,13 @@
    *  ordinary sense — pasteable into a chat as text. The same formatters the
    *  panel renders with, so the text says what the screen says. */
   const clipboardLine = () => {
-    return [detail.title ?? '(no title)', whenLine, detail.location ?? ''].filter(Boolean).join('\n');
+    const when = detail.is_all_day ? day : `${day} ${hhmm(occurrenceStartMs)}–${hhmm(occurrenceEndMs)}`;
+    return [detail.title ?? '(no title)', when, detail.location ?? ''].filter(Boolean).join('\n');
   };
 
-  function copyField(value: string, label: string) {
-    try { navigator.clipboard?.writeText(value).catch(() => {}); } catch { /* no clipboard here */ }
-    note = { text: `Copied ${label}`, kind: 'info' };
-  }
-
-  // Ctrl+C — ⌘C on a Mac — copies the focused field when it has one, otherwise
-  // the event this popover is about. On `window` for the same reason Escape
-  // is, and with one yield: a real text selection in the panel keeps native
+  // Ctrl+C — ⌘C on a Mac — copies the event this popover is about. On
+  // `window` for the same reason Escape is, and with one yield: a real text
+  // selection in the panel keeps native
   // copy, because taking the chord away from selected text would break the
   // older meaning of the key to serve the newer one. Shift and Alt variants
   // pass through untouched — Ctrl+Shift+C is a devtools chord in the webview.
@@ -340,11 +331,6 @@
     if (e.key.toLowerCase() !== 'c' || !(e.ctrlKey || e.metaKey) || e.altKey || e.shiftKey) return;
     if (document.getSelection()?.toString()) return;
     e.preventDefault();
-    const field = (e.target as HTMLElement | null)?.closest<HTMLElement>('[data-copy-value]');
-    if (field) {
-      copyField(field.dataset.copyValue ?? '', field.dataset.copyLabel ?? 'field');
-      return;
-    }
     // Fire-and-forget: the buffer `oncopy` fills is what paste reads, and a
     // webview denying clipboard access must not turn the copy into an error.
     try { navigator.clipboard?.writeText(clipboardLine()).catch(() => {}); } catch { /* no clipboard here */ }
@@ -385,8 +371,8 @@
   };
 
   /** An open event owns these bare keys. Focused controls keep Enter's native
-   * meaning — a focused Join link joins once, an RSVP button answers, and a
-   * copy field copies — while Enter on the panel itself joins immediately. */
+   * meaning — a focused Join link joins once and an RSVP button answers —
+   * while Enter on the panel itself joins immediately. */
   function onPopoverKey(e: KeyboardEvent) {
     onCopyKey(e);
     if (e.defaultPrevented || e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return;
@@ -426,36 +412,23 @@
   aria-label={detail.title ?? '(no title)'}
   style="top:{pos.top}px; left:{pos.left}px"
 >
-  <h2 aria-label={detail.title ?? '(no title)'}><button type="button" class="copyfield"
-      aria-label="Copy title" data-copy-label="title"
-      data-copy-value={detail.title ?? '(no title)'}
-      onclick={() => copyField(detail.title ?? '(no title)', 'title')}
-      >{detail.title ?? '(no title)'}</button></h2>
-  <p class="when"><button type="button" class="copyfield" aria-label="Copy date and time"
-     data-copy-label="date and time"
-     data-copy-value={whenLine} onclick={() => copyField(whenLine, 'date and time')}
-     >{whenLine}</button></p>
-  {#if cadence}<p class="cadence"><button type="button" class="copyfield" aria-label="Copy repeat schedule"
-                       data-copy-label="repeat schedule" data-copy-value={cadence}
-                       onclick={() => copyField(cadence!, 'repeat schedule')}
-                       >{cadence}</button></p>{/if}
+  <h2>{detail.title ?? '(no title)'}</h2>
+  <p class="when">
+    {day}{#if !detail.is_all_day}
+      &nbsp;· {hhmm(occurrenceStartMs)}–{hhmm(occurrenceEndMs)}{/if}
+  </p>
+  {#if cadence}<p class="cadence">{cadence}</p>{/if}
 
   {#if segments.length}
-    <div class="desc">
-      <button type="button" class="copydesc" data-copy-label="description"
-              data-copy-value={detail.description ?? ''}
-              onclick={() => copyField(detail.description ?? '', 'description')}>Copy</button>
-      <p>{#each segments as s}{#if s.kind === 'link'}<a
-              href={s.value} target="_blank" rel="noopener noreferrer"
-              data-copy-label="link" data-copy-value={s.value}>{s.value}</a
-          >{:else}{s.value}{/if}{/each}</p>
-    </div>
+    <p class="desc">
+      {#each segments as s}
+        {#if s.kind === 'link'}<a href={s.value} target="_blank" rel="noopener noreferrer">{s.value}</a
+          >{:else}{s.value}{/if}
+      {/each}
+    </p>
   {/if}
 
-  {#if locationShown}<p class="loc"><button type="button" class="copyfield" aria-label="Copy location"
-                            data-copy-label="location" data-copy-value={locationShown}
-                            onclick={() => copyField(locationShown!, 'location')}
-                            >{locationShown}</button></p>{/if}
+  {#if locationShown}<p class="loc">{locationShown}</p>{/if}
   {#if joinUrl}
     <!-- The `href` stays for what an anchor gives away free — copy-link,
          middle-click, the status-bar preview — but a plain left click is
@@ -464,7 +437,6 @@
          crashes it (issue #1, `browser::open_external`). The backend
          re-derives the URL from its store rather than trusting this one. -->
     <a class="conf" href={joinUrl} target="_blank" rel="noopener noreferrer"
-       data-copy-label="meeting link" data-copy-value={joinUrl}
        onclick={(e) => { e.preventDefault(); void openConference(detail.id); }}>Join video call</a>
   {/if}
   <!-- Suppressed for the addresses Google mints for shared calendars and
@@ -472,10 +444,7 @@
        than nothing, and there is no name to fall back to — `EventDetail`
        carries no `organizer.displayName`. See `organizer.ts`. -->
   {#if detail.organizer_email && !isMachineAddress(detail.organizer_email)}
-    <p class="organizer"><button type="button" class="copyfield" aria-label="Copy organizer email"
-       data-copy-label="organizer email" data-copy-value={detail.organizer_email}
-       onclick={() => copyField(detail.organizer_email!, 'organizer email')}
-       >Organized by {detail.organizer_email}</button></p>
+    <p class="organizer">Organized by {detail.organizer_email}</p>
   {/if}
 
   {#if shownAttendees.length}
@@ -484,15 +453,8 @@
         <!-- `title` says the word on hover: a tilde in a 13px ring was read as
              "no idea what that is" (Omarchy, 2026-08-10), and the sighted had
              no equivalent of `.sr` to fall back on. -->
-        <button
-          type="button"
-          class="guest copyfield {a.response_status}"
-          data-copy-label="guest email"
-          data-copy-value={a.email}
-          onclick={() => copyField(a.email, 'guest email')}
-          aria-label="Copy guest email for {a.display_name ?? a.email}. {a.response_status === 'needsAction'
-            ? 'Awaiting response'
-            : STATUS_WORD[a.response_status] ?? 'Awaiting response'}"
+        <div
+          class="guest {a.response_status}"
           title={STATUS_WORD[a.response_status] ?? STATUS_WORD.needsAction}
         >
           <!-- The glyph carries the status, not the colour. This app takes its
@@ -503,7 +465,7 @@
           <i class="mark" aria-hidden="true">{MARK[a.response_status] ?? MARK.needsAction}</i>
           <span class="who">{a.display_name ?? a.email}{a.is_self ? ' (you)' : ''}</span>
           <span class="sr">{STATUS_WORD[a.response_status] ?? STATUS_WORD.needsAction}</span>
-        </button>
+        </div>
       {/each}
     </div>
   {/if}
@@ -592,23 +554,11 @@
      itself operable — a ring around the whole popover would only be noise.
      The controls inside keep theirs. */
   .pop:focus { outline: none; }
-  .copyfield { appearance: none; -webkit-appearance: none; font: inherit; color: inherit;
-               background: none; border: 0; padding: 0; margin: 0; text-align: left;
-               cursor: copy; }
-  .copyfield:focus-visible, .copydesc:focus-visible {
-    outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 3px;
-  }
-
   h2 { font-size: 14px; font-weight: 600; margin: 0 0 4px; letter-spacing: -.01em; }
   .when { color: var(--muted); font-size: 11px; margin: 0 0 8px; }
 
-  .desc { position: relative; white-space: pre-wrap; word-break: break-word; line-height: 1.5;
-          margin: 0 0 10px; padding-right: 38px; }
-  .desc p { margin: 0; }
-  .copydesc { appearance: none; -webkit-appearance: none; position: absolute; top: 0; right: 0;
-              font: inherit; font-size: 9.5px; color: var(--muted); cursor: copy;
-              border: 0; border-radius: 3px; background: none; padding: 1px 3px; }
-  .copydesc:hover { color: var(--text); }
+  .desc { white-space: pre-wrap; word-break: break-word; line-height: 1.5;
+          margin: 0 0 10px; }
   .desc a { color: var(--accent); }
 
   .loc, .organizer { color: var(--muted); font-size: 11px; margin: 0 0 4px; }

--- a/ui/src/lib/EventPopover.svelte
+++ b/ui/src/lib/EventPopover.svelte
@@ -378,7 +378,7 @@
     if (e.defaultPrevented || e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return;
 
     const key = e.key.toLowerCase();
-    const hit = EVENT_SHORTCUT_LIST.find((s) => s.key === key);
+    const hit = EVENT_SHORTCUT_LIST.find((s) => s.key === key || s.aliases?.includes(key));
     if (!hit) return;
 
     if (hit.id === 'join') {

--- a/ui/src/lib/EventPopover.svelte
+++ b/ui/src/lib/EventPopover.svelte
@@ -11,6 +11,7 @@
   import { occurrenceDate, ruleInWords } from './eventform';
   import { isMachineAddress } from './organizer';
   import { respondToEvent, type Attendee, type EventDetail } from './eventdetail';
+  import { EVENT_SHORTCUT_LIST, type EventShortcutId } from './shortcuts';
 
   let {
     detail,
@@ -350,9 +351,63 @@
     note = { text: 'Copied — Ctrl+V pastes it as a new event', kind: 'info' };
     oncopy();
   }
+
+  function clickResponse(response: 'accepted' | 'tentative' | 'declined') {
+    const button = panelEl?.querySelector<HTMLButtonElement>(
+      `[data-event-response="${response}"]`,
+    );
+    if (!button || button.disabled) return false;
+    // Use the real control so one-off responses, recurring scope questions,
+    // optimistic state and focus restoration remain the click path's job.
+    button.click();
+    return true;
+  }
+
+  const EVENT_SHORTCUT_ACTIONS: Record<EventShortcutId, () => boolean> = {
+    edit: () => {
+      if (!detail.can_edit) return false;
+      onedit();
+      return true;
+    },
+    delete: () => {
+      if (!detail.can_edit) return false;
+      ondelete();
+      return true;
+    },
+    yes: () => clickResponse('accepted'),
+    maybe: () => clickResponse('tentative'),
+    no: () => clickResponse('declined'),
+    join: () => {
+      if (!joinUrl) return false;
+      void openConference(detail.id);
+      return true;
+    },
+  };
+
+  /** An open event owns these bare keys. Focused controls keep Enter's native
+   * meaning — a focused Join link joins once, an RSVP button answers, and a
+   * copy field copies — while Enter on the panel itself joins immediately. */
+  function onPopoverKey(e: KeyboardEvent) {
+    onCopyKey(e);
+    if (e.defaultPrevented || e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return;
+
+    const key = e.key.toLowerCase();
+    const hit = EVENT_SHORTCUT_LIST.find((s) => s.key === key);
+    if (!hit) return;
+
+    if (hit.id === 'join') {
+      const target = e.target as Element | null;
+      if (target && target !== panelEl
+          && target.closest('a[href], button, input, select, textarea, [contenteditable="true"]')) {
+        return;
+      }
+    }
+
+    if (EVENT_SHORTCUT_ACTIONS[hit.id]()) e.preventDefault();
+  }
 </script>
 
-<svelte:window onkeydown={onCopyKey} />
+<svelte:window onkeydown={onPopoverKey} />
 
 <!-- A sibling of `.pop`, not a wrapper around it, so a click inside the
      panel — the guest list included — never reaches this button. -->
@@ -466,13 +521,13 @@
       </div>
     {/if}
     <div class="rsvp">
-      <button class:chosen={shown === 'accepted'} disabled={busy.size > 0 || pending !== null} onclick={(e) => ask('accepted', e)}
+      <button data-event-response="accepted" class:chosen={shown === 'accepted'} disabled={busy.size > 0 || pending !== null} onclick={(e) => ask('accepted', e)}
         >Yes</button
       >
-      <button class:chosen={shown === 'tentative'} disabled={busy.size > 0 || pending !== null} onclick={(e) => ask('tentative', e)}
+      <button data-event-response="tentative" class:chosen={shown === 'tentative'} disabled={busy.size > 0 || pending !== null} onclick={(e) => ask('tentative', e)}
         >Maybe</button
       >
-      <button class:chosen={shown === 'declined'} disabled={busy.size > 0 || pending !== null} onclick={(e) => ask('declined', e)}
+      <button data-event-response="declined" class:chosen={shown === 'declined'} disabled={busy.size > 0 || pending !== null} onclick={(e) => ask('declined', e)}
         >No</button
       >
     </div>

--- a/ui/src/lib/EventPopover.svelte
+++ b/ui/src/lib/EventPopover.svelte
@@ -66,8 +66,9 @@
      *  by clicking this: the caller owns the confirmation, which has three
      *  scopes, a guest count and no undo behind it. */
     ondelete: () => void;
-    /** Ctrl+C (⌘C) landed while this popover was open: the caller should
-     *  remember this occurrence as what Ctrl+V will paste. Living here rather
+    /** Ctrl+C (⌘C) landed on the popover itself rather than one of its
+     *  focusable copy fields: the caller should remember this occurrence as
+     *  what Ctrl+V will paste. Living here rather
      *  than in `App`'s key handler because *here* is the only place that
      *  knows a popover is open at all for Day and Week — `WeekGrid` owns that
      *  popover end-to-end, and `App` never sees its occurrence. One listener
@@ -130,6 +131,9 @@
     detail.is_all_day
       ? dayOfDate(occurrenceDate(detail.start_date, detail.start_ms, occurrenceStartMs))
       : dayOfInstant(occurrenceStartMs),
+  );
+  const whenLine = $derived(
+    detail.is_all_day ? day : `${day} · ${hhmm(occurrenceStartMs)}–${hhmm(occurrenceEndMs)}`,
   );
 
   // A neutral default so `.pop` renders (and so `offsetWidth`/`offsetHeight`
@@ -317,21 +321,29 @@
    *  ordinary sense — pasteable into a chat as text. The same formatters the
    *  panel renders with, so the text says what the screen says. */
   const clipboardLine = () => {
-    const when = detail.is_all_day ? day : `${day} ${hhmm(occurrenceStartMs)}–${hhmm(occurrenceEndMs)}`;
-    return [detail.title ?? '(no title)', when, detail.location ?? ''].filter(Boolean).join('\n');
+    return [detail.title ?? '(no title)', whenLine, detail.location ?? ''].filter(Boolean).join('\n');
   };
 
-  // Ctrl+C — ⌘C on a Mac — copies the event this popover is about. On
-  // `window` for the same reason Escape is, and with one yield: a real text
-  // selection in the panel (an address, a line of the description) keeps
-  // native copy, because taking the chord away from selected text would break
-  // the older meaning of the key to serve the newer one. Shift and Alt
-  // variants pass through untouched — Ctrl+Shift+C is a devtools chord in the
-  // webview this ships in.
+  function copyField(value: string, label: string) {
+    try { navigator.clipboard?.writeText(value).catch(() => {}); } catch { /* no clipboard here */ }
+    note = { text: `Copied ${label}`, kind: 'info' };
+  }
+
+  // Ctrl+C — ⌘C on a Mac — copies the focused field when it has one, otherwise
+  // the event this popover is about. On `window` for the same reason Escape
+  // is, and with one yield: a real text selection in the panel keeps native
+  // copy, because taking the chord away from selected text would break the
+  // older meaning of the key to serve the newer one. Shift and Alt variants
+  // pass through untouched — Ctrl+Shift+C is a devtools chord in the webview.
   function onCopyKey(e: KeyboardEvent) {
     if (e.key.toLowerCase() !== 'c' || !(e.ctrlKey || e.metaKey) || e.altKey || e.shiftKey) return;
     if (document.getSelection()?.toString()) return;
     e.preventDefault();
+    const field = (e.target as HTMLElement | null)?.closest<HTMLElement>('[data-copy-value]');
+    if (field) {
+      copyField(field.dataset.copyValue ?? '', field.dataset.copyLabel ?? 'field');
+      return;
+    }
     // Fire-and-forget: the buffer `oncopy` fills is what paste reads, and a
     // webview denying clipboard access must not turn the copy into an error.
     try { navigator.clipboard?.writeText(clipboardLine()).catch(() => {}); } catch { /* no clipboard here */ }
@@ -359,23 +371,36 @@
   aria-label={detail.title ?? '(no title)'}
   style="top:{pos.top}px; left:{pos.left}px"
 >
-  <h2>{detail.title ?? '(no title)'}</h2>
-  <p class="when">
-    {day}{#if !detail.is_all_day}
-      &nbsp;· {hhmm(occurrenceStartMs)}–{hhmm(occurrenceEndMs)}{/if}
-  </p>
-  {#if cadence}<p class="cadence">{cadence}</p>{/if}
+  <h2 aria-label={detail.title ?? '(no title)'}><button type="button" class="copyfield"
+      aria-label="Copy title" data-copy-label="title"
+      data-copy-value={detail.title ?? '(no title)'}
+      onclick={() => copyField(detail.title ?? '(no title)', 'title')}
+      >{detail.title ?? '(no title)'}</button></h2>
+  <p class="when"><button type="button" class="copyfield" aria-label="Copy date and time"
+     data-copy-label="date and time"
+     data-copy-value={whenLine} onclick={() => copyField(whenLine, 'date and time')}
+     >{whenLine}</button></p>
+  {#if cadence}<p class="cadence"><button type="button" class="copyfield" aria-label="Copy repeat schedule"
+                       data-copy-label="repeat schedule" data-copy-value={cadence}
+                       onclick={() => copyField(cadence!, 'repeat schedule')}
+                       >{cadence}</button></p>{/if}
 
   {#if segments.length}
-    <p class="desc">
-      {#each segments as s}
-        {#if s.kind === 'link'}<a href={s.value} target="_blank" rel="noopener noreferrer">{s.value}</a
-          >{:else}{s.value}{/if}
-      {/each}
-    </p>
+    <div class="desc">
+      <button type="button" class="copydesc" data-copy-label="description"
+              data-copy-value={detail.description ?? ''}
+              onclick={() => copyField(detail.description ?? '', 'description')}>Copy</button>
+      <p>{#each segments as s}{#if s.kind === 'link'}<a
+              href={s.value} target="_blank" rel="noopener noreferrer"
+              data-copy-label="link" data-copy-value={s.value}>{s.value}</a
+          >{:else}{s.value}{/if}{/each}</p>
+    </div>
   {/if}
 
-  {#if locationShown}<p class="loc">{locationShown}</p>{/if}
+  {#if locationShown}<p class="loc"><button type="button" class="copyfield" aria-label="Copy location"
+                            data-copy-label="location" data-copy-value={locationShown}
+                            onclick={() => copyField(locationShown!, 'location')}
+                            >{locationShown}</button></p>{/if}
   {#if joinUrl}
     <!-- The `href` stays for what an anchor gives away free — copy-link,
          middle-click, the status-bar preview — but a plain left click is
@@ -384,6 +409,7 @@
          crashes it (issue #1, `browser::open_external`). The backend
          re-derives the URL from its store rather than trusting this one. -->
     <a class="conf" href={joinUrl} target="_blank" rel="noopener noreferrer"
+       data-copy-label="meeting link" data-copy-value={joinUrl}
        onclick={(e) => { e.preventDefault(); void openConference(detail.id); }}>Join video call</a>
   {/if}
   <!-- Suppressed for the addresses Google mints for shared calendars and
@@ -391,7 +417,10 @@
        than nothing, and there is no name to fall back to — `EventDetail`
        carries no `organizer.displayName`. See `organizer.ts`. -->
   {#if detail.organizer_email && !isMachineAddress(detail.organizer_email)}
-    <p class="organizer">Organized by {detail.organizer_email}</p>
+    <p class="organizer"><button type="button" class="copyfield" aria-label="Copy organizer email"
+       data-copy-label="organizer email" data-copy-value={detail.organizer_email}
+       onclick={() => copyField(detail.organizer_email!, 'organizer email')}
+       >Organized by {detail.organizer_email}</button></p>
   {/if}
 
   {#if shownAttendees.length}
@@ -400,8 +429,15 @@
         <!-- `title` says the word on hover: a tilde in a 13px ring was read as
              "no idea what that is" (Omarchy, 2026-08-10), and the sighted had
              no equivalent of `.sr` to fall back on. -->
-        <div
-          class="guest {a.response_status}"
+        <button
+          type="button"
+          class="guest copyfield {a.response_status}"
+          data-copy-label="guest email"
+          data-copy-value={a.email}
+          onclick={() => copyField(a.email, 'guest email')}
+          aria-label="Copy guest email for {a.display_name ?? a.email}. {a.response_status === 'needsAction'
+            ? 'Awaiting response'
+            : STATUS_WORD[a.response_status] ?? 'Awaiting response'}"
           title={STATUS_WORD[a.response_status] ?? STATUS_WORD.needsAction}
         >
           <!-- The glyph carries the status, not the colour. This app takes its
@@ -412,7 +448,7 @@
           <i class="mark" aria-hidden="true">{MARK[a.response_status] ?? MARK.needsAction}</i>
           <span class="who">{a.display_name ?? a.email}{a.is_self ? ' (you)' : ''}</span>
           <span class="sr">{STATUS_WORD[a.response_status] ?? STATUS_WORD.needsAction}</span>
-        </div>
+        </button>
       {/each}
     </div>
   {/if}
@@ -501,12 +537,23 @@
      itself operable — a ring around the whole popover would only be noise.
      The controls inside keep theirs. */
   .pop:focus { outline: none; }
+  .copyfield { appearance: none; -webkit-appearance: none; font: inherit; color: inherit;
+               background: none; border: 0; padding: 0; margin: 0; text-align: left;
+               cursor: copy; }
+  .copyfield:focus-visible, .copydesc:focus-visible {
+    outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 3px;
+  }
 
   h2 { font-size: 14px; font-weight: 600; margin: 0 0 4px; letter-spacing: -.01em; }
   .when { color: var(--muted); font-size: 11px; margin: 0 0 8px; }
 
-  .desc { white-space: pre-wrap; word-break: break-word; line-height: 1.5;
-          margin: 0 0 10px; }
+  .desc { position: relative; white-space: pre-wrap; word-break: break-word; line-height: 1.5;
+          margin: 0 0 10px; padding-right: 38px; }
+  .desc p { margin: 0; }
+  .copydesc { appearance: none; -webkit-appearance: none; position: absolute; top: 0; right: 0;
+              font: inherit; font-size: 9.5px; color: var(--muted); cursor: copy;
+              border: 0; border-radius: 3px; background: none; padding: 1px 3px; }
+  .copydesc:hover { color: var(--text); }
   .desc a { color: var(--accent); }
 
   .loc, .organizer { color: var(--muted); font-size: 11px; margin: 0 0 4px; }

--- a/ui/src/lib/Filmstrip.svelte
+++ b/ui/src/lib/Filmstrip.svelte
@@ -8,8 +8,9 @@
   import WeatherGlyph from './WeatherGlyph.svelte';
   import { dateKey, type DayWeather } from './weather';
   import type { ListDay } from './filmstrip';
+  import { cursorNamesEvent, type KeyboardCursor } from './keyboardnav';
 
-  let { days, weather = null, revealNowRequest = 0, onopen }: {
+  let { days, weather = null, revealNowRequest = 0, keyboardCursor = null, onopen }: {
     /** Already grouped, ordered and emptied of blank days by `filmstrip.ts`.
      *  This component draws a list; it does not decide what is in one. */
     days: ListDay[];
@@ -18,6 +19,7 @@
     weather?: Map<string, DayWeather> | null;
     /** The explicit Today request counter shared with the clock grid. */
     revealNowRequest?: number;
+    keyboardCursor?: KeyboardCursor | null;
     /** Same contract as `MonthGrid`'s and `BigYearRibbon`'s: the clicked event
      *  plus an anchor rect, handed straight up to `App.openGridEvent` and so to
      *  `openOccurrence`.
@@ -126,7 +128,9 @@
   {:else}
     {#each days as d (d.startMs)}
       {@const marker = markerIndex(d, nowMs)}
-      <section class="sday" data-start-ms={d.startMs}>
+      <section class="sday" class:keyboard={keyboardCursor?.dayStartMs === d.startMs}
+               data-start-ms={d.startMs}
+               data-kbd-selected-day={keyboardCursor?.dayStartMs === d.startMs ? '' : undefined}>
         <h2 class="sdate">
           {dateLabel(d.startMs)}
           {#if weather?.get(dateKey(d.startMs))}
@@ -166,6 +170,11 @@
               <button
                 class="srow"
                 class:allday={ev.is_all_day}
+                class:keyboard={keyboardCursor
+                  ? cursorNamesEvent(keyboardCursor, d.startMs, ev)
+                  : false}
+                data-kbd-selected-event={keyboardCursor
+                  && cursorNamesEvent(keyboardCursor, d.startMs, ev) ? '' : undefined}
                 onclick={(e) => open(ev, e)}
               >
                 <em class="when">
@@ -234,6 +243,8 @@
 
   .sday { border-top: 1px solid var(--hairline); padding: 6px 0 8px; }
   .sday:first-child { border-top: 0; }
+  .sday.keyboard { box-shadow: inset 2px 0 0 color-mix(in srgb, var(--accent) 55%, transparent);
+                   padding-left: 6px; }
 
   /* Sticky, so the day a row belongs to is still named after scrolling past its
      heading — the one thing a list loses that a grid gives for free. */
@@ -276,6 +287,7 @@
              on the row moves. */
           box-shadow: inset 2px 0 0 0 var(--cal); background: none;
           color: var(--text); border-radius: 4px; padding: 4px 8px 4px 10px; }
+  .srow.keyboard { outline: 2px solid var(--accent); outline-offset: 1px; }
 
   /* Tabular figures so the times form a column the eye can run down, and a
      fixed width so a title never starts at a different x from the row above

--- a/ui/src/lib/MonthGrid.svelte
+++ b/ui/src/lib/MonthGrid.svelte
@@ -4,9 +4,12 @@
   import { weekStartDay } from './weekstartstore.svelte';
   import type { MonthPayload, UiEvent } from './api';
   import type { Rect } from './position';
+  import { cursorNamesEvent, type KeyboardCursor } from './keyboardnav';
+  import { MONTH_GRID_TIMED_LIMIT } from './filmstrip';
 
-  let { month, onopen, ondaypick, oncreate }: {
+  let { month, keyboardCursor = null, onopen, ondaypick, oncreate }: {
     month: MonthPayload;
+    keyboardCursor?: KeyboardCursor | null;
     /** Same contract as `WeekGrid`'s: an anchor rect plus the clicked event,
      *  handed straight to `EventPopover` via `placePopover`. */
     onopen: (event: UiEvent, rect: Rect) => void;
@@ -30,8 +33,8 @@
   const MAX_BAR_LANES = 3;
   // How many timed lines a cell shows before folding the rest into "+N more".
   // Matches `pack_lanes`'s own lane cap for bars — three is what a narrow
-  // cell has room for before a title stops being legible.
-  const MAX_LINES = 3;
+  // cell has room for before a title stops being legible. The value lives in
+  // `filmstrip.ts` because App's keyboard cursor must share this exact limit.
 
   // Written Monday-first and rotated, never rewritten per setting: one
   // spelling of the seven names, and `rotate` is tested on its own.
@@ -77,6 +80,14 @@
     const r = (e.currentTarget as HTMLElement).getBoundingClientRect();
     oncreate(dayStartMs, { top: r.top, left: r.left, width: r.width, height: r.height });
   }
+
+  function isBarSelected(lane: { start_col: number; end_col: number }, event: UiEvent,
+                         cells: { start_ms: number }[]): boolean {
+    if (!keyboardCursor) return false;
+    const column = cells.findIndex((cell) => cell.start_ms === keyboardCursor.dayStartMs);
+    return column >= lane.start_col && column <= lane.end_col
+      && cursorNamesEvent(keyboardCursor, keyboardCursor.dayStartMs, event);
+  }
 </script>
 
 <div class="head">
@@ -89,10 +100,13 @@
       <div class="bars">
         {#each row.bars as lane (`${lane.idx}:${lane.lane}`)}
           {@const ev = row.bar_events[lane.idx]}
+          {@const keyboardSelected = isBarSelected(lane, ev, row.cells)}
           <button
             class="bar"
             class:cl={lane.cont_left}
             class:cr={lane.cont_right}
+            class:keyboard={keyboardSelected}
+            data-kbd-selected-event={keyboardSelected ? '' : undefined}
             style="
               grid-row:{lane.lane + 1};
               grid-column:{lane.start_col + 1} / {lane.end_col + 2};
@@ -116,7 +130,9 @@
           <!-- `data-start-ms` on every view's day element, uniformly: it is
                how App's paste finds the day under the mouse. -->
           <div class="mcell" class:out={!cell.in_month} class:today={cell.start_ms === todayStart}
-               data-start-ms={cell.start_ms}>
+               class:keyboard={keyboardCursor?.dayStartMs === cell.start_ms}
+               data-start-ms={cell.start_ms}
+               data-kbd-selected-day={keyboardCursor?.dayStartMs === cell.start_ms ? '' : undefined}>
             <!-- Empty cell space, as a real control — same reasoning as
                  `WeekGrid`'s own `.newhere`, including the `tabindex="-1"`:
                  42 invisible tab stops per month would be noise, and `n`
@@ -130,16 +146,21 @@
             <button class="num" onclick={() => pickDay(cell.start_ms)}>
               {new Date(cell.start_ms).getDate()}
             </button>
-            {#each cell.timed.slice(0, MAX_LINES) as ev}
+            {#each cell.timed.slice(0, MONTH_GRID_TIMED_LIMIT) as ev}
               <button
                 class="timed"
+                class:keyboard={keyboardCursor
+                  ? cursorNamesEvent(keyboardCursor, cell.start_ms, ev)
+                  : false}
+                data-kbd-selected-event={keyboardCursor
+                  && cursorNamesEvent(keyboardCursor, cell.start_ms, ev) ? '' : undefined}
                 style="--cal:{ev.color}"
                 onclick={(e) => openEvent(ev, e)}
               ><i class="dot" style="background:{ev.color}"></i>{ev.title}</button>
             {/each}
-            {#if cell.timed.length > MAX_LINES}
+            {#if cell.timed.length > MONTH_GRID_TIMED_LIMIT}
               <button class="more" onclick={() => pickDay(cell.start_ms)}>
-                +{cell.timed.length - MAX_LINES} more
+                +{cell.timed.length - MONTH_GRID_TIMED_LIMIT} more
               </button>
             {/if}
           </div>
@@ -175,6 +196,7 @@
          color: color-mix(in srgb, var(--cal) 60%, var(--text)); }
   .bar.cl { border-top-left-radius: 0; border-bottom-left-radius: 0; border-left-style: dashed; }
   .bar.cr { border-top-right-radius: 0; border-bottom-right-radius: 0; }
+  .bar.keyboard { outline: 2px solid var(--accent); outline-offset: 1px; }
 
   /* Date + three timed lines + the cell's `+N more`, including their gaps and
      padding. A row with all-day lanes adds those above this budget instead of
@@ -201,6 +223,8 @@
 
   .mcell:first-child { border-left: 0; }
   .mcell.today { background: var(--today-tint); border-radius: 6px; }
+  .mcell.keyboard { box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 45%, transparent);
+                    border-radius: 6px; }
   .mcell.out .num { color: var(--muted); opacity: .6; }
   .mcell.out .timed { opacity: .55; }
 
@@ -218,6 +242,8 @@
            font-size: 10.5px; color: var(--text); white-space: nowrap; overflow: hidden;
            text-overflow: ellipsis; position: relative; z-index: 1; flex: none; }
   .dot { width: 6px; height: 6px; border-radius: 50%; flex: none; }
+  .timed.keyboard { border-radius: 3px;
+                    outline: 2px solid var(--accent); outline-offset: 1px; }
 
   .more { font: inherit; font-size: 10px; line-height: 1.2; color: var(--muted); opacity: .8;
           padding: 0; background: transparent; border: 0; text-align: left;

--- a/ui/src/lib/ShortcutSheet.svelte
+++ b/ui/src/lib/ShortcutSheet.svelte
@@ -1,7 +1,9 @@
 <!-- ui/src/lib/ShortcutSheet.svelte -->
 <script lang="ts">
   import { escapeCloses } from './dismiss.svelte';
-  import { CHORDS, groupedShortcuts, SHORTCUT_TEXT } from './shortcuts';
+  import {
+    CHORDS, EVENT_SHORTCUT_LIST, groupedShortcuts, SHORTCUT_TEXT,
+  } from './shortcuts';
 
   let { onclose }: { onclose: () => void } = $props();
 
@@ -24,7 +26,7 @@
 
   {#each groups as g (g.group)}
     <h3>{g.group}</h3>
-    <dl>
+    <dl data-shortcut-scope="calendar">
       {#each g.items as s (s.id)}
         <!-- `<kbd>` is the element for this and it is not decoration: a
              screen reader announces it as a key rather than reading the
@@ -53,6 +55,14 @@
       {/if}
     </dl>
   {/each}
+
+  <h3>Event details</h3>
+  <dl data-shortcut-scope="event">
+    {#each EVENT_SHORTCUT_LIST as s (s.id)}
+      <dt><kbd>{s.label}</kbd></dt>
+      <dd><span class="what">{s.text}</span></dd>
+    {/each}
+  </dl>
 
   <p class="foot">Escape closes this.</p>
 </div>

--- a/ui/src/lib/WeekGrid.svelte
+++ b/ui/src/lib/WeekGrid.svelte
@@ -15,8 +15,9 @@
   import {
     SNAP_MS, beganDrag, colsMoved, edgeAt, spanForMove, spanForResize, spanForSweep,
   } from './drag';
+  import { cursorNamesEvent, type KeyboardCursor } from './keyboardnav';
 
-  let { week, weather = null, formPreview = null, revealNowRequest = 0, oncreate, onedit, ondelete, oncopy, onmove, onresponded }: {
+  let { week, weather = null, formPreview = null, revealNowRequest = 0, keyboardCursor = null, oncreate, onedit, ondelete, oncopy, onmove, onresponded }: {
     week: WeekPayload;
     /** The forecast by ISO date (`weather.ts`), or null for none — off, not
      *  yet fetched, or failed all look the same here: a header with no sky,
@@ -29,6 +30,7 @@
     /** Incremented by App for every explicit Today action, including when the
      *  anchor already names today and therefore no payload navigation occurs. */
     revealNowRequest?: number;
+    keyboardCursor?: KeyboardCursor | null;
     /** A click on empty space in a day column, at the half hour it landed in,
      *  or a **sweep** across it, which names an `endMs` as well.
      *  `rect` is the anchor to put the form beside — the column at the height
@@ -837,7 +839,8 @@
     {/if}
   </div>
   {#each week.days as d}
-    <div class="head" class:today={d.start_ms === todayStart}>
+    <div class="head" class:today={d.start_ms === todayStart}
+         class:keyboard={keyboardCursor?.dayStartMs === d.start_ms}>
       <span>{dayName(d.start_ms)}</span>
       <span class="daterow">
         <b>{new Date(d.start_ms).getDate()}</b>
@@ -869,6 +872,8 @@
   events={week.all_day_events}
   overflow={week.overflow}
   columns={week.days.length}
+  dayStarts={week.days.map((day) => day.start_ms)}
+  {keyboardCursor}
   onopen={openPopover}
 />
 
@@ -889,7 +894,10 @@
   {#each effectiveDays as day}
     {@const isToday = day.start_ms === todayStart}
     {@const ghost = sweepStyle(day)}
-    <div class="col" class:today={isToday} data-start-ms={day.start_ms}>
+    <div class="col" class:today={isToday}
+         class:keyboard={keyboardCursor?.dayStartMs === day.start_ms}
+         data-start-ms={day.start_ms}
+         data-kbd-selected-day={keyboardCursor?.dayStartMs === day.start_ms ? '' : undefined}>
       <!-- Empty grid space, as a real control rather than a click handler on
            the column div: the role, the pointer target and the accessible name
            come with the element. First in the column so every block, rule and
@@ -954,6 +962,9 @@
           ongrab={(ev, e) => startDrag(ev, day, e)}
           preview={previewFor(day.events[p.idx])}
           liveSpan={liveSpanFor(day.events[p.idx])}
+          keyboardSelected={keyboardCursor
+            ? cursorNamesEvent(keyboardCursor, day.start_ms, day.events[p.idx])
+            : false}
         />
       {/each}
 
@@ -1045,6 +1056,7 @@
      golden holds it to that). The forecast hangs off the number's right
      via the absolute `.wx` below. */
   .daterow { display: block; position: relative; }
+  .head.keyboard:not(.today) b { color: var(--accent); font-weight: 650; }
 
   /* No column borders: the grid reads through alignment, not rules (spec §7.1). */
   /* 70px per hour (24 x 70 = 1680), up from 50 (2026-08-14): at 50 a
@@ -1056,6 +1068,8 @@
      column, so nothing else knows the number. */
   .col { position: relative; min-height: 1680px; }
   .col.today { background: var(--today-tint); border-radius: 6px; }
+  .col.keyboard { box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 45%, transparent);
+                  border-radius: 6px; }
 
   .gutter { position: relative; }
   /* 11.5px at .85, up from 10.5 at .7 (2026-08-26, by request twice over):

--- a/ui/src/lib/filmstrip.ts
+++ b/ui/src/lib/filmstrip.ts
@@ -32,12 +32,17 @@ import type { Lane, MonthPayload, UiEvent, WeekPayload } from './api';
 export const LISTABLE_VIEWS = ['day', 'week', 'month'] as const;
 export type ListableView = (typeof LISTABLE_VIEWS)[number];
 
+/** Month's timed-event reading budget. Shared with keyboard navigation so a
+ * cursor can never name a row the grid has already folded into `+N more`. */
+export const MONTH_GRID_TIMED_LIMIT = 3;
+
 export function listable(view: string): view is ListableView {
   return (LISTABLE_VIEWS as readonly string[]).includes(view);
 }
 
-/** One day of a list: the day it is, and every event on it in draw order.
- *  Only days that carry something are ever built — see `daysFromWeek`. */
+/** One day of a period: the day it is, and every event on it in draw order.
+ * `allDaysFrom*` retains blank days for keyboard navigation; `daysFrom*`
+ * removes them for the filmstrip's ordinary rendering. */
 export type ListDay = { startMs: number; events: UiEvent[] };
 
 /**
@@ -107,11 +112,14 @@ function rowsForDay(allDay: UiEvent[], timed: UiEvent[]): UiEvent[] {
  * that changes per view is one nobody can predict, and the gap in a week is
  * visible from the dates themselves.
  */
-export function daysFromWeek(week: WeekPayload): ListDay[] {
+export function allDaysFromWeek(week: WeekPayload): ListDay[] {
   const allDay = allDayByColumn(week.all_day, week.all_day_events, week.days.length);
   return week.days
-    .map((d, i) => ({ startMs: d.start_ms, events: rowsForDay(allDay[i], d.events) }))
-    .filter((d) => d.events.length > 0);
+    .map((d, i) => ({ startMs: d.start_ms, events: rowsForDay(allDay[i], d.events) }));
+}
+
+export function daysFromWeek(week: WeekPayload): ListDay[] {
+  return allDaysFromWeek(week).filter((d) => d.events.length > 0);
 }
 
 /**
@@ -126,14 +134,18 @@ export function daysFromWeek(week: WeekPayload): ListDay[] {
  * Each row is lane-packed independently by `assemble_month`, so a bar crossing
  * a row boundary is two segments and each row places its own half.
  */
-export function daysFromMonth(month: MonthPayload): ListDay[] {
+export function allDaysFromMonth(month: MonthPayload): ListDay[] {
   const out: ListDay[] = [];
   for (const row of month.rows) {
     const allDay = allDayByColumn(row.bars, row.bar_events, row.cells.length);
     row.cells.forEach((cell, i) => {
       const events = rowsForDay(allDay[i], cell.timed);
-      if (events.length > 0) out.push({ startMs: cell.start_ms, events });
+      out.push({ startMs: cell.start_ms, events });
     });
   }
   return out;
+}
+
+export function daysFromMonth(month: MonthPayload): ListDay[] {
+  return allDaysFromMonth(month).filter((d) => d.events.length > 0);
 }

--- a/ui/src/lib/filmstrip.ts
+++ b/ui/src/lib/filmstrip.ts
@@ -40,10 +40,12 @@ export function listable(view: string): view is ListableView {
   return (LISTABLE_VIEWS as readonly string[]).includes(view);
 }
 
-/** One day of a period: the day it is, and every event on it in draw order.
+/** One day of a period: its exact display-zone interval, and every event on it in draw order.
  * `allDaysFrom*` retains blank days for keyboard navigation; `daysFrom*`
- * removes them for the filmstrip's ordinary rendering. */
-export type ListDay = { startMs: number; events: UiEvent[] };
+ * removes them for the filmstrip's ordinary rendering. `endMs` is carried
+ * from the backend rather than guessed as 24 hours so navigation still knows
+ * which day contains the current instant across DST and differing zones. */
+export type ListDay = { startMs: number; endMs: number; events: UiEvent[] };
 
 /**
  * The all-day events of one lane-packed row, grouped by the column they cover.
@@ -115,7 +117,11 @@ function rowsForDay(allDay: UiEvent[], timed: UiEvent[]): UiEvent[] {
 export function allDaysFromWeek(week: WeekPayload): ListDay[] {
   const allDay = allDayByColumn(week.all_day, week.all_day_events, week.days.length);
   return week.days
-    .map((d, i) => ({ startMs: d.start_ms, events: rowsForDay(allDay[i], d.events) }));
+    .map((d, i) => ({
+      startMs: d.start_ms,
+      endMs: d.end_ms,
+      events: rowsForDay(allDay[i], d.events),
+    }));
 }
 
 export function daysFromWeek(week: WeekPayload): ListDay[] {
@@ -140,7 +146,7 @@ export function allDaysFromMonth(month: MonthPayload): ListDay[] {
     const allDay = allDayByColumn(row.bars, row.bar_events, row.cells.length);
     row.cells.forEach((cell, i) => {
       const events = rowsForDay(allDay[i], cell.timed);
-      out.push({ startMs: cell.start_ms, events });
+      out.push({ startMs: cell.start_ms, endMs: cell.end_ms, events });
     });
   }
   return out;

--- a/ui/src/lib/keyboardnav.ts
+++ b/ui/src/lib/keyboardnav.ts
@@ -18,6 +18,11 @@ export type CursorMove = {
   overflow: -1 | 1 | null;
 };
 
+export type NavigationClock = {
+  nowMs: number;
+  todayStartMs: number;
+};
+
 export function dayCursor(dayStartMs: number): KeyboardCursor {
   return { dayStartMs, eventId: null, eventStartMs: null };
 }
@@ -49,26 +54,60 @@ export function moveDay(days: ListDay[], cursor: KeyboardCursor, dir: -1 | 1): C
 }
 
 /**
- * Move through events in reading order. From a selected day, `j` takes its
- * first event and `k` its last. Crossing an edge skips empty days and lands on
- * the first/last event in the next non-empty day.
+ * Move through events in reading order. From a selected day other than today,
+ * `j` takes its first event and `k` its last. Today is time-aware when a
+ * clock is supplied: `j` starts with the first event that has not ended and
+ * `k` with the last event that has begun. If there is no such event today,
+ * traversal continues into the adjacent day instead of replaying elapsed or
+ * not-yet-started events. Once an event is selected, movement is strictly
+ * adjacent and the clock no longer participates.
  */
-export function moveEvent(days: ListDay[], cursor: KeyboardCursor, dir: -1 | 1): CursorMove {
+export function moveEvent(
+  days: ListDay[],
+  cursor: KeyboardCursor,
+  dir: -1 | 1,
+  clock: NavigationClock | null = null,
+): CursorMove {
   const dayIndex = days.findIndex((d) => d.startMs === cursor.dayStartMs);
   if (dayIndex === -1) return { cursor, overflow: dir };
 
   const day = days[dayIndex];
-  const eventIndex = cursor.eventId === null || cursor.eventStartMs === null
+  const dayOnly = cursor.eventId === null || cursor.eventStartMs === null;
+  const eventIndex = dayOnly
     ? -1
     : day.events.findIndex((event) => cursorNamesEvent(cursor, day.startMs, event));
 
-  if (eventIndex === -1 && day.events.length > 0) {
+  if (dayOnly && day.events.length > 0) {
+    let event: UiEvent | undefined;
+    // The caller supplies the day boundary as well as the instant. Deriving it
+    // here would use whichever timezone this pure function happened to run
+    // in, which need not be the calendar/browser zone that named `startMs`.
+    if (clock && day.startMs === clock.todayStartMs) {
+      if (dir === 1) {
+        event = day.events.find((candidate) => candidate.end_ms > clock.nowMs);
+      } else {
+        for (let i = day.events.length - 1; i >= 0; i -= 1) {
+          if (day.events[i].start_ms <= clock.nowMs) {
+            event = day.events[i];
+            break;
+          }
+        }
+      }
+    } else {
+      event = dir === 1 ? day.events[0] : day.events[day.events.length - 1];
+    }
+    if (event) return { cursor: eventCursor(day, event), overflow: null };
+  } else if (eventIndex === -1 && day.events.length > 0) {
+    // A stale event identity is treated as its day selection. It is not the
+    // initial-today path above, so a clock tick must not skip visible rows.
     const event = dir === 1 ? day.events[0] : day.events[day.events.length - 1];
     return { cursor: eventCursor(day, event), overflow: null };
   }
 
-  const nextInDay = day.events[eventIndex + dir];
-  if (nextInDay) return { cursor: eventCursor(day, nextInDay), overflow: null };
+  if (!dayOnly) {
+    const nextInDay = day.events[eventIndex + dir];
+    if (nextInDay) return { cursor: eventCursor(day, nextInDay), overflow: null };
+  }
 
   for (let i = dayIndex + dir; i >= 0 && i < days.length; i += dir) {
     if (days[i].events.length === 0) continue;

--- a/ui/src/lib/keyboardnav.ts
+++ b/ui/src/lib/keyboardnav.ts
@@ -20,7 +20,6 @@ export type CursorMove = {
 
 export type NavigationClock = {
   nowMs: number;
-  todayStartMs: number;
 };
 
 export function dayCursor(dayStartMs: number): KeyboardCursor {
@@ -79,10 +78,11 @@ export function moveEvent(
 
   if (dayOnly && day.events.length > 0) {
     let event: UiEvent | undefined;
-    // The caller supplies the day boundary as well as the instant. Deriving it
-    // here would use whichever timezone this pure function happened to run
-    // in, which need not be the calendar/browser zone that named `startMs`.
-    if (clock && day.startMs === clock.todayStartMs) {
+    // The payload's own interval names today. Comparing `startMs` with a
+    // browser-derived midnight was subtly wrong whenever the display calendar
+    // and browser/system zones differed; adding 24 hours would also be wrong
+    // on a DST boundary. The backend already supplied both true boundaries.
+    if (clock && clock.nowMs >= day.startMs && clock.nowMs < day.endMs) {
       if (dir === 1) {
         event = day.events.find((candidate) => candidate.end_ms > clock.nowMs);
       } else {

--- a/ui/src/lib/keyboardnav.ts
+++ b/ui/src/lib/keyboardnav.ts
@@ -55,11 +55,14 @@ export function moveDay(days: ListDay[], cursor: KeyboardCursor, dir: -1 | 1): C
 /**
  * Move through events in reading order. From a selected day other than today,
  * `j` takes its first event and `k` its last. Today is time-aware when a
- * clock is supplied: `j` starts with the first event that has not ended and
- * `k` with the last event that has begun. If there is no such event today,
- * traversal continues into the adjacent day instead of replaying elapsed or
- * not-yet-started events. Once an event is selected, movement is strictly
- * adjacent and the clock no longer participates.
+ * clock is supplied: `j` starts with the first timed event that has not ended
+ * and `k` with the last timed event that has begun. All-day rows have no useful
+ * position relative to the current clock, so this initial-today check ignores
+ * them. If there is no eligible timed event today, traversal continues into
+ * the adjacent day instead of replaying elapsed events or selecting an all-day
+ * row merely because its stored midnight-to-midnight span contains `now`.
+ * Once an event is selected, movement is strictly adjacent—including all-day
+ * rows—and the clock no longer participates.
  */
 export function moveEvent(
   days: ListDay[],
@@ -84,10 +87,12 @@ export function moveEvent(
     // on a DST boundary. The backend already supplied both true boundaries.
     if (clock && clock.nowMs >= day.startMs && clock.nowMs < day.endMs) {
       if (dir === 1) {
-        event = day.events.find((candidate) => candidate.end_ms > clock.nowMs);
+        event = day.events.find(
+          (candidate) => !candidate.is_all_day && candidate.end_ms > clock.nowMs,
+        );
       } else {
         for (let i = day.events.length - 1; i >= 0; i -= 1) {
-          if (day.events[i].start_ms <= clock.nowMs) {
+          if (!day.events[i].is_all_day && day.events[i].start_ms <= clock.nowMs) {
             event = day.events[i];
             break;
           }

--- a/ui/src/lib/keyboardnav.ts
+++ b/ui/src/lib/keyboardnav.ts
@@ -1,0 +1,79 @@
+import type { UiEvent } from './api';
+import type { ListDay } from './filmstrip';
+
+/** The occurrence currently named by the calendar keyboard. `eventId` and
+ * `eventStartMs` are null together when the day itself, rather than one of its
+ * events, is selected. The day stays separate because a multi-day all-day
+ * occurrence can appear in more than one column. */
+export type KeyboardCursor = {
+  dayStartMs: number;
+  eventId: number | null;
+  eventStartMs: number | null;
+};
+
+export type CursorMove = {
+  cursor: KeyboardCursor;
+  /** The payload ended before the requested destination. App uses this to
+   * fetch the adjacent period; pure navigation never guesses its size. */
+  overflow: -1 | 1 | null;
+};
+
+export function dayCursor(dayStartMs: number): KeyboardCursor {
+  return { dayStartMs, eventId: null, eventStartMs: null };
+}
+
+export function cursorNamesEvent(cursor: KeyboardCursor, dayStartMs: number, event: UiEvent): boolean {
+  return cursor.dayStartMs === dayStartMs
+    && cursor.eventId === event.id
+    && cursor.eventStartMs === event.start_ms;
+}
+
+export function eventAtCursor(days: ListDay[], cursor: KeyboardCursor): UiEvent | null {
+  const day = days.find((d) => d.startMs === cursor.dayStartMs);
+  if (!day || cursor.eventId === null || cursor.eventStartMs === null) return null;
+  return day.events.find((event) => cursorNamesEvent(cursor, day.startMs, event)) ?? null;
+}
+
+function eventCursor(day: ListDay, event: UiEvent): KeyboardCursor {
+  return { dayStartMs: day.startMs, eventId: event.id, eventStartMs: event.start_ms };
+}
+
+/** Move to the adjacent visible day and leave its event list unselected. */
+export function moveDay(days: ListDay[], cursor: KeyboardCursor, dir: -1 | 1): CursorMove {
+  const i = days.findIndex((d) => d.startMs === cursor.dayStartMs);
+  if (i === -1) return { cursor, overflow: dir };
+  const next = days[i + dir];
+  return next
+    ? { cursor: dayCursor(next.startMs), overflow: null }
+    : { cursor, overflow: dir };
+}
+
+/**
+ * Move through events in reading order. From a selected day, `j` takes its
+ * first event and `k` its last. Crossing an edge skips empty days and lands on
+ * the first/last event in the next non-empty day.
+ */
+export function moveEvent(days: ListDay[], cursor: KeyboardCursor, dir: -1 | 1): CursorMove {
+  const dayIndex = days.findIndex((d) => d.startMs === cursor.dayStartMs);
+  if (dayIndex === -1) return { cursor, overflow: dir };
+
+  const day = days[dayIndex];
+  const eventIndex = cursor.eventId === null || cursor.eventStartMs === null
+    ? -1
+    : day.events.findIndex((event) => cursorNamesEvent(cursor, day.startMs, event));
+
+  if (eventIndex === -1 && day.events.length > 0) {
+    const event = dir === 1 ? day.events[0] : day.events[day.events.length - 1];
+    return { cursor: eventCursor(day, event), overflow: null };
+  }
+
+  const nextInDay = day.events[eventIndex + dir];
+  if (nextInDay) return { cursor: eventCursor(day, nextInDay), overflow: null };
+
+  for (let i = dayIndex + dir; i >= 0 && i < days.length; i += dir) {
+    if (days[i].events.length === 0) continue;
+    const event = dir === 1 ? days[i].events[0] : days[i].events[days[i].events.length - 1];
+    return { cursor: eventCursor(days[i], event), overflow: null };
+  }
+  return { cursor, overflow: dir };
+}

--- a/ui/src/lib/shortcuts.ts
+++ b/ui/src/lib/shortcuts.ts
@@ -73,6 +73,8 @@ export const SHORTCUTS = [
 
   { id: 'openSelected', key: 'o', aliases: ['enter'], label: 'o / Enter',
     group: 'Doing things', consumes: true },
+  { id: 'deleteSelected', key: 'backspace', label: 'Backspace',
+    group: 'Doing things', consumes: true },
   { id: 'create',   key: 'n', label: 'n', group: 'Doing things', consumes: true },
   { id: 'quickCreate', key: 'q', label: 'q', group: 'Doing things', consumes: true },
   { id: 'list',     key: 'f', label: 'f', group: 'Doing things' },
@@ -110,6 +112,7 @@ export const SHORTCUT_TEXT: Record<ShortcutId, string> = {
   search: 'Search',
   quickCreate: 'Quick add from natural language',
   openSelected: 'Open the selected event',
+  deleteSelected: 'Delete the selected event (asks first)',
   create: 'New event',
   list: 'Switch between the grid and the list',
   help: 'This list',
@@ -153,13 +156,15 @@ export const CHORDS: { label: string; text: string; hint?: string }[] = [
 export type EventShortcut = {
   id: string;
   key: string;
+  aliases?: readonly string[];
   label: string;
   text: string;
 };
 
 export const EVENT_SHORTCUTS = [
   { id: 'edit',   key: 'e',     label: 'e',     text: 'Edit event' },
-  { id: 'delete', key: 'd',     label: 'd',     text: 'Delete event' },
+  { id: 'delete', key: 'd', aliases: ['backspace'], label: 'd / Backspace',
+    text: 'Delete event (asks first)' },
   { id: 'yes',    key: 'y',     label: 'y',     text: 'RSVP yes' },
   { id: 'maybe',  key: 'm',     label: 'm',     text: 'RSVP maybe' },
   { id: 'no',     key: 'n',     label: 'n',     text: 'RSVP no' },

--- a/ui/src/lib/shortcuts.ts
+++ b/ui/src/lib/shortcuts.ts
@@ -43,9 +43,9 @@ export type Shortcut = {
    *  than in a second map beside it — that map was `KEY_VIEW`, and a table
    *  that lists a key without saying what it does is half the drift back. */
   view?: View;
-  /** Whether the handler must consume the keystroke. `/` and `q` protect the
-   * fields they mount and focus in WebKitGTK; open protects its calendar
-   * surface. */
+  /** Whether the handler must consume the keystroke. `/`, `n`, and `q`
+   * protect the fields they mount and focus in WebKitGTK; open protects its
+   * calendar surface. */
   consumes?: true;
 };
 
@@ -73,7 +73,7 @@ export const SHORTCUTS = [
 
   { id: 'openSelected', key: 'o', aliases: ['enter'], label: 'o / Enter',
     group: 'Doing things', consumes: true },
-  { id: 'create',   key: 'n', label: 'n', group: 'Doing things' },
+  { id: 'create',   key: 'n', label: 'n', group: 'Doing things', consumes: true },
   { id: 'quickCreate', key: 'q', label: 'q', group: 'Doing things', consumes: true },
   { id: 'list',     key: 'f', label: 'f', group: 'Doing things' },
   { id: 'help',     key: '?', label: '?', group: 'Doing things' },

--- a/ui/src/lib/shortcuts.ts
+++ b/ui/src/lib/shortcuts.ts
@@ -28,6 +28,9 @@ export type Shortcut = {
    *  is what makes `H` step like `h` (the old `switch` did the same), and it
    *  leaves digits and punctuation alone: `'?'.toLowerCase()` is `'?'`. */
   key: string;
+  /** Other `KeyboardEvent.key` spellings for the same action. Kept off the
+   * printed label so `Enter` can share `o` without becoming a duplicate row. */
+  aliases?: readonly string[];
   /** What the sheet prints in the key column. Usually the key itself; spelled
    *  out where the character is not what you press (`⇧/` would be a lie about
    *  a layout we do not know). */
@@ -41,7 +44,8 @@ export type Shortcut = {
    *  that lists a key without saying what it does is half the drift back. */
   view?: View;
   /** Whether the handler must consume the keystroke. `/` and `q` protect the
-   * fields they mount and focus in WebKitGTK. */
+   * fields they mount and focus in WebKitGTK; open protects its calendar
+   * surface. */
   consumes?: true;
 };
 
@@ -56,9 +60,19 @@ export const SHORTCUTS = [
     hint: 'a day, a week, a month — whatever the view shows' },
   { id: 'next',     key: 'l', label: 'l', group: 'Getting around',
     hint: 'a day, a week, a month — whatever the view shows' },
+  { id: 'prevDay',  key: 'b', label: 'b', group: 'Getting around',
+    hint: 'select the previous day' },
+  { id: 'nextDay',  key: 'w', label: 'w', group: 'Getting around',
+    hint: 'select the next day' },
+  { id: 'prevEvent', key: 'k', label: 'k', group: 'Getting around',
+    hint: 'up, then into the previous day' },
+  { id: 'nextEvent', key: 'j', label: 'j', group: 'Getting around',
+    hint: 'down, then into the next day' },
   { id: 'today',    key: 't', label: 't', group: 'Getting around' },
   { id: 'search',   key: '/', label: '/', group: 'Getting around', consumes: true },
 
+  { id: 'openSelected', key: 'o', aliases: ['enter'], label: 'o / Enter',
+    group: 'Doing things', consumes: true },
   { id: 'create',   key: 'n', label: 'n', group: 'Doing things' },
   { id: 'quickCreate', key: 'q', label: 'q', group: 'Doing things', consumes: true },
   { id: 'list',     key: 'f', label: 'f', group: 'Doing things' },
@@ -88,9 +102,14 @@ export const SHORTCUT_TEXT: Record<ShortcutId, string> = {
   bigyear: 'Big Year',
   prev: 'Back one step',
   next: 'Forward one step',
+  prevDay: 'Previous day',
+  nextDay: 'Next day',
+  prevEvent: 'Previous event',
+  nextEvent: 'Next event',
   today: 'Back to today',
   search: 'Search',
   quickCreate: 'Quick add from natural language',
+  openSelected: 'Open the selected event',
   create: 'New event',
   list: 'Switch between the grid and the list',
   help: 'This list',

--- a/ui/src/lib/shortcuts.ts
+++ b/ui/src/lib/shortcuts.ts
@@ -144,6 +144,32 @@ export const CHORDS: { label: string; text: string; hint?: string }[] = [
     hint: 'opens the form on the day you are looking at, to fine-tune first' },
 ];
 
+/** Bare keys that belong to an open event rather than to the calendar.
+ *
+ * Kept out of `SHORTCUTS` because `App` deliberately ignores every key whose
+ * target is inside a dialog. `EventPopover` dispatches this table itself, and
+ * the shortcut sheet renders these same rows, preserving the binding-and-docs
+ * invariant without making `n` both "new event" and "RSVP no" globally. */
+export type EventShortcut = {
+  id: string;
+  key: string;
+  label: string;
+  text: string;
+};
+
+export const EVENT_SHORTCUTS = [
+  { id: 'edit',   key: 'e',     label: 'e',     text: 'Edit event' },
+  { id: 'delete', key: 'd',     label: 'd',     text: 'Delete event' },
+  { id: 'yes',    key: 'y',     label: 'y',     text: 'RSVP yes' },
+  { id: 'maybe',  key: 'm',     label: 'm',     text: 'RSVP maybe' },
+  { id: 'no',     key: 'n',     label: 'n',     text: 'RSVP no' },
+  { id: 'join',   key: 'enter', label: 'Enter', text: 'Join meeting' },
+] as const satisfies readonly EventShortcut[];
+
+export type EventShortcutId = (typeof EVENT_SHORTCUTS)[number]['id'];
+export const EVENT_SHORTCUT_LIST: readonly (EventShortcut & { id: EventShortcutId })[] =
+  EVENT_SHORTCUTS;
+
 /** The table in the order the sheet draws it. A group with no shortcuts is
  *  dropped rather than drawn empty, so `SHORTCUT_GROUPS` can name a heading
  *  before anything is filed under it. */

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -4,7 +4,9 @@
 // stubbed IPC layer (tests/harness/tauri.ts).
 
 import { test, expect, type Page } from '@playwright/test';
-import { CHORDS, SHORTCUT_LIST, SHORTCUT_TEXT } from '../src/lib/shortcuts';
+import {
+  CHORDS, EVENT_SHORTCUT_LIST, SHORTCUT_LIST, SHORTCUT_TEXT,
+} from '../src/lib/shortcuts';
 import {
   APP_MON, APP_NOW, weekLabel,
   APP_SOLO_SERIES_ID,
@@ -3388,6 +3390,13 @@ test.describe('App: keyboard event navigation', () => {
     await page.keyboard.press('j');
     await expect(selectedTitle(page)).toContainText('Plan the launch');
 
+    // A disabled control can briefly leave focus on body. The still-open
+    // dialog owns bare keys even then; `n` must not create a form behind it.
+    await page.evaluate(() => (document.activeElement as HTMLElement)?.blur());
+    await page.keyboard.press('n');
+    await expect(page.getByRole('dialog', { name: 'New event' })).toHaveCount(0);
+    await expect(dialog).toBeVisible();
+
     await page.keyboard.press('Escape');
     await expect(dialog).toHaveCount(0);
     await page.keyboard.press('Enter');
@@ -3467,7 +3476,7 @@ test.describe('App: the keyboard sheet', () => {
 
     for (const s of SHORTCUT_LIST) {
       await expect(
-        sheet(page).locator('dt', { hasText: literal(s.label) }),
+        sheet(page).locator('[data-shortcut-scope="calendar"] dt', { hasText: literal(s.label) }),
         `${s.label} (${s.id}) is bound but not listed`,
       ).toHaveCount(1);
       await expect(
@@ -3480,6 +3489,17 @@ test.describe('App: the keyboard sheet', () => {
         sheet(page).locator('dt', { hasText: literal(c.label) }),
       ).toHaveCount(1);
       await expect(sheet(page).locator('.what', { hasText: literal(c.text) })).toHaveCount(1);
+    }
+
+    for (const s of EVENT_SHORTCUT_LIST) {
+      await expect(
+        sheet(page).locator('[data-shortcut-scope="event"] dt', { hasText: literal(s.label) }),
+        `${s.label} (${s.id}) is scoped to event details but not listed`,
+      ).toHaveCount(1);
+      await expect(
+        sheet(page).locator('.what', { hasText: literal(s.text) }),
+        `${s.id} is listed under a key but not described`,
+      ).toHaveCount(1);
     }
   });
 

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -1113,6 +1113,24 @@ test.describe('App', () => {
     await expect(newForm(page).getByLabel('Start', { exact: true })).toHaveValue('12:30');
   });
 
+  test('n is consumed instead of becoming the new event title', async ({ page }) => {
+    await writable(page);
+    // WebKitGTK applies a keydown's default insertion after the shortcut has
+    // mounted and focused the title field. A synthetic cancelable event makes
+    // that contract observable in Playwright; the empty title confirms the
+    // form itself still opens cleanly.
+    const prevented = await page.evaluate(() => {
+      const event = new KeyboardEvent('keydown', {
+        key: 'n', cancelable: true, bubbles: true,
+      });
+      window.dispatchEvent(event);
+      return event.defaultPrevented;
+    });
+    expect(prevented, 'an unconsumed n is typed into the title it just focused').toBe(true);
+    await expect(newForm(page)).toBeVisible();
+    await expect(newForm(page).getByLabel('Title', { exact: true })).toHaveValue('');
+  });
+
   test('clicking empty grid space opens the form at that time', async ({ page }) => {
     await writable(page);
     const col = page.locator('.col').first();

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -3344,6 +3344,10 @@ test.describe('App: keyboard event navigation', () => {
 
   test('j late today begins with tomorrow instead of replaying past events', async ({ page }) => {
     await page.clock.setFixedTime(APP_MON + 22 * 3_600_000);
+    // This row is still visibly part of today, but has no clock position. It
+    // must not keep the time-aware entrance on today after every timed event
+    // has ended.
+    await expect(page.getByText('All-day planning', { exact: true })).toBeVisible();
 
     await page.keyboard.press('j');
     await expect(selectedTitle(page)).toContainText('Tuesday brief');
@@ -3370,7 +3374,7 @@ test.describe('App: keyboard event navigation', () => {
 
   test('j continues into the first event of the next loaded period', async ({ page }) => {
     for (let i = 0; i < 5; i++) await page.keyboard.press('j');
-    await expect(selectedTitle(page)).toContainText('Plan the launch');
+    await expect(selectedTitle(page)).toContainText('All-day planning');
     await expect(page.locator('[data-kbd-selected-day]'))
       .toHaveAttribute('data-start-ms', String(APP_MON + WEEK));
   });

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -3325,16 +3325,25 @@ test.describe('App: keyboard event navigation', () => {
     // the time-aware entrance separately.
     await page.clock.setFixedTime(APP_MON + 8 * 3_600_000);
     await page.goto(app('keyboard-navigation'));
-    await expect(page.locator('[data-kbd-selected-day]')).toBeVisible();
+    // Gate on App having mounted before asserting the cursor's absence. An
+    // empty pre-mount document also has no cursor, but does not yet have the
+    // window key handler the next line of each test needs.
+    await expect(page.locator('.vswitch button.active')).toBeVisible();
+    await expect(page.locator('[data-kbd-selected-day]')).toHaveCount(0);
+    await expect(page.locator('[data-kbd-selected-event]')).toHaveCount(0);
+    await expect(page.locator('.kbd-status')).toHaveCount(0);
   });
 
   const selectedTitle = (page: Page) =>
     page.locator('[data-kbd-selected-event]');
 
-  test('w and b select adjacent days', async ({ page }) => {
-    await expect(page.locator('[data-kbd-selected-day]'))
-      .toHaveAttribute('data-start-ms', String(APP_MON));
+  test('the cursor appears only after keyboard navigation begins', async ({ page }) => {
+    await page.keyboard.press('w');
+    await expect(page.locator('[data-kbd-selected-day]')).toBeVisible();
+    await expect(page.locator('.kbd-status')).toContainText('Selected Tuesday');
+  });
 
+  test('w and b select adjacent days', async ({ page }) => {
     await page.keyboard.press('w');
     await expect(page.locator('[data-kbd-selected-day]'))
       .toHaveAttribute('data-start-ms', String(APP_MON + 24 * 3_600_000));
@@ -3430,24 +3439,8 @@ test.describe('App: keyboard event navigation', () => {
     await expect(dialog).toBeVisible();
     await expect(dialog).toBeFocused();
 
-    await page.keyboard.press('Tab');
-    await expect(dialog.getByRole('button', { name: 'Copy title' })).toBeFocused();
-    await page.evaluate(() => {
-      Object.defineProperty(navigator, 'clipboard', {
-        configurable: true,
-        value: { writeText: async (value: string) => { (window as any).__fieldCopy = value; } },
-      });
-    });
-    await page.keyboard.press('Control+c');
-    await expect.poll(() => page.evaluate(() => (window as any).__fieldCopy))
-      .toBe('Plan the launch');
-    await expect(dialog.locator('.note')).toHaveText('Copied title');
-
-    await page.keyboard.press('Tab');
-    await expect(dialog.getByRole('button', { name: 'Copy date and time' })).toBeFocused();
-    await page.keyboard.press('Tab');
     const join = dialog.getByRole('link', { name: 'Join video call' });
-    await expect(join).toBeFocused();
+    await join.focus();
     await page.keyboard.press('Enter');
     await expect.poll(() => page.evaluate(() =>
       window.__harness.calls.filter((call) => call.cmd === 'open_conference').length,

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -3298,6 +3298,103 @@ test.describe('App: the clock format', () => {
  * What is left for a spec is the other end — that the sheet prints every row,
  * and that the keys it prints are the keys that work.
  */
+test.describe('App: keyboard event navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.clock.setFixedTime(APP_NOW);
+    await page.goto(app('keyboard-navigation'));
+    await expect(page.locator('[data-kbd-selected-day]')).toBeVisible();
+  });
+
+  const selectedTitle = (page: Page) =>
+    page.locator('[data-kbd-selected-event]');
+
+  test('w and b select adjacent days', async ({ page }) => {
+    await expect(page.locator('[data-kbd-selected-day]'))
+      .toHaveAttribute('data-start-ms', String(APP_MON));
+
+    await page.keyboard.press('w');
+    await expect(page.locator('[data-kbd-selected-day]'))
+      .toHaveAttribute('data-start-ms', String(APP_MON + 24 * 3_600_000));
+
+    await page.keyboard.press('b');
+    await expect(page.locator('[data-kbd-selected-day]'))
+      .toHaveAttribute('data-start-ms', String(APP_MON));
+  });
+
+  test('j and k cross day boundaries in event order', async ({ page }) => {
+    await page.keyboard.press('j');
+    await expect(selectedTitle(page)).toContainText('Plan the launch');
+    await page.keyboard.press('j');
+    await expect(selectedTitle(page)).toContainText('Review notes');
+    await page.keyboard.press('j');
+    await expect(selectedTitle(page)).toContainText('Tuesday brief');
+    await expect(page.locator('[data-kbd-selected-day]'))
+      .toHaveAttribute('data-start-ms', String(APP_MON + 24 * 3_600_000));
+
+    await page.keyboard.press('k');
+    await expect(selectedTitle(page)).toContainText('Review notes');
+    await page.keyboard.press('k');
+    await expect(selectedTitle(page)).toContainText('Plan the launch');
+  });
+
+  test('k from a selected day begins at its last event, then crosses backward', async ({ page }) => {
+    await page.keyboard.press('w');
+    await page.keyboard.press('k');
+    await expect(selectedTitle(page)).toContainText('Tuesday brief');
+    await page.keyboard.press('k');
+    await expect(selectedTitle(page)).toContainText('Review notes');
+  });
+
+  test('j continues into the first event of the next loaded period', async ({ page }) => {
+    for (let i = 0; i < 5; i++) await page.keyboard.press('j');
+    await expect(selectedTitle(page)).toContainText('Plan the launch');
+    await expect(page.locator('[data-kbd-selected-day]'))
+      .toHaveAttribute('data-start-ms', String(APP_MON + WEEK));
+  });
+
+  test('o and Enter open details, whose own keyboard interaction stays native', async ({ page }) => {
+    await page.keyboard.press('j');
+    await page.keyboard.press('o');
+
+    const dialog = page.getByRole('dialog', { name: 'Plan the launch' });
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toBeFocused();
+
+    await page.keyboard.press('Tab');
+    await expect(dialog.getByRole('button', { name: 'Copy title' })).toBeFocused();
+    await page.evaluate(() => {
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText: async (value: string) => { (window as any).__fieldCopy = value; } },
+      });
+    });
+    await page.keyboard.press('Control+c');
+    await expect.poll(() => page.evaluate(() => (window as any).__fieldCopy))
+      .toBe('Plan the launch');
+    await expect(dialog.locator('.note')).toHaveText('Copied title');
+
+    await page.keyboard.press('Tab');
+    await expect(dialog.getByRole('button', { name: 'Copy date and time' })).toBeFocused();
+    await page.keyboard.press('Tab');
+    const join = dialog.getByRole('link', { name: 'Join video call' });
+    await expect(join).toBeFocused();
+    await page.keyboard.press('Enter');
+    await expect.poll(() => page.evaluate(() =>
+      window.__harness.calls.filter((call) => call.cmd === 'open_conference').length,
+    )).toBe(1);
+
+    // `j` belongs to the dialog while its focus is inside: it must not move
+    // the calendar cursor behind the still-open details.
+    await page.keyboard.press('j');
+    await expect(selectedTitle(page)).toContainText('Plan the launch');
+
+    await page.keyboard.press('Escape');
+    await expect(dialog).toHaveCount(0);
+    await page.keyboard.press('Enter');
+    await expect(page.getByRole('dialog', { name: 'Plan the launch' })).toBeVisible();
+  });
+});
+
 test.describe('App: the keyboard sheet', () => {
   test.beforeEach(async ({ page }) => {
     await page.clock.setFixedTime(APP_NOW);

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -3302,7 +3302,10 @@ test.describe('App: the clock format', () => {
  */
 test.describe('App: keyboard event navigation', () => {
   test.beforeEach(async ({ page }) => {
-    await page.clock.setFixedTime(APP_NOW);
+    // Before the first event, so the ordinary traversal specs still start at
+    // the top. The late-today spec below advances this same clock to exercise
+    // the time-aware entrance separately.
+    await page.clock.setFixedTime(APP_MON + 8 * 3_600_000);
     await page.goto(app('keyboard-navigation'));
     await expect(page.locator('[data-kbd-selected-day]')).toBeVisible();
   });
@@ -3337,6 +3340,24 @@ test.describe('App: keyboard event navigation', () => {
     await expect(selectedTitle(page)).toContainText('Review notes');
     await page.keyboard.press('k');
     await expect(selectedTitle(page)).toContainText('Plan the launch');
+  });
+
+  test('j late today begins with tomorrow instead of replaying past events', async ({ page }) => {
+    await page.clock.setFixedTime(APP_MON + 22 * 3_600_000);
+
+    await page.keyboard.press('j');
+    await expect(selectedTitle(page)).toContainText('Tuesday brief');
+    await expect(page.locator('[data-kbd-selected-day]'))
+      .toHaveAttribute('data-start-ms', String(APP_MON + 24 * 3_600_000));
+  });
+
+  test('j on a future day starts with that day’s first event', async ({ page }) => {
+    for (let i = 0; i < 3; i++) await page.keyboard.press('w');
+
+    await page.keyboard.press('j');
+    await expect(selectedTitle(page)).toContainText('Off-site');
+    await expect(page.locator('[data-kbd-selected-day]'))
+      .toHaveAttribute('data-start-ms', String(APP_MON + 3 * 24 * 3_600_000));
   });
 
   test('k from a selected day begins at its last event, then crosses backward', async ({ page }) => {

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -3342,7 +3342,7 @@ test.describe('App: keyboard event navigation', () => {
     await expect(selectedTitle(page)).toContainText('Plan the launch');
   });
 
-  test('entering a day through its first all-day item reveals the top of its hours', async ({ page }) => {
+  test('entering a day through its first all-day item reveals its first timed event one hour down', async ({ page }) => {
     await page.keyboard.press('w');
     await page.keyboard.press('j');
     await expect(selectedTitle(page)).toContainText('Tuesday brief');
@@ -3357,7 +3357,14 @@ test.describe('App: keyboard event navigation', () => {
 
     await page.keyboard.press('k');
     await expect(selectedTitle(page)).toContainText('All-day planning');
-    await expect.poll(() => body.evaluate((el) => el.scrollTop)).toBe(0);
+    await expect.poll(() => page.evaluate(() => {
+      const viewport = document.querySelector<HTMLElement>('[data-testid="week-body"]')!;
+      const firstTimed = [...viewport.querySelectorAll<HTMLElement>('.ev')]
+        .find((event) => event.textContent?.includes('Plan the launch'))!;
+      const oneHour = viewport.scrollHeight / 24;
+      return Math.abs(firstTimed.getBoundingClientRect().top
+        - viewport.getBoundingClientRect().top - oneHour);
+    })).toBeLessThan(4);
   });
 
   test('j late today begins with tomorrow instead of replaying past events', async ({ page }) => {

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -3342,6 +3342,24 @@ test.describe('App: keyboard event navigation', () => {
     await expect(selectedTitle(page)).toContainText('Plan the launch');
   });
 
+  test('entering a day through its first all-day item reveals the top of its hours', async ({ page }) => {
+    await page.keyboard.press('w');
+    await page.keyboard.press('j');
+    await expect(selectedTitle(page)).toContainText('Tuesday brief');
+    await page.keyboard.press('k');
+    await expect(selectedTitle(page)).toContainText('Review notes');
+    await page.keyboard.press('k');
+    await expect(selectedTitle(page)).toContainText('Plan the launch');
+
+    const body = page.getByTestId('week-body');
+    await body.evaluate((el) => { el.scrollTop = el.scrollHeight; });
+    expect(await body.evaluate((el) => el.scrollTop)).toBeGreaterThan(0);
+
+    await page.keyboard.press('k');
+    await expect(selectedTitle(page)).toContainText('All-day planning');
+    await expect.poll(() => body.evaluate((el) => el.scrollTop)).toBe(0);
+  });
+
   test('j late today begins with tomorrow instead of replaying past events', async ({ page }) => {
     await page.clock.setFixedTime(APP_MON + 22 * 3_600_000);
     // This row is still visibly part of today, but has no clock position. It

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -3336,6 +3336,9 @@ test.describe('App: keyboard event navigation', () => {
 
   const selectedTitle = (page: Page) =>
     page.locator('[data-kbd-selected-event]');
+  const deleteCalls = (page: Page) => page.evaluate(() =>
+    window.__harness.calls.filter((call) => call.cmd === 'delete_event_cmd'),
+  );
 
   test('the cursor appears only after keyboard navigation begins', async ({ page }) => {
     await page.keyboard.press('w');
@@ -3462,6 +3465,31 @@ test.describe('App: keyboard event navigation', () => {
     await expect(dialog).toHaveCount(0);
     await page.keyboard.press('Enter');
     await expect(page.getByRole('dialog', { name: 'Plan the launch' })).toBeVisible();
+  });
+
+  test('Backspace on the selected event asks before deleting', async ({ page }) => {
+    await page.keyboard.press('j');
+    await page.keyboard.press('j');
+    await expect(selectedTitle(page)).toContainText('Review notes');
+    await page.keyboard.press('Backspace');
+
+    const confirm = page.getByRole('dialog', { name: 'Delete event' });
+    await expect(confirm).toBeVisible();
+    await expect(confirm.locator('h2')).toContainText('Review notes');
+    expect(await deleteCalls(page)).toEqual([]);
+  });
+
+  test('Backspace on an open event asks before deleting', async ({ page }) => {
+    await page.keyboard.press('j');
+    await page.keyboard.press('j');
+    await page.keyboard.press('Enter');
+    await expect(page.getByRole('dialog', { name: 'Review notes' })).toBeVisible();
+    await page.keyboard.press('Backspace');
+
+    const confirm = page.getByRole('dialog', { name: 'Delete event' });
+    await expect(confirm).toBeVisible();
+    await expect(confirm.locator('h2')).toContainText('Review notes');
+    expect(await deleteCalls(page)).toEqual([]);
   });
 });
 

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -2117,6 +2117,91 @@ test.describe('EventPopover', () => {
     await expect(page.locator('.pop')).toBeFocused();
   });
 
+  test('e edits and d deletes an event the user can change', async ({ page }) => {
+    await page.goto(show('editable'));
+    await expect(page.locator('.pop')).toBeFocused();
+
+    await page.keyboard.press('e');
+    expect(await page.evaluate(() => (window as any).__lastEdit)).toEqual({ edited: true });
+    expect(await page.evaluate(() => (window as any).__lastDelete)).toBeNull();
+
+    await page.keyboard.press('d');
+    expect(await page.evaluate(() => (window as any).__lastDelete)).toEqual({ deleted: true });
+  });
+
+  test('edit and delete keys do nothing when the event is read-only', async ({ page }) => {
+    await page.goto(show('standup'));
+    await expect(page.locator('.pop')).toBeFocused();
+
+    await page.keyboard.press('e');
+    await page.keyboard.press('d');
+    expect(await page.evaluate(() => (window as any).__lastEdit)).toBeNull();
+    expect(await page.evaluate(() => (window as any).__lastDelete)).toBeNull();
+  });
+
+  test('y, m and n answer Yes, Maybe and No', async ({ page }) => {
+    for (const [key, response] of [
+      ['y', 'accepted'],
+      ['m', 'tentative'],
+      ['n', 'declined'],
+    ] as const) {
+      await page.goto(show('standup'));
+      await expect(page.locator('.pop')).toBeFocused();
+      await page.keyboard.press(key);
+      await expect.poll(() => page.evaluate(() => (window as any).__lastRespondCall?.response))
+        .toBe(response);
+    }
+  });
+
+  test('an RSVP key on a recurring event opens the existing scope choice', async ({ page }) => {
+    await page.goto(show('recurring'));
+    await expect(page.locator('.pop')).toBeFocused();
+
+    await page.keyboard.press('n');
+    await expect(page.locator('.scope')).toBeVisible();
+    expect(await page.evaluate(() => (window as any).__lastRespondCall ?? null)).toBeNull();
+  });
+
+  test('RSVP keys do nothing when the event cannot be answered', async ({ page }) => {
+    await page.goto(show('readonly'));
+    await expect(page.locator('.pop')).toBeFocused();
+
+    await page.keyboard.press('y');
+    await page.keyboard.press('m');
+    await page.keyboard.press('n');
+    expect(await page.evaluate(() => (window as any).__lastRespondCall ?? null)).toBeNull();
+  });
+
+  test('Enter joins the meeting when the panel itself has focus', async ({ page }) => {
+    await page.goto(show('location-holds-a-real-zoom-link'));
+    await expect(page.locator('.pop')).toBeFocused();
+
+    await page.keyboard.press('Enter');
+    const calls = await page.evaluate(() => (window as any).__harness.calls);
+    expect(calls.filter((c: any) => c.cmd === 'open_conference')).toEqual([
+      expect.objectContaining({ args: { id: 64 } }),
+    ]);
+  });
+
+  test('Enter keeps the focused control native instead of joining twice', async ({ page }) => {
+    await page.goto(show('location-holds-a-real-zoom-link'));
+    const join = page.getByRole('link', { name: 'Join video call' });
+    await join.focus();
+
+    await page.keyboard.press('Enter');
+    const calls = await page.evaluate(() => (window as any).__harness.calls);
+    expect(calls.filter((c: any) => c.cmd === 'open_conference')).toHaveLength(1);
+  });
+
+  test('Enter does nothing when the event has no meeting', async ({ page }) => {
+    await page.goto(show('standup'));
+    await expect(page.locator('.pop')).toBeFocused();
+
+    await page.keyboard.press('Enter');
+    const calls = await page.evaluate(() => (window as any).__harness.calls);
+    expect(calls.filter((c: any) => c.cmd === 'open_conference')).toHaveLength(0);
+  });
+
   test('a description containing markup is shown as text', async ({ page }) => {
     await page.goto(show('nasty-description'));
     await expect(page.locator('.desc')).toContainText('<script>alert(1)</script>');

--- a/ui/tests/filmstrip.spec.ts
+++ b/ui/tests/filmstrip.spec.ts
@@ -35,7 +35,7 @@ test.describe('daysFromWeek', () => {
   test('the navigation form retains every day, including gaps', () => {
     const days = allDaysFromWeek(filmstripWeek());
     expect(days).toHaveLength(7);
-    expect(days[1]).toEqual({ startMs: dayOf(1), events: [] });
+    expect(days[1]).toEqual({ startMs: dayOf(1), endMs: dayOf(2), events: [] });
   });
   test('the fixture really is out of order, and really has a gap', () => {
     // §5 of the testing standard: a fixture built from a stated hazard proves

--- a/ui/tests/filmstrip.spec.ts
+++ b/ui/tests/filmstrip.spec.ts
@@ -11,7 +11,9 @@
 
 import { test, expect } from '@playwright/test';
 import type { WeekPayload } from '../src/lib/api';
-import { daysFromMonth, daysFromWeek, listable, LISTABLE_VIEWS } from '../src/lib/filmstrip';
+import {
+  allDaysFromMonth, allDaysFromWeek, daysFromMonth, daysFromWeek, listable, LISTABLE_VIEWS,
+} from '../src/lib/filmstrip';
 import {
   FIXTURES, crossZoneWeek, filmstripMonth, filmstripWeek,
   XZONE_DAY, XZONE_DISPLAY_MISREADING,
@@ -30,6 +32,11 @@ const titlesOn = (days: ReturnType<typeof daysFromWeek>, startMs: number) =>
   days.find((d) => d.startMs === startMs)?.events.map((e) => e.title);
 
 test.describe('daysFromWeek', () => {
+  test('the navigation form retains every day, including gaps', () => {
+    const days = allDaysFromWeek(filmstripWeek());
+    expect(days).toHaveLength(7);
+    expect(days[1]).toEqual({ startMs: dayOf(1), events: [] });
+  });
   test('the fixture really is out of order, and really has a gap', () => {
     // §5 of the testing standard: a fixture built from a stated hazard proves
     // the statement unless the statement is checked. Both premises the two
@@ -140,6 +147,10 @@ test.describe('daysFromMonth', () => {
     for (const c of [3, 4, 5, 6]) {
       expect(m.rows[1].cells[c].timed, `6-9 Aug must be the gap`).toEqual([]);
     }
+  });
+
+  test('the navigation form retains all 42 grid cells', () => {
+    expect(allDaysFromMonth(filmstripMonth())).toHaveLength(42);
   });
 
   test('a month lists only the days that carry something, in grid order', () => {

--- a/ui/tests/fixtures.spec.ts
+++ b/ui/tests/fixtures.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from '@playwright/test';
 import type { MonthPayload, WeekPayload } from '../src/lib/api';
 import {
-  FIXTURES, bandAsWeek, busyDayMonth, labelledWeek, appWritableWeek, crossZoneWeek, APP_MON,
+  FIXTURES, bandAsWeek, busyDayMonth, labelledWeek, keyboardWeek, appWritableWeek,
+  crossZoneWeek, APP_MON,
 } from './fixtures';
 
 // The fixtures themselves are under test here.
@@ -277,6 +278,7 @@ const weeks: [string, WeekPayload][] = [
   ),
   ['app:labelled', labelledWeek(APP_MON)],
   ['app:labelled-next', labelledWeek(APP_MON + 7 * 24 * H)],
+  ['app:keyboard', keyboardWeek(APP_MON)],
   ['app:writable', appWritableWeek()],
   ['app:cross-zone', crossZoneWeek()],
   // `AllDayBand`'s own props fixtures, lifted back into the payload they are a
@@ -363,7 +365,7 @@ test.describe('the hand-written week fixtures describe payloads assemble_days co
       expect.arrayContaining([
         'empty', 'populated', 'popover', 'popover-two-occurrences', 'popover-all-day',
         'single-day', 'single-day-overlap', 'filmstrip',
-        'app:labelled', 'app:labelled-next', 'app:writable', 'app:cross-zone',
+        'app:labelled', 'app:labelled-next', 'app:keyboard', 'app:writable', 'app:cross-zone',
       ]),
     );
   });

--- a/ui/tests/fixtures.ts
+++ b/ui/tests/fixtures.ts
@@ -306,10 +306,12 @@ export const KEYBOARD_FIRST_ID = 901;
 export const KEYBOARD_SECOND_ID = 902;
 export const KEYBOARD_NEXT_DAY_ID = 903;
 export const KEYBOARD_ALL_DAY_ID = 904;
+export const KEYBOARD_TODAY_ALL_DAY_ID = 905;
 
 /** A week whose ordering can distinguish every keyboard edge: two events on
- * the first day, one on the next, an empty day, then an all-day chip. Built at
- * the requested boundary so paging across a payload edge remains truthful. */
+ * the first day beneath an all-day chip, one on the next, an empty day, then
+ * another all-day chip. Built at the requested boundary so paging across a
+ * payload edge remains truthful. */
 export const keyboardWeek = (weekStartMs: number): WeekPayload => {
   const w = emptyWeekAt(weekStartMs);
   if (w.days[0]) {
@@ -321,6 +323,13 @@ export const keyboardWeek = (weekStartMs: number): WeekPayload => {
            start_ms: weekStartMs + 11 * H, end_ms: weekStartMs + 12 * H }),
     ];
     w.days[0].placed = [placed(9 / 24, 1 / 24, 0, 1, 0), placed(11 / 24, 1 / 24, 0, 1, 1)];
+    w.all_day_events.push(
+      ev({ id: KEYBOARD_TODAY_ALL_DAY_ID, title: 'All-day planning', is_all_day: true,
+           start_ms: weekStartMs, end_ms: weekStartMs + 24 * H }),
+    );
+    w.all_day.push(
+      { idx: 0, lane: 0, start_col: 0, end_col: 0, cont_left: false, cont_right: false },
+    );
   }
   if (w.days[1]) {
     const start = weekStartMs + 24 * H;
@@ -332,13 +341,14 @@ export const keyboardWeek = (weekStartMs: number): WeekPayload => {
   }
   if (w.days[3]) {
     const start = weekStartMs + 3 * 24 * H;
-    w.all_day_events = [
+    w.all_day_events.push(
       ev({ id: KEYBOARD_ALL_DAY_ID, title: 'Off-site', is_all_day: true,
            start_ms: start, end_ms: start + 24 * H }),
-    ];
-    w.all_day = [
-      { idx: 0, lane: 0, start_col: 3, end_col: 3, cont_left: false, cont_right: false },
-    ];
+    );
+    w.all_day.push(
+      { idx: w.all_day_events.length - 1, lane: 0, start_col: 3, end_col: 3,
+        cont_left: false, cont_right: false },
+    );
   }
   return w;
 };
@@ -595,6 +605,14 @@ POPOVER_DETAILS[KEYBOARD_ALL_DAY_ID] = detail({
   is_all_day: true,
   start_date: utcDate(APP_MON + 3 * 24 * H),
   end_date: utcDate(APP_MON + 3 * 24 * H),
+  can_respond: false,
+});
+POPOVER_DETAILS[KEYBOARD_TODAY_ALL_DAY_ID] = detail({
+  id: KEYBOARD_TODAY_ALL_DAY_ID,
+  title: 'All-day planning',
+  is_all_day: true,
+  start_date: utcDate(APP_MON),
+  end_date: utcDate(APP_MON),
   can_respond: false,
 });
 

--- a/ui/tests/fixtures.ts
+++ b/ui/tests/fixtures.ts
@@ -594,7 +594,7 @@ POPOVER_DETAILS[KEYBOARD_FIRST_ID] = detail({
   can_respond: false,
 });
 POPOVER_DETAILS[KEYBOARD_SECOND_ID] = detail({
-  id: KEYBOARD_SECOND_ID, title: 'Review notes', can_respond: false,
+  id: KEYBOARD_SECOND_ID, title: 'Review notes', can_edit: true, can_respond: false,
 });
 POPOVER_DETAILS[KEYBOARD_NEXT_DAY_ID] = detail({
   id: KEYBOARD_NEXT_DAY_ID, title: 'Tuesday brief', can_respond: false,

--- a/ui/tests/fixtures.ts
+++ b/ui/tests/fixtures.ts
@@ -302,6 +302,47 @@ export const labelledWeek = (weekStartMs: number, dayCount = 7): WeekPayload => 
   overflow: [],
 });
 
+export const KEYBOARD_FIRST_ID = 901;
+export const KEYBOARD_SECOND_ID = 902;
+export const KEYBOARD_NEXT_DAY_ID = 903;
+export const KEYBOARD_ALL_DAY_ID = 904;
+
+/** A week whose ordering can distinguish every keyboard edge: two events on
+ * the first day, one on the next, an empty day, then an all-day chip. Built at
+ * the requested boundary so paging across a payload edge remains truthful. */
+export const keyboardWeek = (weekStartMs: number): WeekPayload => {
+  const w = emptyWeekAt(weekStartMs);
+  if (w.days[0]) {
+    w.days[0].events = [
+      ev({ id: KEYBOARD_FIRST_ID, title: 'Plan the launch',
+           start_ms: weekStartMs + 9 * H, end_ms: weekStartMs + 10 * H,
+           conference: 'https://meet.example.test/launch' }),
+      ev({ id: KEYBOARD_SECOND_ID, title: 'Review notes',
+           start_ms: weekStartMs + 11 * H, end_ms: weekStartMs + 12 * H }),
+    ];
+    w.days[0].placed = [placed(9 / 24, 1 / 24, 0, 1, 0), placed(11 / 24, 1 / 24, 0, 1, 1)];
+  }
+  if (w.days[1]) {
+    const start = weekStartMs + 24 * H;
+    w.days[1].events = [
+      ev({ id: KEYBOARD_NEXT_DAY_ID, title: 'Tuesday brief',
+           start_ms: start + 10 * H, end_ms: start + 11 * H }),
+    ];
+    w.days[1].placed = [placed(10 / 24, 1 / 24)];
+  }
+  if (w.days[3]) {
+    const start = weekStartMs + 3 * 24 * H;
+    w.all_day_events = [
+      ev({ id: KEYBOARD_ALL_DAY_ID, title: 'Off-site', is_all_day: true,
+           start_ms: start, end_ms: start + 24 * H }),
+    ];
+    w.all_day = [
+      { idx: 0, lane: 0, start_col: 3, end_col: 3, cont_left: false, cont_right: false },
+    ];
+  }
+  return w;
+};
+
 const block = (title: string, mins: number, response: UiEvent['response'],
                location: string | null = 'Room 4A') => ({
   event: ev({ title, location, response, start_ms: MON + 9 * H,
@@ -535,6 +576,27 @@ export const POPOVER_DETAILS: Record<number, EventDetail> = {
   60: detail({ id: 60, title: 'Event A' }),
   61: detail({ id: 61, title: 'Event B' }),
 };
+
+POPOVER_DETAILS[KEYBOARD_FIRST_ID] = detail({
+  id: KEYBOARD_FIRST_ID,
+  title: 'Plan the launch',
+  conference_uri: 'https://meet.example.test/launch',
+  can_respond: false,
+});
+POPOVER_DETAILS[KEYBOARD_SECOND_ID] = detail({
+  id: KEYBOARD_SECOND_ID, title: 'Review notes', can_respond: false,
+});
+POPOVER_DETAILS[KEYBOARD_NEXT_DAY_ID] = detail({
+  id: KEYBOARD_NEXT_DAY_ID, title: 'Tuesday brief', can_respond: false,
+});
+POPOVER_DETAILS[KEYBOARD_ALL_DAY_ID] = detail({
+  id: KEYBOARD_ALL_DAY_ID,
+  title: 'Off-site',
+  is_all_day: true,
+  start_date: utcDate(APP_MON + 3 * 24 * H),
+  end_date: utcDate(APP_MON + 3 * 24 * H),
+  can_respond: false,
+});
 
 /** What `refresh_event(50)` resolves with once a spec releases it — a
  *  different `location` than `POPOVER_DETAILS[50]`, so the after-paint

--- a/ui/tests/harness/mount.svelte.ts
+++ b/ui/tests/harness/mount.svelte.ts
@@ -320,12 +320,20 @@ if (name === 'App') {
       // closes it" would have nothing to observe: the fixture's own
       // `onclose` is a no-op, since it can't know about this harness.
       (window as any).__lastCopy = null;
+      (window as any).__lastEdit = null;
+      (window as any).__lastDelete = null;
       let app: object;
       app = mount(EventPopover, {
         target,
         props: {
           ...props,
           onclose: () => unmount(app),
+          onedit: () => {
+            (window as any).__lastEdit = { edited: true };
+          },
+          ondelete: () => {
+            (window as any).__lastDelete = { deleted: true };
+          },
           oncopy: () => {
             (window as any).__lastCopy = { copied: true };
           },

--- a/ui/tests/harness/tauri.ts
+++ b/ui/tests/harness/tauri.ts
@@ -21,7 +21,7 @@ import {
   APP_ONE_OFF_ID, APP_ONE_OFF_START, APP_GUESTS_ID, APP_SOLO_SERIES_ID,
   POPOVER_DETAILS, busyDayMonth,
   appWritableWeek, APP_WRITE_CALENDARS, CREATED_DETAIL, crossZoneWeek,
-  XZONE_WEEK_START,
+  XZONE_WEEK_START, keyboardWeek,
 } from '../fixtures';
 
 /** What the real `get_palette` returns; the same fallback_dark values. */
@@ -395,6 +395,9 @@ function getWeek(scenario: string, weekStartMs: number, dayCount = 7): Promise<W
   // below: its specs pin literal instants, and none of them needs the payload
   // to match the week it requested.
   if (scenario === 'writable') return Promise.resolve(appWritableWeek());
+  if (scenario === 'keyboard-navigation') {
+    return Promise.resolve(keyboardWeek(weekStartMs));
+  }
   // `cross-zone` is the one scenario where the week actually asked for is part
   // of the claim: its payload's columns are `Europe/Sofia` midnights, and it
   // only describes what is on screen if the app requested that same Monday.

--- a/ui/tests/keyboardnav.spec.ts
+++ b/ui/tests/keyboardnav.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+import { allDaysFromWeek } from '../src/lib/filmstrip';
+import { dayCursor, eventAtCursor, moveDay, moveEvent } from '../src/lib/keyboardnav';
+import { APP_MON, keyboardWeek } from './fixtures';
+
+const DAY = 24 * 3_600_000;
+const days = () => allDaysFromWeek(keyboardWeek(APP_MON));
+
+test.describe('calendar keyboard cursor', () => {
+  test('w and b move one visible day and clear the event selection', () => {
+    const forward = moveDay(days(), dayCursor(APP_MON), 1);
+    expect(forward).toEqual({ cursor: dayCursor(APP_MON + DAY), overflow: null });
+
+    const back = moveDay(days(), forward.cursor, -1);
+    expect(back).toEqual({ cursor: dayCursor(APP_MON), overflow: null });
+  });
+
+  test('j walks down a day, then enters the first event of the next day', () => {
+    const list = days();
+    const first = moveEvent(list, dayCursor(APP_MON), 1);
+    expect(eventAtCursor(list, first.cursor)?.title).toBe('Plan the launch');
+
+    const second = moveEvent(list, first.cursor, 1);
+    expect(eventAtCursor(list, second.cursor)?.title).toBe('Review notes');
+
+    const nextDay = moveEvent(list, second.cursor, 1);
+    expect(nextDay.cursor.dayStartMs).toBe(APP_MON + DAY);
+    expect(eventAtCursor(list, nextDay.cursor)?.title).toBe('Tuesday brief');
+  });
+
+  test('k at the top enters the last event of the previous day', () => {
+    const list = days();
+    const tuesdayLast = moveEvent(list, dayCursor(APP_MON + DAY), -1);
+    expect(eventAtCursor(list, tuesdayLast.cursor)?.title).toBe('Tuesday brief');
+
+    const mondayLast = moveEvent(list, tuesdayLast.cursor, -1);
+    expect(mondayLast.cursor.dayStartMs).toBe(APP_MON);
+    expect(eventAtCursor(list, mondayLast.cursor)?.title).toBe('Review notes');
+  });
+
+  test('cross-day event movement skips an empty day and includes all-day events', () => {
+    const list = days();
+    const fromTuesday = moveEvent(list, moveEvent(list, dayCursor(APP_MON + DAY), 1).cursor, 1);
+    expect(fromTuesday.cursor.dayStartMs).toBe(APP_MON + 3 * DAY);
+    expect(eventAtCursor(list, fromTuesday.cursor)?.title).toBe('Off-site');
+  });
+
+  test('reports a payload edge instead of wrapping around', () => {
+    expect(moveDay(days(), dayCursor(APP_MON), -1).overflow).toBe(-1);
+    const last = dayCursor(APP_MON + 6 * DAY);
+    expect(moveEvent(days(), last, 1).overflow).toBe(1);
+  });
+});

--- a/ui/tests/keyboardnav.spec.ts
+++ b/ui/tests/keyboardnav.spec.ts
@@ -15,21 +15,34 @@ test.describe('calendar keyboard cursor', () => {
     expect(back).toEqual({ cursor: dayCursor(APP_MON), overflow: null });
   });
 
-  test('j walks down a day, then enters the first event of the next day', () => {
+  test('j walks down all-day and timed rows, then enters the next day', () => {
     const list = days();
     const first = moveEvent(list, dayCursor(APP_MON), 1);
-    expect(eventAtCursor(list, first.cursor)?.title).toBe('Plan the launch');
+    expect(eventAtCursor(list, first.cursor)?.title).toBe('All-day planning');
 
     const second = moveEvent(list, first.cursor, 1);
-    expect(eventAtCursor(list, second.cursor)?.title).toBe('Review notes');
+    expect(eventAtCursor(list, second.cursor)?.title).toBe('Plan the launch');
 
-    const nextDay = moveEvent(list, second.cursor, 1);
+    const third = moveEvent(list, second.cursor, 1);
+    expect(eventAtCursor(list, third.cursor)?.title).toBe('Review notes');
+
+    const nextDay = moveEvent(list, third.cursor, 1);
     expect(nextDay.cursor.dayStartMs).toBe(APP_MON + DAY);
     expect(eventAtCursor(list, nextDay.cursor)?.title).toBe('Tuesday brief');
   });
 
   test('j from today skips events that have already ended', () => {
     const list = days();
+    const lateMonday = APP_MON + 22 * 3_600_000;
+    const next = moveEvent(list, dayCursor(APP_MON), 1, { nowMs: lateMonday });
+
+    expect(next.cursor.dayStartMs).toBe(APP_MON + DAY);
+    expect(eventAtCursor(list, next.cursor)?.title).toBe('Tuesday brief');
+  });
+
+  test('j from late today ignores an all-day row and advances to tomorrow', () => {
+    const list = days();
+    expect(list[0].events.some((event) => event.is_all_day)).toBe(true);
     const lateMonday = APP_MON + 22 * 3_600_000;
     const next = moveEvent(list, dayCursor(APP_MON), 1, { nowMs: lateMonday });
 
@@ -49,6 +62,29 @@ test.describe('calendar keyboard cursor', () => {
 
   test('k from today skips events that have not started yet', () => {
     const list = days();
+    const earlyTuesday = APP_MON + DAY + 8 * 3_600_000;
+    const previous = moveEvent(list, dayCursor(APP_MON + DAY), -1, { nowMs: earlyTuesday });
+
+    expect(previous.cursor.dayStartMs).toBe(APP_MON);
+    expect(eventAtCursor(list, previous.cursor)?.title).toBe('Review notes');
+  });
+
+  test('k from early today ignores an all-day row and retreats to yesterday', () => {
+    const list = days();
+    const source = list[3].events.find((event) => event.is_all_day)!;
+    list[1] = {
+      ...list[1],
+      events: [
+        {
+          ...source,
+          id: 906,
+          title: 'Today all day',
+          start_ms: APP_MON + DAY,
+          end_ms: APP_MON + 2 * DAY,
+        },
+        ...list[1].events,
+      ],
+    };
     const earlyTuesday = APP_MON + DAY + 8 * 3_600_000;
     const previous = moveEvent(list, dayCursor(APP_MON + DAY), -1, { nowMs: earlyTuesday });
 

--- a/ui/tests/keyboardnav.spec.ts
+++ b/ui/tests/keyboardnav.spec.ts
@@ -31,9 +31,7 @@ test.describe('calendar keyboard cursor', () => {
   test('j from today skips events that have already ended', () => {
     const list = days();
     const lateMonday = APP_MON + 22 * 3_600_000;
-    const next = moveEvent(list, dayCursor(APP_MON), 1, {
-      nowMs: lateMonday, todayStartMs: APP_MON,
-    });
+    const next = moveEvent(list, dayCursor(APP_MON), 1, { nowMs: lateMonday });
 
     expect(next.cursor.dayStartMs).toBe(APP_MON + DAY);
     expect(eventAtCursor(list, next.cursor)?.title).toBe('Tuesday brief');
@@ -52,12 +50,24 @@ test.describe('calendar keyboard cursor', () => {
   test('k from today skips events that have not started yet', () => {
     const list = days();
     const earlyTuesday = APP_MON + DAY + 8 * 3_600_000;
-    const previous = moveEvent(list, dayCursor(APP_MON + DAY), -1, {
-      nowMs: earlyTuesday, todayStartMs: APP_MON + DAY,
-    });
+    const previous = moveEvent(list, dayCursor(APP_MON + DAY), -1, { nowMs: earlyTuesday });
 
     expect(previous.cursor.dayStartMs).toBe(APP_MON);
     expect(eventAtCursor(list, previous.cursor)?.title).toBe('Review notes');
+  });
+
+  test('the payload day interval, not the browser midnight, decides which day is today', () => {
+    const list = days();
+    const lateMonday = APP_MON + 22 * 3_600_000;
+
+    // A calendar can display a zone other than the browser/system zone. Its
+    // midnight is then a different instant, but 10 PM is still inside the
+    // day interval the payload supplied. This is the live-app failure the
+    // previous exact-midnight comparison missed.
+    const next = moveEvent(list, dayCursor(APP_MON), 1, { nowMs: lateMonday });
+
+    expect(next.cursor.dayStartMs).toBe(APP_MON + DAY);
+    expect(eventAtCursor(list, next.cursor)?.title).toBe('Tuesday brief');
   });
 
   test('cross-day event movement skips an empty day and includes all-day events', () => {

--- a/ui/tests/keyboardnav.spec.ts
+++ b/ui/tests/keyboardnav.spec.ts
@@ -28,6 +28,17 @@ test.describe('calendar keyboard cursor', () => {
     expect(eventAtCursor(list, nextDay.cursor)?.title).toBe('Tuesday brief');
   });
 
+  test('j from today skips events that have already ended', () => {
+    const list = days();
+    const lateMonday = APP_MON + 22 * 3_600_000;
+    const next = moveEvent(list, dayCursor(APP_MON), 1, {
+      nowMs: lateMonday, todayStartMs: APP_MON,
+    });
+
+    expect(next.cursor.dayStartMs).toBe(APP_MON + DAY);
+    expect(eventAtCursor(list, next.cursor)?.title).toBe('Tuesday brief');
+  });
+
   test('k at the top enters the last event of the previous day', () => {
     const list = days();
     const tuesdayLast = moveEvent(list, dayCursor(APP_MON + DAY), -1);
@@ -36,6 +47,17 @@ test.describe('calendar keyboard cursor', () => {
     const mondayLast = moveEvent(list, tuesdayLast.cursor, -1);
     expect(mondayLast.cursor.dayStartMs).toBe(APP_MON);
     expect(eventAtCursor(list, mondayLast.cursor)?.title).toBe('Review notes');
+  });
+
+  test('k from today skips events that have not started yet', () => {
+    const list = days();
+    const earlyTuesday = APP_MON + DAY + 8 * 3_600_000;
+    const previous = moveEvent(list, dayCursor(APP_MON + DAY), -1, {
+      nowMs: earlyTuesday, todayStartMs: APP_MON + DAY,
+    });
+
+    expect(previous.cursor.dayStartMs).toBe(APP_MON);
+    expect(eventAtCursor(list, previous.cursor)?.title).toBe('Review notes');
   });
 
   test('cross-day event movement skips an empty day and includes all-day events', () => {


### PR DESCRIPTION
## Summary

- make Backspace on the keyboard-selected event open the existing delete confirmation instead of deleting immediately
- make Backspace on an already-open event popover take the same guarded path as its Delete action
- fetch current edit permissions and re-check occurrence identity before opening confirmation
- document both bindings in the shared shortcut tables

## Dependency

This is stacked on #5, which introduces the keyboard event cursor and open-event shortcuts this action extends. The final `feat(keyboard): confirm Backspace event deletion` commit is the new review unit.

## Tests

- `npm run check`
- `npx playwright test tests/app.spec.ts --project=chromium --grep "Backspace on"` (2 passed)