### PR TITLE
feat(keyboard): save edits with Ctrl+Enter

### DIFF
--- a/ui/src/lib/EventForm.svelte
+++ b/ui/src/lib/EventForm.svelte
@@ -259,6 +259,7 @@
   );
 
   let panelEl: HTMLDivElement | undefined = $state();
+  let formEl: HTMLFormElement | undefined = $state();
   let titleEl: HTMLInputElement | undefined = $state();
   // A neutral default so the panel renders — and is measurable — before
   // `onMount` places it. `anchor` never changes for this component's lifetime
@@ -442,6 +443,17 @@
     asking = { result };
   }
 
+  /** Save an edit from whichever field has focus. `requestSubmit` is the
+   * important part: it takes the form's ordinary submit handler, so validation
+   * and the guest-notification choice cannot be skipped by the shortcut. */
+  function saveEditKey(e: KeyboardEvent) {
+    if (!initial.isEdit || asking || e.defaultPrevented
+        || e.key !== 'Enter' || !(e.ctrlKey || e.metaKey) || e.altKey || e.shiftKey) return;
+    if (!(e.target instanceof Node) || !panelEl?.contains(e.target)) return;
+    e.preventDefault();
+    formEl?.requestSubmit();
+  }
+
   /** The answer. The save happens here and nowhere else, which is what makes
    *  Cancel witnessable by the absence of one. */
   function confirmSave(notify: SendUpdates) {
@@ -485,6 +497,8 @@
   escapeCloses(() => !asking, () => oncancel());
 </script>
 
+<svelte:window onkeydown={saveEditKey} />
+
 <!-- A sibling of `.pop`, not a wrapper, so a click inside the panel never
      reaches this button. -->
 <button class="scrim" aria-label="Cancel" onclick={oncancel}></button>
@@ -498,6 +512,7 @@
   style="top:{pos.top}px; left:{pos.left}px"
 >
   <form
+    bind:this={formEl}
     onsubmit={(e) => {
       e.preventDefault();
       save();
@@ -899,7 +914,7 @@
             // on an event with guests opening the notify choice for a change
             // nobody had finished making. With a row highlighted, Return is
             // that row; otherwise it is whatever was typed, as ever.
-            if (e.key === 'Enter') {
+            if (e.key === 'Enter' && !e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey) {
               e.preventDefault();
               const picked = hi >= 0 ? guestMatches[hi] : undefined;
               if (picked) pickGuest(picked);

--- a/ui/src/lib/ShortcutSheet.svelte
+++ b/ui/src/lib/ShortcutSheet.svelte
@@ -1,7 +1,7 @@
 <!-- ui/src/lib/ShortcutSheet.svelte -->
 <script lang="ts">
   import { escapeCloses } from './dismiss.svelte';
-  import { CHORDS, groupedShortcuts, SHORTCUT_TEXT } from './shortcuts';
+  import { CHORDS, EDIT_CHORDS, groupedShortcuts, SHORTCUT_TEXT } from './shortcuts';
 
   let { onclose }: { onclose: () => void } = $props();
 
@@ -53,6 +53,17 @@
       {/if}
     </dl>
   {/each}
+
+  <h3>Editing an event</h3>
+  <dl data-shortcut-scope="edit">
+    {#each EDIT_CHORDS as c (c.label)}
+      <dt><kbd>{c.label}</kbd></dt>
+      <dd>
+        <span class="what">{c.text}</span>
+        {#if c.hint}<em>{c.hint}</em>{/if}
+      </dd>
+    {/each}
+  </dl>
 
   <p class="foot">Escape closes this.</p>
 </div>

--- a/ui/src/lib/shortcuts.ts
+++ b/ui/src/lib/shortcuts.ts
@@ -125,6 +125,13 @@ export const CHORDS: { label: string; text: string; hint?: string }[] = [
     hint: 'opens the form on the day you are looking at, to fine-tune first' },
 ];
 
+/** A form chord rather than a bare key: it bubbles from any field to the form
+ * and submits through the same validation and guest-notification path as its
+ * Save button. */
+export const EDIT_CHORDS: { label: string; text: string; hint?: string }[] = [
+  { label: `${MOD_LABEL} Enter`, text: 'Save edits', hint: 'from anywhere in the edit form' },
+];
+
 /** The table in the order the sheet draws it. A group with no shortcuts is
  *  dropped rather than drawn empty, so `SHORTCUT_GROUPS` can name a heading
  *  before anything is filed under it. */

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -4,7 +4,7 @@
 // stubbed IPC layer (tests/harness/tauri.ts).
 
 import { test, expect, type Page } from '@playwright/test';
-import { CHORDS, SHORTCUT_LIST, SHORTCUT_TEXT } from '../src/lib/shortcuts';
+import { CHORDS, EDIT_CHORDS, SHORTCUT_LIST, SHORTCUT_TEXT } from '../src/lib/shortcuts';
 import {
   APP_MON, APP_NOW, weekLabel,
   APP_SOLO_SERIES_ID,
@@ -3381,6 +3381,13 @@ test.describe('App: the keyboard sheet', () => {
     for (const c of CHORDS) {
       await expect(
         sheet(page).locator('dt', { hasText: literal(c.label) }),
+      ).toHaveCount(1);
+      await expect(sheet(page).locator('.what', { hasText: literal(c.text) })).toHaveCount(1);
+    }
+
+    for (const c of EDIT_CHORDS) {
+      await expect(
+        sheet(page).locator('[data-shortcut-scope="edit"] dt', { hasText: literal(c.label) }),
       ).toHaveCount(1);
       await expect(sheet(page).locator('.what', { hasText: literal(c.text) })).toHaveCount(1);
     }

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -3815,6 +3815,24 @@ test.describe('EventForm', () => {
     await expect(page.getByTestId('all-events-note')).toContainText('every occurrence an hour later');
   });
 
+  test('Ctrl+Enter saves an edit from inside a text field', async ({ page }) => {
+    await open(page, 'custom-repeat');
+    await page.getByLabel('Description', { exact: true }).fill('Ready to send');
+
+    await page.keyboard.press('Control+Enter');
+    const [saved] = await saves(page);
+    expect(saved.fields.description).toBe('Ready to send');
+    expect(await saves(page)).toHaveLength(1);
+  });
+
+  test('Ctrl+Enter keeps the guest notification choice in the save path', async ({ page }) => {
+    await open(page, 'with-guests');
+
+    await page.keyboard.press('Control+Enter');
+    await expect(page.getByRole('dialog', { name: 'Save event' })).toBeVisible();
+    expect(await saves(page)).toEqual([]);
+  });
+
   test('a one-off event offers no scope choice', async ({ page }) => {
     // Without this the scope spec above passes on a form that always shows
     // three radios, whatever it was given.


### PR DESCRIPTION
## Summary

A focused rider split from #5 at review request.

- Ctrl/Command+Enter submits an existing event edit from any field
- uses requestSubmit so ordinary validation and repeat-scope handling remain in force
- preserves the guest notification confirmation instead of bypassing it
- leaves new-event creation unchanged
- documents the chord in the generated keyboard shortcut sheet

## Validation

- npm run check
- focused Chromium shortcut and save-path tests: 3 passed

## Relationship

This contains no keyboard cursor/navigation work and no click-to-copy field behavior.