### PR TITLE
feat(events): add rich descriptions and polish the event form

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",
-        "@tauri-apps/plugin-opener": "^2"
+        "@tauri-apps/plugin-opener": "^2",
+        "dompurify": "^3.4.14"
       },
       "devDependencies": {
         "@playwright/test": "^1.62.1",
@@ -1215,7 +1216,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/acorn": {
@@ -1311,6 +1312,15 @@
       "integrity": "sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.12",

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,7 +16,8 @@
   "license": "MIT",
   "dependencies": {
     "@tauri-apps/api": "^2",
-    "@tauri-apps/plugin-opener": "^2"
+    "@tauri-apps/plugin-opener": "^2",
+    "dompurify": "^3.4.14"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.1",

--- a/ui/src/lib/EventForm.svelte
+++ b/ui/src/lib/EventForm.svelte
@@ -10,6 +10,7 @@
   import { REMINDER_UNITS, reminderAmountOf, reminderMax, reminderUnitOf } from './reminders';
   import { offerableCalendarId, writableCalendars, type Calendar } from './calendars';
   import SaveConfirm from './SaveConfirm.svelte';
+  import RichTextEditor from './RichTextEditor.svelte';
   import type { SendUpdates } from './eventdetail';
   import {
     CUSTOM_REPEAT, REPEAT_OPTIONS, WEEKDAY_OPTIONS, addGuest, endAfterStart, isAddress,
@@ -647,8 +648,7 @@
          rule; nothing here decides that. The `email` rows are deliberately
          not rendered — Google sends those — but they count toward Google's
          cap of 5, which is why the add control reads the sum. -->
-    <div class="field" role="group" aria-label="Reminders">
-      <span class="lab">Notify</span>
+    <div class="field section-start" role="group" aria-label="Reminders">
       <div class="reminders">
         {#each value.popupReminders as _, i}
           <div class="reminder">
@@ -676,12 +676,12 @@
             <span>before</span>
             <button
               type="button"
-              class="unremind"
+              class="x"
               aria-label="Remove reminder"
               onclick={() => {
                 value.popupReminders = value.popupReminders.filter((_, j) => j !== i);
               }}
-            >⊗</button>
+            >×</button>
           </div>
         {/each}
         {#if value.popupReminders.length + value.emailReminders.length < 5}
@@ -701,17 +701,15 @@
       </div>
     </div>
 
-    <label class="field">
+    <div class="field">
       <span class="lab">Description</span>
-      <!-- A textarea, and never anything rendered. Descriptions arrive from
-           whoever created the event — anyone who knows the user's email can put
-           one on their calendar — and this one round-trips byte for byte:
-           stripping or unescaping it on the way in would quietly rewrite what
-           the user typed and then save the rewrite back. -->
-      <textarea rows="3" bind:value={value.description}></textarea>
-    </label>
+      <!-- The editor only ever receives DOMPurify-cleaned allowlist HTML.
+           Descriptions are invitation-controlled input inside a Tauri webview,
+           so raw calendar markup is never inserted into the DOM. -->
+      <RichTextEditor bind:value={value.description} />
+    </div>
 
-    <label class="field">
+    <label class="field section-start">
       <span class="lab">Calendar</span>
       <!-- `aria-label`, even though the wrapping `<label>` already names it:
            a label that wraps a `<select>` also wraps every `<option>`, so its
@@ -875,6 +873,10 @@
                 aria-label={isSelf ? 'Remove yourself from this event' : `Remove ${g.email}`}
                 onclick={() => (value.guests = removeGuest(value.guests, g.email))}
               >×</button>
+            {:else}
+              <!-- Keep every Optional control on the same column even when
+                   Google forbids removing the organizer. -->
+              <span class="xslot" aria-hidden="true"></span>
             {/if}
           </li>
         {/each}
@@ -992,30 +994,29 @@
          border-radius: 8px; padding: 12px 14px; box-shadow: 0 8px 28px rgba(0, 0, 0, .45);
          font-size: 12px; color: var(--text); }
 
-  form { display: flex; flex-direction: column; gap: 8px; }
+  form { display: flex; flex-direction: column; gap: 11px; }
 
-  .field { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+  .field { display: flex; flex-direction: column; gap: 5px; min-width: 0; }
+  .section-start { margin-top: 3px; }
   .lab { font-size: 9.5px; color: var(--muted); letter-spacing: .05em; }
 
-  .reminders { display: flex; flex-direction: column; gap: 4px; align-items: flex-start; }
+  .reminders { display: flex; flex-direction: column; gap: 6px; align-items: flex-start; }
   .reminder { display: flex; align-items: center; gap: 5px; width: 100%; font-size: 12px; }
   .reminder input[type='number'] { width: 56px; flex: none; }
   .reminder select { width: auto; flex: none; }
-  .unremind { font: inherit; font-size: 13px; color: var(--muted); cursor: pointer;
-              background: none; border: 0; padding: 0 2px; margin-left: auto; }
-  .unremind:hover { color: var(--text); }
+  .reminder > .x { margin-left: auto; }
   .remind { font: inherit; font-size: 11px; color: var(--muted); cursor: pointer;
             background: none; border: 1px solid var(--hairline); border-radius: 5px;
             padding: 2px 7px; }
   .remhint { font-size: 10px; color: var(--muted); opacity: .8; }
 
-  input, select, textarea {
+  input, select {
     font: inherit; font-size: 12px; color: var(--text);
     background: color-mix(in srgb, var(--text) 5%, transparent);
     border: 1px solid var(--hairline); border-radius: 5px;
     padding: 4px 6px; min-width: 0; width: 100%; box-sizing: border-box;
   }
-  input:focus, select:focus, textarea:focus { outline: 1px solid var(--accent); outline-offset: -1px; }
+  input:focus, select:focus { outline: 1px solid var(--accent); outline-offset: -1px; }
   /* The appearance/chevron rule is global now — App.svelte, and fix/56's
      commit message for why. Only the background shorthand's reset needs
      compensating here: it clears the global background-image, so the chevron
@@ -1034,7 +1035,6 @@
   .calrow { display: flex; align-items: center; gap: 7px; }
   .calrow select { flex: 1; min-width: 0; }
   .caldot { width: 10px; height: 10px; border-radius: 3px; flex: none; }
-  textarea { resize: vertical; line-height: 1.45; }
   .title { font-size: 13px; }
 
   .weekdayfield { display: flex; flex-direction: column; gap: 4px; }
@@ -1081,10 +1081,11 @@
 
   .hint { font-size: 10px; color: var(--muted); opacity: .85; line-height: 1.45; margin: 0; }
 
-  .guests { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+  .guests { display: flex; flex-direction: column; gap: 6px; min-width: 0; margin-top: 3px; }
   .guests ul { list-style: none; margin: 0; padding: 0; display: flex;
-               flex-direction: column; gap: 3px; }
-  .guest { display: flex; align-items: center; gap: 6px; font-size: 11px; min-width: 0; }
+               flex-direction: column; gap: 5px; }
+  .guest { display: grid; grid-template-columns: minmax(0, 1fr) auto 16px;
+           align-items: center; gap: 6px; font-size: 11px; min-width: 0; }
   /* The address takes what is left and truncates rather than wrapping: a long
      one would otherwise push the two controls beside it off the panel. */
   .addr { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis;
@@ -1092,8 +1093,10 @@
   .opt { display: flex; align-items: center; gap: 4px; color: var(--muted);
          font-size: 10px; cursor: pointer; flex: none; }
   .opt input { width: auto; }
-  .x { flex: none; font: inherit; font-size: 13px; line-height: 1; cursor: pointer;
-       background: none; border: 0; color: var(--muted); padding: 0 2px; }
+  .x, .xslot { flex: none; width: 16px; height: 18px; box-sizing: border-box; }
+  .x { display: inline-grid; place-items: center; font: inherit; font-size: 13px;
+       line-height: 1; cursor: pointer; background: none; border: 0;
+       color: var(--muted); padding: 0; }
   .x:hover { color: var(--text); }
 
   .addguest { display: flex; gap: 6px; position: relative; }

--- a/ui/src/lib/EventPopover.svelte
+++ b/ui/src/lib/EventPopover.svelte
@@ -7,7 +7,7 @@
   import { onMount, tick } from 'svelte';
   import { escapeCloses } from './dismiss.svelte';
   import { placePopover, type Rect } from './position';
-  import { descriptionSegments } from './sanitize';
+  import { renderedDescriptionHtml } from './sanitize';
   import { occurrenceDate, ruleInWords } from './eventform';
   import { isMachineAddress } from './organizer';
   import { respondToEvent, type Attendee, type EventDetail } from './eventdetail';
@@ -79,7 +79,9 @@
     oncopy: () => void;
   } = $props();
 
-  const segments = $derived(descriptionSegments(detail.description));
+  // This is already DOMPurify-cleaned allowlist HTML; raw calendar markup
+  // never reaches the `{@html}` block below.
+  const descriptionHtml = $derived(renderedDescriptionHtml(detail.description));
 
   const hhmm = (ms: number) => formatClock(ms, clockFormat());
 
@@ -447,16 +449,13 @@
                        onclick={() => copyField(cadence!, 'repeat schedule')}
                        >{cadence}</button></p>{/if}
 
-  {#if segments.length}
+  {#if descriptionHtml}
     <div class="desc">
       <button type="button" class="copydesc" aria-label="Copy description"
               data-copy-label="description"
               data-copy-value={detail.description ?? ''}
               onclick={() => copyField(detail.description ?? '', 'description')}>Copy</button>
-      <p>{#each segments as s}{#if s.kind === 'link'}<a
-              href={s.value} target="_blank" rel="noopener noreferrer"
-              data-copy-label="link" data-copy-value={s.value}>{s.value}</a
-          >{:else}{s.value}{/if}{/each}</p>
+      <div class="desc-content">{@html descriptionHtml}</div>
     </div>
   {/if}
 
@@ -612,12 +611,14 @@
 
   .desc { position: relative; white-space: pre-wrap; word-break: break-word; line-height: 1.5;
           margin: 0 0 10px; padding-right: 38px; }
-  .desc p { margin: 0; }
   .copydesc { appearance: none; -webkit-appearance: none; position: absolute; top: 0; right: 0;
               font: inherit; font-size: 9.5px; color: var(--muted); cursor: copy;
               border: 0; border-radius: 3px; background: none; padding: 1px 3px; }
   .copydesc:hover { color: var(--text); }
-  .desc a { color: var(--accent); }
+  :global(.desc p), :global(.desc div) { margin: 0 0 .55em; }
+  :global(.desc h2), :global(.desc h3) { margin: .25em 0 .45em; font-size: 1.1em; }
+  :global(.desc ul), :global(.desc ol) { margin: .35em 0; padding-left: 1.45em; }
+  :global(.desc a) { color: var(--accent); }
 
   .loc, .organizer { color: var(--muted); font-size: 11px; margin: 0 0 4px; }
   .conf { display: inline-block; color: var(--accent); font-size: 11px;

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -11,6 +11,7 @@
   let linkDraft = $state('https://');
   let linkError = $state(false);
   let linkRange: Range | null = null;
+  let rememberedListRange: Range | null = null;
   // Chromium may place typing back inside the preceding formatted element
   // when a collapsed range sits in an empty sibling text node. A temporary
   // zero-width caret anchor makes the sibling non-empty. It never enters the
@@ -20,12 +21,15 @@
 
   onMount(() => {
     if (!editor) return;
+    const rememberSelection = () => rememberListSelection();
+    document.addEventListener('selectionchange', rememberSelection);
     const safe = sanitizeDescriptionHtml(value);
     editor.innerHTML = safe;
     // Once this is an HTML editor, saving the original hostile markup while
     // displaying a cleaned version would be a trap. The visible, sanitised
     // document is the value from the moment the editor opens.
     value = safe;
+    return () => document.removeEventListener('selectionchange', rememberSelection);
   });
 
   function sync() {
@@ -76,6 +80,7 @@
   function settle(event: FocusEvent) {
     if (!editor) return;
     if (event.relatedTarget instanceof Node && richtext?.contains(event.relatedTarget)) return;
+    rememberedListRange = null;
     const safe = sanitizeDescriptionHtml(withoutCaretAnchors(editor.innerHTML));
     if (editor.innerHTML !== safe) editor.innerHTML = safe;
     value = safe;
@@ -119,7 +124,7 @@
    * line as a boundary on the surrounding list instead of a point inside
    * the li. Resolve that boundary to the item the caret visually belongs to. */
   function listItemAtBoundary(container: Node, offset: number, preferFollowing: boolean): HTMLLIElement | null {
-    if ((container instanceof HTMLUListElement || container instanceof HTMLOListElement) && editor?.contains(container)) {
+    if (container instanceof Element && editor?.contains(container)) {
       const following = boundaryChildListItem(container.childNodes[offset], true);
       const preceding = boundaryChildListItem(container.childNodes[offset - 1], false);
       const boundaryItem = preferFollowing ? following ?? preceding : preceding ?? following;
@@ -167,6 +172,33 @@
     const through = siblings.indexOf(last);
     if (from < 0 || through < from) return null;
     return { first, last, list, items: siblings.slice(from, through + 1) };
+  }
+
+  function rememberListSelection() {
+    if (!editor) return;
+    const selection = window.getSelection();
+    const range = selection?.rangeCount ? selection.getRangeAt(0) : null;
+    // An outside selection can be WebKit temporarily displacing the caret
+    // while the contenteditable still owns focus. Keep the last good list
+    // caret for that case; settle() clears it once focus genuinely leaves.
+    if (!range || !editor.contains(range.commonAncestorContainer)) return;
+    rememberedListRange = selectedListItems() ? range.cloneRange() : null;
+  }
+
+  function restoreRememberedListSelection(): boolean {
+    if (!editor || document.activeElement !== editor || !rememberedListRange) return false;
+    const selection = window.getSelection();
+    const current = selection?.rangeCount ? selection.getRangeAt(0) : null;
+    // A real caret in ordinary editor text must retain normal form traversal.
+    // The fallback is only for a selection WebKit moved outside the editor.
+    if (current && editor.contains(current.commonAncestorContainer)) return false;
+    if (!editor.contains(rememberedListRange.startContainer) || !editor.contains(rememberedListRange.endContainer)) {
+      rememberedListRange = null;
+      return false;
+    }
+    selection?.removeAllRanges();
+    selection?.addRange(rememberedListRange.cloneRange());
+    return selectionInsideOneListTree();
   }
 
   const listTag = (list: ListElement): 'ul' | 'ol' => list instanceof HTMLOListElement ? 'ol' : 'ul';
@@ -357,13 +389,15 @@
       outdentTopLevelItems(selected);
     }
     sync();
+    rememberListSelection();
     return true;
   }
 
   function listIndentKeydown(event: KeyboardEvent): boolean {
     let direction: ListIndent | null = null;
     const reverseTab = event.key === 'ISO_Left_Tab' || event.key === 'BackTab';
-    if ((event.key === 'Tab' || reverseTab) && !event.ctrlKey && !event.metaKey && !event.altKey) {
+    const tabKey = event.key === 'Tab' || reverseTab || event.code === 'Tab' || event.keyCode === 9;
+    if (tabKey && !event.ctrlKey && !event.metaKey && !event.altKey) {
       // WebKitGTK may expose Shift+Tab using GTK's reverse-tab key name,
       // with or without also retaining the Shift modifier.
       direction = event.shiftKey || reverseTab ? 'outdent' : 'indent';
@@ -371,7 +405,7 @@
       if (event.key === ']') direction = 'indent';
       else if (event.key === '[') direction = 'outdent';
     }
-    if (!direction || !selectionInsideOneListTree()) return false;
+    if (!direction || (!selectionInsideOneListTree() && !restoreRememberedListSelection())) return false;
     event.preventDefault();
     changeListIndent(direction);
     return true;

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -11,6 +11,12 @@
   let linkDraft = $state('https://');
   let linkError = $state(false);
   let linkRange: Range | null = null;
+  // Chromium may place typing back inside the preceding formatted element
+  // when a collapsed range sits in an empty sibling text node. A temporary
+  // zero-width caret anchor makes the sibling non-empty. It never enters the
+  // bound/saved HTML and is removed from the live DOM when focus leaves.
+  const CARET_ANCHOR = '\u200b';
+  const withoutCaretAnchors = (text: string) => text.split(CARET_ANCHOR).join('');
 
   onMount(() => {
     if (!editor) return;
@@ -23,7 +29,44 @@
   });
 
   function sync() {
-    if (editor) value = sanitizeDescriptionHtml(editor.innerHTML);
+    if (editor) value = sanitizeDescriptionHtml(withoutCaretAnchors(editor.innerHTML));
+  }
+
+  function input() {
+    if (!editor || !editor.textContent?.includes(CARET_ANCHOR)) {
+      sync();
+      return;
+    }
+
+    const selection = window.getSelection();
+    const active = selection?.rangeCount ? selection.getRangeAt(0) : null;
+    const startNode = active?.startContainer instanceof Text ? active.startContainer : null;
+    const endNode = active?.endContainer instanceof Text ? active.endContainer : null;
+    let startOffset = active?.startOffset ?? 0;
+    let endOffset = active?.endOffset ?? 0;
+    const walker = document.createTreeWalker(editor, NodeFilter.SHOW_TEXT);
+    const nodes: Text[] = [];
+    let node: Node | null;
+    while ((node = walker.nextNode())) nodes.push(node as Text);
+
+    for (const textNode of nodes) {
+      if (!textNode.data.includes(CARET_ANCHOR)) continue;
+      if (textNode === startNode) {
+        startOffset -= textNode.data.slice(0, startOffset).split(CARET_ANCHOR).length - 1;
+      }
+      if (textNode === endNode) {
+        endOffset -= textNode.data.slice(0, endOffset).split(CARET_ANCHOR).length - 1;
+      }
+      textNode.data = withoutCaretAnchors(textNode.data);
+    }
+
+    if (active && selection && startNode && endNode) {
+      active.setStart(startNode, Math.max(0, startOffset));
+      active.setEnd(endNode, Math.max(0, endOffset));
+      selection.removeAllRanges();
+      selection.addRange(active);
+    }
+    sync();
   }
 
   // `sync` keeps the bound value safe on every keystroke without moving the
@@ -33,7 +76,7 @@
   function settle(event: FocusEvent) {
     if (!editor) return;
     if (event.relatedTarget instanceof Node && richtext?.contains(event.relatedTarget)) return;
-    const safe = sanitizeDescriptionHtml(editor.innerHTML);
+    const safe = sanitizeDescriptionHtml(withoutCaretAnchors(editor.innerHTML));
     if (editor.innerHTML !== safe) editor.innerHTML = safe;
     value = safe;
   }
@@ -183,7 +226,142 @@
     sync();
   }
 
+  /** Markdown's line-opening shortcuts are useful here as gestures, not as a
+   * storage format. As soon as the marker's trailing space is pressed, remove
+   * the marker and ask the browser to create the same HTML the toolbar does.
+   * Requiring the marker to be the block's entire contents keeps prose such
+   * as "budget - " from unexpectedly turning into a list. */
+  function markdownBlockShortcut(event: KeyboardEvent): boolean {
+    if (event.isComposing || event.ctrlKey || event.metaKey || event.altKey || event.key !== ' ') {
+      return false;
+    }
+    if (!editor) return false;
+
+    const selection = window.getSelection();
+    const caret = selection?.rangeCount ? selection.getRangeAt(0) : null;
+    if (!caret?.collapsed || !editor.contains(caret.commonAncestorContainer)) return false;
+
+    const parent = caret.startContainer instanceof Element
+      ? caret.startContainer
+      : caret.startContainer.parentElement;
+    let block = parent?.closest('li, p, div, h2, h3') as HTMLElement | null;
+    if (!block || !editor.contains(block)) block = editor;
+    // A marker at the beginning of an existing list item is content, not a
+    // request to toggle the surrounding list off.
+    if (block.closest('li')) return false;
+
+    const before = document.createRange();
+    before.selectNodeContents(block);
+    try {
+      before.setEnd(caret.startContainer, caret.startOffset);
+    } catch {
+      return false;
+    }
+
+    const marker = before.toString();
+    if ((block.textContent ?? '') !== marker) return false;
+    const format = marker === '-' || marker === '*'
+      ? { command: 'insertUnorderedList' }
+      : marker === '1.'
+        ? { command: 'insertOrderedList' }
+        : marker === '#'
+          ? { command: 'formatBlock', argument: 'h3' }
+          : null;
+    if (!format) return false;
+
+    event.preventDefault();
+    before.deleteContents();
+    before.collapse(true);
+    selection?.removeAllRanges();
+    selection?.addRange(before);
+    if (format.argument === 'h3') {
+      const heading = document.createElement('h3');
+      heading.append(document.createElement('br'));
+      if (block === editor) editor.replaceChildren(heading);
+      else block.replaceWith(heading);
+      const inside = document.createRange();
+      inside.setStart(heading, 0);
+      inside.collapse(true);
+      selection?.removeAllRanges();
+      selection?.addRange(inside);
+      sync();
+      return true;
+    }
+    document.execCommand(format.command, false, format.argument);
+    sync();
+    return true;
+  }
+
+  /** Replace a just-completed inline Markdown-style run with safe rich HTML.
+   * The closing character is intercepted before it enters the document, and
+   * a temporary caret anchor after the new element gives typing an
+   * unformatted place to continue. Single stars intentionally mean bold here,
+   * matching the compact invocation shown to users; conventional **bold**
+   * works too.
+   * Markdown has no native underline marker, so this editor uses the common
+   * extension spelling ++underline++. */
+  function markdownInlineShortcut(event: KeyboardEvent): boolean {
+    if (event.isComposing || event.ctrlKey || event.metaKey || event.altKey) return false;
+    if (!editor || !['*', '_', '+'].includes(event.key)) return false;
+
+    const selection = window.getSelection();
+    const caret = selection?.rangeCount ? selection.getRangeAt(0) : null;
+    if (!caret?.collapsed || !editor.contains(caret.commonAncestorContainer)) return false;
+    if (!(caret.startContainer instanceof Text)) return false;
+
+    const textNode = caret.startContainer;
+    const before = textNode.data.slice(0, caret.startOffset);
+    const rules: Array<{
+      key: string;
+      pattern: RegExp;
+      openLength: number;
+      partialCloseLength: number;
+      tag: 'strong' | 'em' | 'u';
+    }> = [
+      { key: '*', pattern: /(?:^|[\s([{])\*\*([^*\n]+)\*$/, openLength: 2, partialCloseLength: 1, tag: 'strong' },
+      { key: '*', pattern: /(?:^|[\s([{])\*([^*\n]+)$/, openLength: 1, partialCloseLength: 0, tag: 'strong' },
+      { key: '_', pattern: /(?:^|[\s([{])_([^_\n]+)$/, openLength: 1, partialCloseLength: 0, tag: 'em' },
+      { key: '+', pattern: /(?:^|[\s([{])\+\+([^+\n]+)\+$/, openLength: 2, partialCloseLength: 1, tag: 'u' },
+    ];
+
+    for (const rule of rules) {
+      if (event.key !== rule.key) continue;
+      const match = before.match(rule.pattern);
+      const content = match?.[1];
+      if (!content || content.trim() !== content) continue;
+
+      const markerStart = caret.startOffset
+        - rule.openLength
+        - content.length
+        - rule.partialCloseLength;
+      if (markerStart < 0) continue;
+
+      event.preventDefault();
+      const prefix = withoutCaretAnchors(textNode.data.slice(0, markerStart));
+      const suffix = withoutCaretAnchors(textNode.data.slice(caret.startOffset));
+      const formatted = document.createElement(rule.tag);
+      formatted.textContent = content;
+      const tail = document.createElement('span');
+      const tailText = document.createTextNode(CARET_ANCHOR + suffix);
+      tail.append(tailText);
+      const nodes: Node[] = [];
+      if (prefix) nodes.push(document.createTextNode(prefix));
+      nodes.push(formatted, tail);
+      textNode.replaceWith(...nodes);
+
+      const after = document.createRange();
+      after.setStart(tailText, 1);
+      after.collapse(true);
+      selection?.removeAllRanges();
+      selection?.addRange(after);
+      sync();
+      return true;
+    }
+    return false;
+  }
+
   function editorKeydown(event: KeyboardEvent) {
+    if (markdownBlockShortcut(event) || markdownInlineShortcut(event)) return;
     autoLinkBeforeDelimiter(event);
     if (!(event.ctrlKey || event.metaKey) || event.altKey || event.shiftKey) return;
     const key = event.key.toLowerCase();
@@ -200,14 +378,18 @@
 
 <div class="richtext" bind:this={richtext} data-testid="description-editor" onfocusout={settle}>
   <div class="toolbar" role="toolbar" aria-label="Description formatting">
-    <button type="button" aria-label="Bold" aria-keyshortcuts="Control+B Meta+B" title="Bold (Ctrl+B)"
+    <button type="button" aria-label="Bold" aria-keyshortcuts="Control+B Meta+B" title="Bold (Ctrl+B or *text*)"
       onmousedown={(e) => e.preventDefault()} onclick={() => run('bold')}><b>B</b></button>
-    <button type="button" aria-label="Italic" aria-keyshortcuts="Control+I Meta+I" title="Italic (Ctrl+I)"
+    <button type="button" aria-label="Italic" aria-keyshortcuts="Control+I Meta+I" title="Italic (Ctrl+I or _text_)"
       onmousedown={(e) => e.preventDefault()} onclick={() => run('italic')}><i>I</i></button>
-    <button type="button" aria-label="Underline" aria-keyshortcuts="Control+U Meta+U" title="Underline (Ctrl+U)"
+    <button type="button" aria-label="Underline" aria-keyshortcuts="Control+U Meta+U" title="Underline (Ctrl+U or ++text++)"
       onmousedown={(e) => e.preventDefault()} onclick={() => run('underline')}><u>U</u></button>
-    <button type="button" aria-label="Heading" title="Heading"
+    <button type="button" aria-label="Heading" title="Heading (# then Space)"
       onmousedown={(e) => e.preventDefault()} onclick={heading}><b>H</b></button>
+    <button type="button" class="listbutton" aria-label="Bulleted list" title="Bulleted list (- or * then Space)"
+      onmousedown={(e) => e.preventDefault()} onclick={() => run('insertUnorderedList')}>•</button>
+    <button type="button" class="listbutton" aria-label="Numbered list" title="Numbered list (1. then Space)"
+      onmousedown={(e) => e.preventDefault()} onclick={() => run('insertOrderedList')}>1.</button>
     <button type="button" class="linkbutton" aria-label="Link"
       aria-keyshortcuts="Control+K Meta+K" title="Link (Ctrl+K)"
       onmousedown={(e) => e.preventDefault()} onclick={startLink}>Link</button>
@@ -239,7 +421,7 @@
     aria-label="Description"
     aria-multiline="true"
     data-placeholder="Add notes or an agenda"
-    oninput={sync}
+    oninput={input}
     onpaste={paste}
     ondrop={drop}
     onkeydown={editorKeydown}
@@ -265,6 +447,7 @@
     color: var(--text); background: color-mix(in srgb, var(--text) 8%, transparent);
   }
   .toolbar .linkbutton { width: auto; padding: 0 5px; }
+  .toolbar .listbutton { width: 27px; }
 
   .linkrow { display: flex; align-items: center; gap: 3px; padding: 4px;
              border-bottom: 1px solid var(--hairline); }

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -119,14 +119,13 @@
    * line as a boundary on the surrounding list instead of a point inside
    * the li. Resolve that boundary to the item the caret visually belongs to. */
   function listItemAtBoundary(container: Node, offset: number, preferFollowing: boolean): HTMLLIElement | null {
-    const direct = listItemAt(container);
-    if (direct) return direct;
-    if (!(container instanceof HTMLUListElement || container instanceof HTMLOListElement) || !editor?.contains(container)) {
-      return null;
+    if ((container instanceof HTMLUListElement || container instanceof HTMLOListElement) && editor?.contains(container)) {
+      const following = boundaryChildListItem(container.childNodes[offset], true);
+      const preceding = boundaryChildListItem(container.childNodes[offset - 1], false);
+      const boundaryItem = preferFollowing ? following ?? preceding : preceding ?? following;
+      if (boundaryItem) return boundaryItem;
     }
-    const following = boundaryChildListItem(container.childNodes[offset], true);
-    const preceding = boundaryChildListItem(container.childNodes[offset - 1], false);
-    return preferFollowing ? following ?? preceding : preceding ?? following;
+    return listItemAt(container);
   }
 
   function outerList(item: HTMLLIElement): ListElement | null {
@@ -363,8 +362,11 @@
 
   function listIndentKeydown(event: KeyboardEvent): boolean {
     let direction: ListIndent | null = null;
-    if (event.key === 'Tab' && !event.ctrlKey && !event.metaKey && !event.altKey) {
-      direction = event.shiftKey ? 'outdent' : 'indent';
+    const reverseTab = event.key === 'ISO_Left_Tab' || event.key === 'BackTab';
+    if ((event.key === 'Tab' || reverseTab) && !event.ctrlKey && !event.metaKey && !event.altKey) {
+      // WebKitGTK may expose Shift+Tab using GTK's reverse-tab key name,
+      // with or without also retaining the Shift modifier.
+      direction = event.shiftKey || reverseTab ? 'outdent' : 'indent';
     } else if ((event.ctrlKey || event.metaKey) && !event.altKey && !event.shiftKey) {
       if (event.key === ']') direction = 'indent';
       else if (event.key === '[') direction = 'outdent';

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -108,6 +108,27 @@
     return item && editor.contains(item) ? item as HTMLLIElement : null;
   }
 
+  function boundaryChildListItem(node: Node | undefined, fromStart: boolean): HTMLLIElement | null {
+    if (node instanceof HTMLLIElement) return node;
+    if (!(node instanceof Element)) return null;
+    const items = Array.from(node.querySelectorAll('li'));
+    return (fromStart ? items[0] : items[items.length - 1]) ?? null;
+  }
+
+  /** WebKit can expose a caret at the visual front or end of a list-item
+   * line as a boundary on the surrounding list instead of a point inside
+   * the li. Resolve that boundary to the item the caret visually belongs to. */
+  function listItemAtBoundary(container: Node, offset: number, preferFollowing: boolean): HTMLLIElement | null {
+    const direct = listItemAt(container);
+    if (direct) return direct;
+    if (!(container instanceof HTMLUListElement || container instanceof HTMLOListElement) || !editor?.contains(container)) {
+      return null;
+    }
+    const following = boundaryChildListItem(container.childNodes[offset], true);
+    const preceding = boundaryChildListItem(container.childNodes[offset - 1], false);
+    return preferFollowing ? following ?? preceding : preceding ?? following;
+  }
+
   function outerList(item: HTMLLIElement): ListElement | null {
     let list = item.closest('ul, ol') as ListElement | null;
     while (list && editor) {
@@ -123,8 +144,8 @@
     const selection = window.getSelection();
     const range = selection?.rangeCount ? selection.getRangeAt(0) : null;
     if (!range || !editor.contains(range.commonAncestorContainer)) return false;
-    const first = listItemAt(range.startContainer);
-    const last = listItemAt(range.endContainer);
+    const first = listItemAtBoundary(range.startContainer, range.startOffset, true);
+    const last = listItemAtBoundary(range.endContainer, range.endOffset, range.collapsed);
     return !!first && !!last && outerList(first) === outerList(last);
   }
 
@@ -136,8 +157,8 @@
     const selection = window.getSelection();
     const range = selection?.rangeCount ? selection.getRangeAt(0) : null;
     if (!range || !editor.contains(range.commonAncestorContainer)) return null;
-    const first = listItemAt(range.startContainer);
-    const last = listItemAt(range.endContainer);
+    const first = listItemAtBoundary(range.startContainer, range.startOffset, true);
+    const last = listItemAtBoundary(range.endContainer, range.endOffset, range.collapsed);
     const list = first?.parentElement;
     if (!first || !last || list !== last.parentElement || !(list instanceof HTMLUListElement || list instanceof HTMLOListElement)) {
       return null;
@@ -188,6 +209,30 @@
       range.selectNodeContents(fallback);
       range.collapse(false);
     }
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+
+  /** Convert a list-container boundary into a stable position inside its li
+   * before moving that li. This both survives the DOM move and preserves
+   * whether subsequent typing happens at the front or end of the line. */
+  function normalizeCollapsedListCaret(selected: ListItemSelection) {
+    const selection = window.getSelection();
+    const active = selection?.rangeCount ? selection.getRangeAt(0) : null;
+    if (!selection || !active?.collapsed || selected.first !== selected.last) return;
+    if (active.startContainer === selected.first || selected.first.contains(active.startContainer)) return;
+
+    const following = boundaryChildListItem(active.startContainer.childNodes[active.startOffset], true);
+    const range = document.createRange();
+    if (following === selected.first) {
+      range.setStart(selected.first, 0);
+    } else {
+      const nestedListIndex = Array.from(selected.first.childNodes).findIndex(
+        (child) => child instanceof HTMLUListElement || child instanceof HTMLOListElement,
+      );
+      range.setStart(selected.first, nestedListIndex < 0 ? selected.first.childNodes.length : nestedListIndex);
+    }
+    range.collapse(true);
     selection.removeAllRanges();
     selection.addRange(range);
   }
@@ -300,6 +345,7 @@
     const selected = selectedListItems();
     if (!selected) return false;
     editor?.focus();
+    normalizeCollapsedListCaret(selected);
     const bookmark = selectionBookmark();
     if (direction === 'indent') {
       if (!(selected.first.previousElementSibling instanceof HTMLLIElement)) return true;

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -1,0 +1,217 @@
+<script lang="ts">
+  import { onMount, tick } from 'svelte';
+  import { normalizeDescriptionHref, sanitizeDescriptionHtml } from './sanitize';
+
+  let { value = $bindable('') }: { value: string } = $props();
+
+  let editor = $state<HTMLDivElement>();
+  let linkInput = $state<HTMLInputElement>();
+  let linking = $state(false);
+  let linkDraft = $state('https://');
+  let linkError = $state(false);
+  let linkRange: Range | null = null;
+
+  onMount(() => {
+    if (!editor) return;
+    const safe = sanitizeDescriptionHtml(value);
+    editor.innerHTML = safe;
+    // Once this is an HTML editor, saving the original hostile markup while
+    // displaying a cleaned version would be a trap. The visible, sanitised
+    // document is the value from the moment the editor opens.
+    value = safe;
+  });
+
+  function sync() {
+    if (editor) value = sanitizeDescriptionHtml(editor.innerHTML);
+  }
+
+  function run(command: string, argument?: string) {
+    editor?.focus();
+    document.execCommand(command, false, argument);
+    sync();
+  }
+
+  function heading() {
+    const current = String(document.queryCommandValue('formatBlock')).toLowerCase();
+    run('formatBlock', current === 'h3' ? 'p' : 'h3');
+  }
+
+  async function startLink() {
+    const selection = window.getSelection();
+    const range = selection?.rangeCount ? selection.getRangeAt(0) : null;
+    linkRange = range && editor?.contains(range.commonAncestorContainer) ? range.cloneRange() : null;
+    const selected = selection?.toString().trim() ?? '';
+    linkDraft = normalizeDescriptionHref(selected) ?? 'https://';
+    linkError = false;
+    linking = true;
+    await tick();
+    linkInput?.focus();
+    linkInput?.select();
+  }
+
+  function cancelLink() {
+    linking = false;
+    linkError = false;
+    linkRange = null;
+    editor?.focus();
+  }
+
+  function applyLink() {
+    const href = normalizeDescriptionHref(linkDraft);
+    if (!href || !editor) {
+      linkError = true;
+      return;
+    }
+
+    editor.focus();
+    const selection = window.getSelection();
+    if (linkRange && selection) {
+      selection.removeAllRanges();
+      selection.addRange(linkRange);
+    }
+
+    const active = selection?.rangeCount ? selection.getRangeAt(0) : null;
+    if (active && !active.collapsed && editor.contains(active.commonAncestorContainer)) {
+      document.execCommand('createLink', false, href);
+    } else {
+      const anchor = document.createElement('a');
+      anchor.href = href;
+      anchor.textContent = href.replace(/^mailto:/i, '');
+      const range = active && editor.contains(active.commonAncestorContainer)
+        ? active
+        : document.createRange();
+      if (!active || !editor.contains(active.commonAncestorContainer)) range.selectNodeContents(editor);
+      range.collapse(false);
+      range.insertNode(anchor);
+      range.setStartAfter(anchor);
+      range.collapse(true);
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    }
+
+    linking = false;
+    linkError = false;
+    linkRange = null;
+    sync();
+  }
+
+  function paste(event: ClipboardEvent) {
+    event.preventDefault();
+    insertTransferred(event.clipboardData);
+  }
+
+  function insertTransferred(data: DataTransfer | null) {
+    const html = data?.getData('text/html') ?? '';
+    if (html) document.execCommand('insertHTML', false, sanitizeDescriptionHtml(html));
+    else document.execCommand('insertText', false, data?.getData('text/plain') ?? '');
+    sync();
+  }
+
+  function drop(event: DragEvent) {
+    // A drop is another HTML ingress path. Letting the browser handle it
+    // would briefly insert arbitrary markup (including an <img onerror>)
+    // before the input handler could clean the stored value.
+    event.preventDefault();
+    editor?.focus();
+    const range = document.caretRangeFromPoint(event.clientX, event.clientY);
+    const selection = window.getSelection();
+    if (range && editor?.contains(range.commonAncestorContainer) && selection) {
+      selection.removeAllRanges();
+      selection.addRange(range);
+    }
+    insertTransferred(event.dataTransfer);
+  }
+</script>
+
+<div class="richtext" data-testid="description-editor">
+  <div class="toolbar" role="toolbar" aria-label="Description formatting">
+    <button type="button" aria-label="Bold" title="Bold"
+      onmousedown={(e) => e.preventDefault()} onclick={() => run('bold')}><b>B</b></button>
+    <button type="button" aria-label="Italic" title="Italic"
+      onmousedown={(e) => e.preventDefault()} onclick={() => run('italic')}><i>I</i></button>
+    <button type="button" aria-label="Underline" title="Underline"
+      onmousedown={(e) => e.preventDefault()} onclick={() => run('underline')}><u>U</u></button>
+    <button type="button" aria-label="Heading" title="Heading"
+      onmousedown={(e) => e.preventDefault()} onclick={heading}><b>H</b></button>
+    <button type="button" class="linkbutton" aria-label="Link" title="Link (Ctrl+K)"
+      onmousedown={(e) => e.preventDefault()} onclick={startLink}>Link</button>
+  </div>
+  {#if linking}
+    <div class="linkrow">
+      <input
+        bind:this={linkInput}
+        bind:value={linkDraft}
+        aria-label="Link URL"
+        aria-invalid={linkError ? 'true' : undefined}
+        placeholder="https://example.com"
+        oninput={() => (linkError = false)}
+        onkeydown={(e) => {
+          if (e.key === 'Enter') { e.preventDefault(); applyLink(); }
+          else if (e.key === 'Escape') { e.preventDefault(); cancelLink(); }
+        }}
+      />
+      <button type="button" onclick={applyLink}>Apply</button>
+      <button type="button" class="cancel" aria-label="Cancel link" onclick={cancelLink}>×</button>
+    </div>
+  {/if}
+  <div
+    class="editor"
+    bind:this={editor}
+    contenteditable="true"
+    role="textbox"
+    tabindex="0"
+    aria-label="Description"
+    aria-multiline="true"
+    data-placeholder="Add notes or an agenda"
+    oninput={sync}
+    onpaste={paste}
+    ondrop={drop}
+    onkeydown={(e) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        void startLink();
+      }
+    }}
+  ></div>
+</div>
+
+<style>
+  .richtext {
+    overflow: hidden;
+    background: color-mix(in srgb, var(--text) 5%, transparent);
+    border: 1px solid var(--hairline);
+    border-radius: 5px;
+  }
+  .richtext:focus-within { outline: 1px solid var(--accent); outline-offset: -1px; }
+
+  .toolbar { display: flex; align-items: center; gap: 2px; padding: 3px 4px;
+             border-bottom: 1px solid var(--hairline); }
+  .toolbar button, .linkrow button {
+    width: 24px; height: 22px; padding: 0; border: 0; border-radius: 4px;
+    background: none; color: var(--muted); font: inherit; font-size: 11px; cursor: pointer;
+  }
+  .toolbar button:hover, .linkrow button:hover {
+    color: var(--text); background: color-mix(in srgb, var(--text) 8%, transparent);
+  }
+  .toolbar .linkbutton { width: auto; padding: 0 5px; }
+
+  .linkrow { display: flex; align-items: center; gap: 3px; padding: 4px;
+             border-bottom: 1px solid var(--hairline); }
+  .linkrow input { flex: 1; min-width: 0; width: auto; padding: 3px 5px;
+                   border: 1px solid var(--hairline); border-radius: 4px;
+                   background: color-mix(in srgb, var(--text) 4%, transparent);
+                   color: var(--text); font: inherit; font-size: 11px; }
+  .linkrow input:focus { outline: 1px solid var(--accent); outline-offset: -1px; }
+  .linkrow button:first-of-type { width: auto; padding: 0 7px; }
+  .linkrow .cancel { font-size: 14px; }
+
+  .editor { min-height: 84px; max-height: 190px; overflow-y: auto; padding: 7px;
+            color: var(--text); font: inherit; font-size: 12px; line-height: 1.45;
+            white-space: pre-wrap; overflow-wrap: anywhere; }
+  .editor:focus { outline: none; }
+  .editor:empty::before { content: attr(data-placeholder); color: var(--muted); opacity: .65; }
+  :global(.editor p), :global(.editor div) { margin: 0 0 .55em; }
+  :global(.editor h2), :global(.editor h3) { margin: .25em 0 .45em; font-size: 1.15em; }
+  :global(.editor ul), :global(.editor ol) { margin: .3em 0; padding-left: 1.5em; }
+  :global(.editor a) { color: var(--accent); }
+</style>

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -4,6 +4,7 @@
 
   let { value = $bindable('') }: { value: string } = $props();
 
+  let richtext = $state<HTMLDivElement>();
   let editor = $state<HTMLDivElement>();
   let linkInput = $state<HTMLInputElement>();
   let linking = $state(false);
@@ -23,6 +24,18 @@
 
   function sync() {
     if (editor) value = sanitizeDescriptionHtml(editor.innerHTML);
+  }
+
+  // `sync` keeps the bound value safe on every keystroke without moving the
+  // caret. Once focus leaves the whole editor, it is safe to reflect the
+  // auto-linked value back into the contenteditable as well. Moving from the
+  // document to the link row is internal and must preserve its saved range.
+  function settle(event: FocusEvent) {
+    if (!editor) return;
+    if (event.relatedTarget instanceof Node && richtext?.contains(event.relatedTarget)) return;
+    const safe = sanitizeDescriptionHtml(editor.innerHTML);
+    if (editor.innerHTML !== safe) editor.innerHTML = safe;
+    value = safe;
   }
 
   function run(command: string, argument?: string) {
@@ -121,19 +134,33 @@
     }
     insertTransferred(event.dataTransfer);
   }
+
+  function formatShortcut(event: KeyboardEvent) {
+    if (!(event.ctrlKey || event.metaKey) || event.altKey || event.shiftKey) return;
+    const key = event.key.toLowerCase();
+    const command = { b: 'bold', i: 'italic', u: 'underline' }[key];
+    if (command) {
+      event.preventDefault();
+      run(command);
+    } else if (key === 'k') {
+      event.preventDefault();
+      void startLink();
+    }
+  }
 </script>
 
-<div class="richtext" data-testid="description-editor">
+<div class="richtext" bind:this={richtext} data-testid="description-editor" onfocusout={settle}>
   <div class="toolbar" role="toolbar" aria-label="Description formatting">
-    <button type="button" aria-label="Bold" title="Bold"
+    <button type="button" aria-label="Bold" aria-keyshortcuts="Control+B Meta+B" title="Bold (Ctrl+B)"
       onmousedown={(e) => e.preventDefault()} onclick={() => run('bold')}><b>B</b></button>
-    <button type="button" aria-label="Italic" title="Italic"
+    <button type="button" aria-label="Italic" aria-keyshortcuts="Control+I Meta+I" title="Italic (Ctrl+I)"
       onmousedown={(e) => e.preventDefault()} onclick={() => run('italic')}><i>I</i></button>
-    <button type="button" aria-label="Underline" title="Underline"
+    <button type="button" aria-label="Underline" aria-keyshortcuts="Control+U Meta+U" title="Underline (Ctrl+U)"
       onmousedown={(e) => e.preventDefault()} onclick={() => run('underline')}><u>U</u></button>
     <button type="button" aria-label="Heading" title="Heading"
       onmousedown={(e) => e.preventDefault()} onclick={heading}><b>H</b></button>
-    <button type="button" class="linkbutton" aria-label="Link" title="Link (Ctrl+K)"
+    <button type="button" class="linkbutton" aria-label="Link"
+      aria-keyshortcuts="Control+K Meta+K" title="Link (Ctrl+K)"
       onmousedown={(e) => e.preventDefault()} onclick={startLink}>Link</button>
   </div>
   {#if linking}
@@ -166,12 +193,7 @@
     oninput={sync}
     onpaste={paste}
     ondrop={drop}
-    onkeydown={(e) => {
-      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'k') {
-        e.preventDefault();
-        void startLink();
-      }
-    }}
+    onkeydown={formatShortcut}
   ></div>
 </div>
 

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -228,7 +228,7 @@
 
   /** Markdown's line-opening shortcuts are useful here as gestures, not as a
    * storage format. As soon as the marker's trailing space is pressed, remove
-   * the marker and ask the browser to create the same HTML the toolbar does.
+   * the marker and create the same HTML the toolbar does.
    * Requiring the marker to be the block's entire contents keeps prose such
    * as "budget - " from unexpectedly turning into a list. */
   function markdownBlockShortcut(event: KeyboardEvent): boolean {
@@ -260,34 +260,33 @@
 
     const marker = before.toString();
     if ((block.textContent ?? '') !== marker) return false;
-    const format = marker === '-' || marker === '*'
-      ? { command: 'insertUnorderedList' }
+    const tag = marker === '-' || marker === '*'
+      ? 'ul'
       : marker === '1.'
-        ? { command: 'insertOrderedList' }
+        ? 'ol'
         : marker === '#'
-          ? { command: 'formatBlock', argument: 'h3' }
+          ? 'h3'
           : null;
-    if (!format) return false;
+    if (!tag) return false;
 
     event.preventDefault();
-    before.deleteContents();
-    before.collapse(true);
+    const replacement = document.createElement(tag);
+    const caretBlock = tag === 'ul' || tag === 'ol'
+      ? replacement.appendChild(document.createElement('li'))
+      : replacement;
+    caretBlock.append(document.createElement('br'));
+    if (block === editor) editor.replaceChildren(replacement);
+    else block.replaceWith(replacement);
+
+    // Do not leave this to execCommand's block-affinity rules: WebKit can put
+    // a collapsed selection after the new list, visually on the line below
+    // its empty bullet. Offset zero is immediately inside the <li>, before
+    // its placeholder break, so the first typed character has no leading gap.
+    const inside = document.createRange();
+    inside.setStart(caretBlock, 0);
+    inside.collapse(true);
     selection?.removeAllRanges();
-    selection?.addRange(before);
-    if (format.argument === 'h3') {
-      const heading = document.createElement('h3');
-      heading.append(document.createElement('br'));
-      if (block === editor) editor.replaceChildren(heading);
-      else block.replaceWith(heading);
-      const inside = document.createRange();
-      inside.setStart(heading, 0);
-      inside.collapse(true);
-      selection?.removeAllRanges();
-      selection?.addRange(inside);
-      sync();
-      return true;
-    }
-    document.execCommand(format.command, false, format.argument);
+    selection?.addRange(inside);
     sync();
     return true;
   }

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -92,6 +92,243 @@
     run('formatBlock', current === 'h3' ? 'p' : 'h3');
   }
 
+  type ListIndent = 'indent' | 'outdent';
+  type ListElement = HTMLUListElement | HTMLOListElement;
+  type ListItemSelection = {
+    first: HTMLLIElement;
+    last: HTMLLIElement;
+    list: ListElement;
+    items: HTMLLIElement[];
+  };
+
+  function listItemAt(node: Node): HTMLLIElement | null {
+    if (!editor) return null;
+    const element = node instanceof Element ? node : node.parentElement;
+    const item = element?.closest('li');
+    return item && editor.contains(item) ? item as HTMLLIElement : null;
+  }
+
+  function outerList(item: HTMLLIElement): ListElement | null {
+    let list = item.closest('ul, ol') as ListElement | null;
+    while (list && editor) {
+      const parent = list.parentElement?.closest('ul, ol') as ListElement | null;
+      if (!parent || !editor.contains(parent)) break;
+      list = parent;
+    }
+    return list;
+  }
+
+  function selectionInsideOneListTree(): boolean {
+    if (!editor) return false;
+    const selection = window.getSelection();
+    const range = selection?.rangeCount ? selection.getRangeAt(0) : null;
+    if (!range || !editor.contains(range.commonAncestorContainer)) return false;
+    const first = listItemAt(range.startContainer);
+    const last = listItemAt(range.endContainer);
+    return !!first && !!last && outerList(first) === outerList(last);
+  }
+
+  /** Both ends must be on one list level. A cross-level selection still
+   * belongs to the editor (and consumes Tab), but is left unchanged because
+   * there is no single unambiguous level to move as a unit. */
+  function selectedListItems(): ListItemSelection | null {
+    if (!editor) return null;
+    const selection = window.getSelection();
+    const range = selection?.rangeCount ? selection.getRangeAt(0) : null;
+    if (!range || !editor.contains(range.commonAncestorContainer)) return null;
+    const first = listItemAt(range.startContainer);
+    const last = listItemAt(range.endContainer);
+    const list = first?.parentElement;
+    if (!first || !last || list !== last.parentElement || !(list instanceof HTMLUListElement || list instanceof HTMLOListElement)) {
+      return null;
+    }
+    const siblings = Array.from(list.children).filter((child): child is HTMLLIElement => child instanceof HTMLLIElement);
+    const from = siblings.indexOf(first);
+    const through = siblings.indexOf(last);
+    if (from < 0 || through < from) return null;
+    return { first, last, list, items: siblings.slice(from, through + 1) };
+  }
+
+  const listTag = (list: ListElement): 'ul' | 'ol' => list instanceof HTMLOListElement ? 'ol' : 'ul';
+
+  function childList(item: HTMLLIElement, tag: 'ul' | 'ol'): ListElement | null {
+    return Array.from(item.children).find((child) => child.tagName.toLowerCase() === tag) as ListElement | null;
+  }
+
+  type SelectionBookmark = {
+    startContainer: Node;
+    startOffset: number;
+    endContainer: Node;
+    endOffset: number;
+  };
+
+  function selectionBookmark(): SelectionBookmark | null {
+    const selection = window.getSelection();
+    const range = selection?.rangeCount ? selection.getRangeAt(0) : null;
+    return range ? {
+      startContainer: range.startContainer,
+      startOffset: range.startOffset,
+      endContainer: range.endContainer,
+      endOffset: range.endOffset,
+    } : null;
+  }
+
+  function restoreSelection(bookmark: SelectionBookmark | null, fallback: HTMLLIElement) {
+    if (!editor) return;
+    const selection = window.getSelection();
+    if (!selection) return;
+    const range = document.createRange();
+    try {
+      if (!bookmark || !editor.contains(bookmark.startContainer) || !editor.contains(bookmark.endContainer)) {
+        throw new Error('selection endpoints left the editor');
+      }
+      range.setStart(bookmark.startContainer, bookmark.startOffset);
+      range.setEnd(bookmark.endContainer, bookmark.endOffset);
+    } catch {
+      range.selectNodeContents(fallback);
+      range.collapse(false);
+    }
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+
+  function indentListItems(selected: ListItemSelection) {
+    const previous = selected.first.previousElementSibling;
+    if (!(previous instanceof HTMLLIElement)) return;
+    const tag = listTag(selected.list);
+    let nested = childList(previous, tag);
+    if (!nested) {
+      nested = document.createElement(tag);
+      previous.append(nested);
+    }
+    for (const item of selected.items) nested.append(item);
+  }
+
+  function outdentNestedItems(selected: ListItemSelection, parentItem: HTMLLIElement) {
+    const outer = parentItem.parentElement;
+    if (!(outer instanceof HTMLUListElement || outer instanceof HTMLOListElement)) return;
+
+    // Items that followed the moved run must remain after it in reading
+    // order. Keeping them in the old nested list would render them before the
+    // newly outdented run, so carry them under its final item instead.
+    const following: HTMLLIElement[] = [];
+    let sibling = selected.last.nextElementSibling;
+    while (sibling instanceof HTMLLIElement) {
+      following.push(sibling);
+      sibling = sibling.nextElementSibling;
+    }
+    if (following.length) {
+      const tag = listTag(selected.list);
+      let carried = childList(selected.last, tag);
+      if (!carried) {
+        carried = document.createElement(tag);
+        selected.last.append(carried);
+      }
+      for (const item of following) carried.append(item);
+    }
+
+    let after: Element = parentItem;
+    for (const item of selected.items) {
+      after.after(item);
+      after = item;
+    }
+    if (!Array.from(selected.list.children).some((child) => child instanceof HTMLLIElement)) {
+      selected.list.remove();
+    }
+  }
+
+  function outdentTopLevelItems(selected: ListItemSelection) {
+    if (!editor) return;
+    const browserSelection = window.getSelection();
+    const active = browserSelection?.rangeCount ? browserSelection.getRangeAt(0) : null;
+    const startContainer = active?.startContainer;
+    const startOffset = active?.startOffset ?? 0;
+    const endContainer = active?.endContainer;
+    const endOffset = active?.endOffset ?? 0;
+
+    const trailing: HTMLLIElement[] = [];
+    let sibling = selected.last.nextElementSibling;
+    while (sibling instanceof HTMLLIElement) {
+      trailing.push(sibling);
+      sibling = sibling.nextElementSibling;
+    }
+    const afterList = trailing.length ? document.createElement(listTag(selected.list)) : null;
+    if (afterList) for (const item of trailing) afterList.append(item);
+
+    const replacements = new Map<Node, HTMLDivElement>();
+    const blocks = selected.items.map((item) => {
+      const block = document.createElement('div');
+      replacements.set(item, block);
+      while (item.firstChild) block.append(item.firstChild);
+      item.remove();
+      return block;
+    });
+
+    let after: Element = selected.list;
+    for (const block of blocks) {
+      after.after(block);
+      after = block;
+    }
+    if (afterList) after.after(afterList);
+    if (!Array.from(selected.list.children).some((child) => child instanceof HTMLLIElement)) {
+      selected.list.remove();
+    }
+
+    if (!active || !browserSelection || !startContainer || !endContainer) return;
+    const restored = document.createRange();
+    const restoredStart = replacements.get(startContainer) ?? startContainer;
+    const restoredEnd = replacements.get(endContainer) ?? endContainer;
+    const endpointLength = (node: Node) => node instanceof Text ? node.data.length : node.childNodes.length;
+    try {
+      restored.setStart(restoredStart, Math.min(startOffset, endpointLength(restoredStart)));
+      restored.setEnd(restoredEnd, Math.min(endOffset, endpointLength(restoredEnd)));
+      browserSelection.removeAllRanges();
+      browserSelection.addRange(restored);
+    } catch {
+      const fallback = blocks[0];
+      restored.selectNodeContents(fallback);
+      restored.collapse(true);
+      browserSelection.removeAllRanges();
+      browserSelection.addRange(restored);
+    }
+  }
+
+  /** Returns whether list editing owned the command. Indenting a first item
+   * is deliberately a handled no-op: focus stays in the document instead of
+   * Tab unexpectedly ejecting the user into the next form field. */
+  function changeListIndent(direction: ListIndent): boolean {
+    const selected = selectedListItems();
+    if (!selected) return false;
+    editor?.focus();
+    const bookmark = selectionBookmark();
+    if (direction === 'indent') {
+      if (!(selected.first.previousElementSibling instanceof HTMLLIElement)) return true;
+      indentListItems(selected);
+      restoreSelection(bookmark, selected.last);
+    } else if (selected.list.parentElement instanceof HTMLLIElement) {
+      outdentNestedItems(selected, selected.list.parentElement);
+      restoreSelection(bookmark, selected.last);
+    } else {
+      outdentTopLevelItems(selected);
+    }
+    sync();
+    return true;
+  }
+
+  function listIndentKeydown(event: KeyboardEvent): boolean {
+    let direction: ListIndent | null = null;
+    if (event.key === 'Tab' && !event.ctrlKey && !event.metaKey && !event.altKey) {
+      direction = event.shiftKey ? 'outdent' : 'indent';
+    } else if ((event.ctrlKey || event.metaKey) && !event.altKey && !event.shiftKey) {
+      if (event.key === ']') direction = 'indent';
+      else if (event.key === '[') direction = 'outdent';
+    }
+    if (!direction || !selectionInsideOneListTree()) return false;
+    event.preventDefault();
+    changeListIndent(direction);
+    return true;
+  }
+
   async function startLink() {
     const selection = window.getSelection();
     const range = selection?.rangeCount ? selection.getRangeAt(0) : null;
@@ -360,6 +597,7 @@
   }
 
   function editorKeydown(event: KeyboardEvent) {
+    if (listIndentKeydown(event)) return;
     if (markdownBlockShortcut(event) || markdownInlineShortcut(event)) return;
     autoLinkBeforeDelimiter(event);
     if (!(event.ctrlKey || event.metaKey) || event.altKey || event.shiftKey) return;
@@ -389,6 +627,12 @@
       onmousedown={(e) => e.preventDefault()} onclick={() => run('insertUnorderedList')}>•</button>
     <button type="button" class="listbutton" aria-label="Numbered list" title="Numbered list (1. then Space)"
       onmousedown={(e) => e.preventDefault()} onclick={() => run('insertOrderedList')}>1.</button>
+    <button type="button" class="indentbutton" aria-label="Outdent list item"
+      aria-keyshortcuts="Shift+Tab Control+[ Meta+[" title="Outdent list item (Shift+Tab or Ctrl+[)"
+      onmousedown={(e) => e.preventDefault()} onclick={() => changeListIndent('outdent')}>←</button>
+    <button type="button" class="indentbutton" aria-label="Indent list item"
+      aria-keyshortcuts="Tab Control+] Meta+]" title="Indent list item (Tab or Ctrl+])"
+      onmousedown={(e) => e.preventDefault()} onclick={() => changeListIndent('indent')}>→</button>
     <button type="button" class="linkbutton" aria-label="Link"
       aria-keyshortcuts="Control+K Meta+K" title="Link (Ctrl+K)"
       onmousedown={(e) => e.preventDefault()} onclick={startLink}>Link</button>
@@ -446,7 +690,7 @@
     color: var(--text); background: color-mix(in srgb, var(--text) 8%, transparent);
   }
   .toolbar .linkbutton { width: auto; padding: 0 5px; }
-  .toolbar .listbutton { width: 27px; }
+  .toolbar .listbutton, .toolbar .indentbutton { width: 27px; }
 
   .linkrow { display: flex; align-items: center; gap: 3px; padding: 4px;
              border-bottom: 1px solid var(--hairline); }

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -135,7 +135,56 @@
     insertTransferred(event.dataTransfer);
   }
 
-  function formatShortcut(event: KeyboardEvent) {
+  /** Turn the token immediately behind a collapsed caret into the same safe
+   * HTML `sync` would save, before the browser inserts its delimiter. Because
+   * the replacement has identical visible text and the selection is moved
+   * after its final node, Space/Enter lands outside the new anchor instead of
+   * extending it. A URL split across formatting nodes is left for blur/save —
+   * there is no single text token to replace without rewriting the selection. */
+  function autoLinkBeforeDelimiter(event: KeyboardEvent) {
+    if (event.isComposing || event.ctrlKey || event.metaKey || event.altKey) return;
+    if (event.key !== ' ' && event.key !== 'Enter') return;
+    if (!editor) return;
+
+    const selection = window.getSelection();
+    const caret = selection?.rangeCount ? selection.getRangeAt(0) : null;
+    if (!caret?.collapsed || !editor.contains(caret.commonAncestorContainer)) return;
+    if (!(caret.startContainer instanceof Text)) return;
+    const textNode = caret.startContainer;
+    if (textNode.parentElement?.closest('a')) return;
+
+    const before = textNode.data.slice(0, caret.startOffset);
+    const token = before.match(/\S+$/)?.[0];
+    if (!token) return;
+
+    // Start from textContent so characters such as `<` can never become HTML
+    // during detection. The sanitizer performs both conservative recognition
+    // and the final protocol allowlist.
+    const plain = document.createElement('span');
+    plain.textContent = token;
+    const linked = sanitizeDescriptionHtml(plain.innerHTML);
+    const template = document.createElement('template');
+    template.innerHTML = linked;
+    if (!template.content.querySelector('a')) return;
+
+    const replacement = document.createRange();
+    replacement.setStart(textNode, caret.startOffset - token.length);
+    replacement.setEnd(textNode, caret.startOffset);
+    replacement.deleteContents();
+    const last = template.content.lastChild;
+    if (!last) return;
+    replacement.insertNode(template.content);
+
+    const after = document.createRange();
+    after.setStartAfter(last);
+    after.collapse(true);
+    selection?.removeAllRanges();
+    selection?.addRange(after);
+    sync();
+  }
+
+  function editorKeydown(event: KeyboardEvent) {
+    autoLinkBeforeDelimiter(event);
     if (!(event.ctrlKey || event.metaKey) || event.altKey || event.shiftKey) return;
     const key = event.key.toLowerCase();
     const command = { b: 'bold', i: 'italic', u: 'underline' }[key];
@@ -193,7 +242,7 @@
     oninput={sync}
     onpaste={paste}
     ondrop={drop}
-    onkeydown={formatShortcut}
+    onkeydown={editorKeydown}
   ></div>
 </div>
 

--- a/ui/src/lib/sanitize.ts
+++ b/ui/src/lib/sanitize.ts
@@ -1,9 +1,12 @@
+import DOMPurify from 'dompurify';
+
 // Anyone who knows a user's email address can put an event on their
 // calendar, description included. That description renders inside a webview
 // that can invoke Tauri commands, so it is attacker-controlled input, not
-// display text. This module never produces HTML: it returns segments that
-// the component renders with `{#each}` and a plain `<a>`, so there is no
-// code path where `{@html}` could be reintroduced by a later edit.
+// trusted display markup. This module offers two deliberately safe outputs:
+// plain text/link segments for callers that want no formatting, and a tiny
+// allowlist of DOMPurify-cleaned HTML for the description viewer/editor.
+// Raw calendar HTML must never be handed to `{@html}` directly.
 
 export type Segment = { kind: 'text' | 'link'; value: string };
 
@@ -21,6 +24,88 @@ const URL_RE = /https?:\/\/[^\s<>"']+/gi;
 // function, not only the one found in review (see stripTags). Truncate
 // rather than reject: the popover should still show what fits.
 export const MAX_DESCRIPTION_LENGTH = 32 * 1024;
+
+/** Formatting the compact editor can author and the event reader can show.
+ * No images, media, inline styles, classes or arbitrary attributes: calendar
+ * descriptions are an invitation-sized document, not a miniature web page. */
+const DESCRIPTION_TAGS = [
+  'p', 'div', 'br', 'strong', 'b', 'em', 'i', 'u', 'h2', 'h3', 'a', 'ul', 'ol', 'li',
+];
+const DESCRIPTION_ATTRS = ['href', 'title'];
+
+/** Turn a toolbar/link-dialog value into a link we are prepared to render.
+ * A bare address or domain gets the friendly scheme a person meant; any
+ * explicitly supplied protocol outside http(s)/mailto is refused. */
+export function normalizeDescriptionHref(raw: string): string | null {
+  const value = raw.trim();
+  if (!value) return null;
+  if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) return `mailto:${value}`;
+  if (/^www\./i.test(value)) return `https://${value}`;
+  if (/^[a-z0-9-]+(?:\.[a-z0-9-]+)+(?:[/?#].*)?$/i.test(value)) return `https://${value}`;
+  if (/^https?:\/\/[^\s]+$/i.test(value) || /^mailto:[^\s@]+@[^\s@]+$/i.test(value)) {
+    return value;
+  }
+  return null;
+}
+
+/** DOMPurify is the security boundary; the DOM walk after it narrows links
+ * further and unwraps a rejected anchor without losing its visible words. */
+function descriptionTemplate(raw: string | null): HTMLTemplateElement {
+  const bounded = (raw ?? '').slice(0, MAX_DESCRIPTION_LENGTH);
+  const template = document.createElement('template');
+  template.innerHTML = String(DOMPurify.sanitize(bounded, {
+    ALLOWED_TAGS: DESCRIPTION_TAGS,
+    ALLOWED_ATTR: DESCRIPTION_ATTRS,
+  }));
+  for (const anchor of template.content.querySelectorAll('a')) {
+    const href = normalizeDescriptionHref(anchor.getAttribute('href') ?? '');
+    if (href) anchor.setAttribute('href', href);
+    else anchor.replaceWith(...Array.from(anchor.childNodes));
+  }
+  return template;
+}
+
+/** Safe, compact HTML suitable for saving back to a calendar and loading into
+ * the editor. It intentionally omits browsing-only target/rel attributes. */
+export function sanitizeDescriptionHtml(raw: string | null): string {
+  return descriptionTemplate(raw).innerHTML.trim();
+}
+
+/** Safe HTML for the read-only event popover. Existing and bare http(s) links
+ * open outside the app; unsafe schemes have already been unwrapped above. */
+export function renderedDescriptionHtml(raw: string | null): string {
+  const template = descriptionTemplate(raw);
+  const walker = document.createTreeWalker(template.content, NodeFilter.SHOW_TEXT);
+  const nodes: Text[] = [];
+  let node: Node | null;
+  while ((node = walker.nextNode())) nodes.push(node as Text);
+
+  for (const textNode of nodes) {
+    if (textNode.parentElement?.closest('a')) continue;
+    const source = textNode.data;
+    const url = /https?:\/\/[^\s<>"']+/gi;
+    let match: RegExpExecArray | null;
+    let last = 0;
+    const fragment = document.createDocumentFragment();
+    while ((match = url.exec(source))) {
+      fragment.append(source.slice(last, match.index));
+      const anchor = document.createElement('a');
+      anchor.href = match[0];
+      anchor.textContent = match[0];
+      fragment.append(anchor);
+      last = match.index + match[0].length;
+    }
+    if (last === 0) continue;
+    fragment.append(source.slice(last));
+    textNode.replaceWith(fragment);
+  }
+
+  for (const anchor of template.content.querySelectorAll('a')) {
+    anchor.setAttribute('target', '_blank');
+    anchor.setAttribute('rel', 'noopener noreferrer');
+  }
+  return template.innerHTML.trim();
+}
 
 // Step 2: everything else that looks like a tag is removed outright, in a
 // single forward pass. This runs on the raw markup, before any entity
@@ -42,9 +127,8 @@ export const MAX_DESCRIPTION_LENGTH = 32 * 1024;
 // a fixed scan from a quadratic one that just happens to be fast at 32KB.
 // Its output is plain stripped text — not entity-decoded, not link-checked —
 // so it is *not* a general-purpose safe-HTML utility: never pass its result
-// to `{@html}`. Always render a description through descriptionSegments,
-// which runs this as one step among several and returns segments a
-// component renders with `{#each}` instead.
+// to `{@html}`. Use descriptionSegments for inert text, or one of the
+// DOMPurify-backed HTML functions above when formatting is required.
 export function stripTags(input: string): string {
   let out = '';
   let i = 0;

--- a/ui/src/lib/sanitize.ts
+++ b/ui/src/lib/sanitize.ts
@@ -48,6 +48,72 @@ export function normalizeDescriptionHref(raw: string): string | null {
   return null;
 }
 
+// Deliberately narrower than "anything URL-like": active schemes never enter
+// the candidate set, while explicit http(s), www, domain-shaped text and
+// email addresses cover the things a person reasonably expects an editor to
+// recognise. The normaliser above remains the final scheme gate.
+const AUTO_LINK_RE = /\b(?:https?:\/\/|mailto:|www\.)[^\s<>"']+|\b[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,63}\b|\b(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}(?:[/?#][^\s<>"']*)?/gi;
+
+/** Sentence punctuation is not normally part of a link. Balanced closing
+ * brackets are retained for paths such as a Wikipedia title; unmatched ones
+ * are returned to the surrounding text. */
+function autoLinkParts(raw: string): { text: string; suffix: string } {
+  let text = raw;
+  let suffix = '';
+  const peel = () => {
+    suffix = text.slice(-1) + suffix;
+    text = text.slice(0, -1);
+  };
+
+  while (/[.,;:!?]$/.test(text)) peel();
+  for (const [open, close] of [['(', ')'], ['[', ']'], ['{', '}']] as const) {
+    const count = (value: string, needle: string) => value.split(needle).length - 1;
+    while (text.endsWith(close) && count(text, close) > count(text, open)) peel();
+  }
+  return { text, suffix };
+}
+
+/** Add anchors only to inert text nodes. Existing anchors are left alone, so
+ * repeated sanitisation is stable and can never nest links. All nodes and
+ * attributes are created through the DOM rather than interpolated as HTML. */
+function autoLinkText(template: HTMLTemplateElement) {
+  const walker = document.createTreeWalker(template.content, NodeFilter.SHOW_TEXT);
+  const nodes: Text[] = [];
+  let node: Node | null;
+  while ((node = walker.nextNode())) nodes.push(node as Text);
+
+  for (const textNode of nodes) {
+    if (textNode.parentElement?.closest('a')) continue;
+    const source = textNode.data;
+    const fragment = document.createDocumentFragment();
+    let cursor = 0;
+    let linked = false;
+    AUTO_LINK_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = AUTO_LINK_RE.exec(source))) {
+      // Do not make a safe-looking fragment clickable inside an explicitly
+      // supplied scheme token (`javascript:example.com`,
+      // `data:text/html,example.com`, and unknown schemes alike). Explicit
+      // http(s)/mailto candidates begin at the scheme and have no such prefix.
+      const prefixToken = source.slice(0, match.index).match(/\S*$/)?.[0] ?? '';
+      if (/^[a-z][a-z0-9+.-]*:/i.test(prefixToken)) continue;
+      const { text, suffix } = autoLinkParts(match[0]);
+      const href = normalizeDescriptionHref(text);
+      if (!href) continue;
+      fragment.append(source.slice(cursor, match.index));
+      const anchor = document.createElement('a');
+      anchor.setAttribute('href', href);
+      anchor.textContent = text;
+      fragment.append(anchor, suffix);
+      cursor = match.index + match[0].length;
+      linked = true;
+    }
+    if (!linked) continue;
+    fragment.append(source.slice(cursor));
+    textNode.replaceWith(fragment);
+  }
+}
+
 /** DOMPurify is the security boundary; the DOM walk after it narrows links
  * further and unwraps a rejected anchor without losing its visible words. */
 function descriptionTemplate(raw: string | null): HTMLTemplateElement {
@@ -68,37 +134,16 @@ function descriptionTemplate(raw: string | null): HTMLTemplateElement {
 /** Safe, compact HTML suitable for saving back to a calendar and loading into
  * the editor. It intentionally omits browsing-only target/rel attributes. */
 export function sanitizeDescriptionHtml(raw: string | null): string {
-  return descriptionTemplate(raw).innerHTML.trim();
+  const template = descriptionTemplate(raw);
+  autoLinkText(template);
+  return template.innerHTML.trim();
 }
 
-/** Safe HTML for the read-only event popover. Existing and bare http(s) links
- * open outside the app; unsafe schemes have already been unwrapped above. */
+/** Safe HTML for the read-only event popover. Recognised links open outside
+ * the app; unsafe schemes have already been unwrapped or left as plain text. */
 export function renderedDescriptionHtml(raw: string | null): string {
   const template = descriptionTemplate(raw);
-  const walker = document.createTreeWalker(template.content, NodeFilter.SHOW_TEXT);
-  const nodes: Text[] = [];
-  let node: Node | null;
-  while ((node = walker.nextNode())) nodes.push(node as Text);
-
-  for (const textNode of nodes) {
-    if (textNode.parentElement?.closest('a')) continue;
-    const source = textNode.data;
-    const url = /https?:\/\/[^\s<>"']+/gi;
-    let match: RegExpExecArray | null;
-    let last = 0;
-    const fragment = document.createDocumentFragment();
-    while ((match = url.exec(source))) {
-      fragment.append(source.slice(last, match.index));
-      const anchor = document.createElement('a');
-      anchor.href = match[0];
-      anchor.textContent = match[0];
-      fragment.append(anchor);
-      last = match.index + match[0].length;
-    }
-    if (last === 0) continue;
-    fragment.append(source.slice(last));
-    textNode.replaceWith(fragment);
-  }
+  autoLinkText(template);
 
   for (const anchor of template.content.querySelectorAll('a')) {
     anchor.setAttribute('target', '_blank');

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -4040,6 +4040,36 @@ test.describe('EventForm', () => {
     expect(saved.fields.description).not.toContain('href="javascript:');
   });
 
+  test('Space and Enter link a completed safe URL immediately and leave the caret after it', async ({ page }) => {
+    await open(page, 'create');
+    const editor = page.getByLabel('Description', { exact: true });
+
+    await editor.fill('extremelabs.io/docs');
+    await editor.press('Space');
+    const domain = editor.getByRole('link', { name: 'extremelabs.io/docs' });
+    await expect(domain).toHaveAttribute('href', 'https://extremelabs.io/docs');
+    await page.keyboard.type('after');
+    await expect(domain).toHaveText('extremelabs.io/docs');
+    await expect(editor).toContainText('extremelabs.io/docs after');
+
+    await editor.fill('https://example.com/agenda');
+    await editor.press('Enter');
+    const explicit = editor.getByRole('link', { name: 'https://example.com/agenda' });
+    await expect(explicit).toHaveAttribute('href', 'https://example.com/agenda');
+    await page.keyboard.type('Next line');
+    await expect(explicit).toHaveText('https://example.com/agenda');
+    await expect(editor).toContainText('Next line');
+  });
+
+  test('Space does not link a domain-shaped fragment inside an unsafe scheme', async ({ page }) => {
+    await open(page, 'create');
+    const editor = page.getByLabel('Description', { exact: true });
+    await editor.fill('javascript:example.com');
+    await editor.press('Space');
+    await expect(editor.locator('a')).toHaveCount(0);
+    await expect(editor).toContainText('javascript:example.com ');
+  });
+
   test('dropped rich text is sanitised before it enters the editor', async ({ page }) => {
     await open(page, 'create');
     const editor = page.getByLabel('Description', { exact: true });

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -4107,6 +4107,109 @@ test.describe('EventForm', () => {
     await expect(editor.locator('ul > li')).toHaveText('First point');
   });
 
+  test('Tab and bracket shortcuts indent and outdent list items without leaving the editor', async ({ page }) => {
+    await open(page, 'create');
+    const editor = page.getByLabel('Description', { exact: true });
+    await editor.pressSequentially('- ');
+    await page.keyboard.type('Parent');
+    await editor.press('Enter');
+    await page.keyboard.type('Child');
+
+    const topItems = editor.locator('ul').first().locator(':scope > li');
+    const nestedItem = editor.locator('ul > li > ul > li');
+    await editor.press('Tab');
+    await expect(topItems).toHaveCount(1);
+    await expect(nestedItem).toHaveText('Child');
+    await expect(editor).toBeFocused();
+
+    await editor.press('Shift+Tab');
+    await expect(topItems).toHaveCount(2);
+    await expect(topItems.nth(1)).toHaveText('Child');
+    await expect(editor).toBeFocused();
+
+    await editor.press('Control+]');
+    await expect(topItems).toHaveCount(1);
+    await expect(nestedItem).toHaveText('Child');
+    await editor.press('Control+[');
+    await expect(topItems).toHaveCount(2);
+    await expect(topItems.nth(1)).toHaveText('Child');
+
+    await editor.press('Control+]');
+    await page.getByRole('button', { name: 'Create' }).click();
+    const [saved] = await saves(page);
+    expect(saved.fields.description).toContain('<li>Parent<ul><li>Child</li></ul></li>');
+    expect(saved.fields.description).not.toContain('style=');
+  });
+
+  test('list indent controls preserve normal Tab navigation and cannot eject a first item', async ({ page }) => {
+    await open(page, 'create');
+    const editor = page.getByLabel('Description', { exact: true });
+    const box = page.getByTestId('description-editor');
+    await editor.pressSequentially('- ');
+    const before = await editor.evaluate((element) => element.innerHTML);
+
+    // There is no preceding item to nest under. The command is owned by the
+    // editor but deliberately changes nothing and does not move form focus.
+    await editor.press('Tab');
+    await expect(editor).toBeFocused();
+    expect(await editor.evaluate((element) => element.innerHTML)).toBe(before);
+    expect(await editor.evaluate((element) => {
+      const item = element.querySelector('li');
+      const range = window.getSelection()?.getRangeAt(0);
+      return range?.startContainer === item && range.startOffset === 0;
+    })).toBe(true);
+
+    await page.keyboard.type('Parent');
+    await editor.press('Enter');
+    await page.keyboard.type('Child');
+    const topItems = editor.locator('ul').first().locator(':scope > li');
+    await box.getByRole('button', { name: 'Indent list item' }).click();
+    await expect(topItems).toHaveCount(1);
+    await expect(editor.locator('ul > li > ul > li')).toHaveText('Child');
+    await box.getByRole('button', { name: 'Outdent list item' }).click();
+    await expect(topItems).toHaveCount(2);
+
+    // Ordered lists use the same semantic nesting, preserving their type.
+    await open(page, 'create');
+    await editor.pressSequentially('1. ');
+    await page.keyboard.type('One');
+    await editor.press('Enter');
+    await page.keyboard.type('Two');
+    await editor.press('Tab');
+    await expect(editor.locator('ol > li > ol > li')).toHaveText('Two');
+
+    // In ordinary description text, Tab still belongs to the form.
+    await open(page, 'create');
+    await editor.fill('Plain description');
+    await editor.press('Tab');
+    await expect(page.getByLabel('Calendar', { exact: true })).toBeFocused();
+  });
+
+  test('outdenting a top-level item exits the list and keeps its caret', async ({ page }) => {
+    await open(page, 'create');
+    const editor = page.getByLabel('Description', { exact: true });
+    await editor.pressSequentially('- ');
+    await page.keyboard.type('First');
+    await editor.press('Enter');
+    await page.keyboard.type('Second');
+
+    await editor.press('Shift+Tab');
+    expect(await editor.evaluate((element) => Array.from(element.children).map((child) => ({
+      tag: child.tagName,
+      text: child.textContent,
+    })))).toEqual([
+      { tag: 'UL', text: 'First' },
+      { tag: 'DIV', text: 'Second' },
+    ]);
+    await expect(editor).toBeFocused();
+
+    await page.keyboard.type(' continued');
+    await expect(editor.locator('ul > li')).toHaveText('First');
+    await expect(editor.locator(':scope > div')).toHaveText('Second continued');
+    await editor.press('Tab');
+    await expect(page.getByLabel('Calendar', { exact: true })).toBeFocused();
+  });
+
   test('completed inline Markdown-style runs format immediately without retaining markers', async ({ page }) => {
     await open(page, 'create');
     const editor = page.getByLabel('Description', { exact: true });

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -4008,6 +4008,38 @@ test.describe('EventForm', () => {
     expect(saved.fields.description).not.toContain('style=');
   });
 
+  test('Ctrl+U underlines the selection without requiring the Linux Unicode chord', async ({ page }) => {
+    await open(page, 'create');
+    const editor = page.getByLabel('Description', { exact: true });
+    await editor.fill('Agenda');
+    await editor.selectText();
+    await page.keyboard.press('Control+u');
+    await expect(editor.locator('u')).toHaveText('Agenda');
+  });
+
+  test('safe typed URLs auto-link while active schemes remain plain text', async ({ page }) => {
+    await open(page, 'create');
+    const editor = page.getByLabel('Description', { exact: true });
+    await editor.fill(
+      'Docs: extremelabs.io/docs, https://example.com/agenda. Do not link javascript:alert(1).',
+    );
+
+    // Leaving the whole rich editor reflects the already-safe bound value
+    // back into the contenteditable without disrupting an active caret.
+    await page.getByLabel('Title', { exact: true }).focus();
+    await expect(editor.getByRole('link', { name: 'extremelabs.io/docs' }))
+      .toHaveAttribute('href', 'https://extremelabs.io/docs');
+    await expect(editor.getByRole('link', { name: 'https://example.com/agenda' }))
+      .toHaveAttribute('href', 'https://example.com/agenda');
+    await expect(editor.locator('a[href^="javascript:"]')).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Create' }).click();
+    const [saved] = await saves(page);
+    expect(saved.fields.description).toContain('href="https://extremelabs.io/docs"');
+    expect(saved.fields.description).toContain('href="https://example.com/agenda"');
+    expect(saved.fields.description).not.toContain('href="javascript:');
+  });
+
   test('dropped rich text is sanitised before it enters the editor', async ({ page }) => {
     await open(page, 'create');
     const editor = page.getByLabel('Description', { exact: true });

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -4034,6 +4034,16 @@ test.describe('EventForm', () => {
     const editor = page.getByLabel('Description', { exact: true });
 
     await editor.pressSequentially('- ');
+    expect(await editor.evaluate((element) => {
+      const item = element.querySelector('ul > li');
+      const selection = window.getSelection();
+      const range = selection?.rangeCount ? selection.getRangeAt(0) : null;
+      return {
+        collapsed: range?.collapsed,
+        directlyBeforePlaceholder: range?.startContainer === item && range.startOffset === 0,
+        itemText: item?.textContent,
+      };
+    })).toEqual({ collapsed: true, directlyBeforePlaceholder: true, itemText: '' });
     await page.keyboard.type('Dash item');
     await expect(editor.locator('ul > li')).toHaveText('Dash item');
     await expect(editor).not.toContainText('- Dash item');
@@ -4061,6 +4071,40 @@ test.describe('EventForm', () => {
     await editor.press('Space');
     await expect(editor.locator('ul, ol')).toHaveCount(0);
     await expect(editor).toHaveText('Budget - ');
+  });
+
+  test('a Markdown bullet directly after a heading keeps the caret at the bullet', async ({ page }) => {
+    await open(page, 'create');
+    const editor = page.getByLabel('Description', { exact: true });
+
+    await editor.pressSequentially('# ');
+    await page.keyboard.type('Planning');
+    await editor.press('Enter');
+    await editor.pressSequentially('- ');
+
+    expect(await editor.evaluate((element) => {
+      const heading = element.querySelector('h3');
+      const item = element.querySelector('ul > li');
+      const selection = window.getSelection();
+      const range = selection?.rangeCount ? selection.getRangeAt(0) : null;
+      return {
+        headingText: heading?.textContent,
+        listFollowsHeading: heading?.nextElementSibling === item?.parentElement,
+        collapsed: range?.collapsed,
+        directlyBeforePlaceholder: range?.startContainer === item && range.startOffset === 0,
+        itemText: item?.textContent,
+      };
+    })).toEqual({
+      headingText: 'Planning',
+      listFollowsHeading: true,
+      collapsed: true,
+      directlyBeforePlaceholder: true,
+      itemText: '',
+    });
+
+    await page.keyboard.type('First point');
+    await expect(editor.locator('h3')).toHaveText('Planning');
+    await expect(editor.locator('ul > li')).toHaveText('First point');
   });
 
   test('completed inline Markdown-style runs format immediately without retaining markers', async ({ page }) => {

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -2290,6 +2290,17 @@ test.describe('EventPopover', () => {
     await expect(page.locator('.desc script')).toHaveCount(0);
   });
 
+  test('safe description formatting and links render as formatting', async ({ page }) => {
+    await page.goto(show('rich-description'));
+    const description = page.locator('.desc');
+    await expect(description.getByRole('heading', { name: 'Preparation' })).toBeVisible();
+    await expect(description.locator('strong')).toHaveText('quarterly numbers');
+    await expect(description.getByRole('link', { name: 'agenda' }))
+      .toHaveAttribute('href', 'https://example.com/agenda');
+    await expect(description.getByRole('link', { name: 'agenda' }))
+      .toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
   test('a one-off event offers no scope choice', async ({ page }) => {
     await page.goto(show('standup'));
     await expect(page.locator('.rsvp')).toBeVisible();
@@ -3948,16 +3959,101 @@ test.describe('EventForm', () => {
     await expect(page.getByTestId('guest-notice')).toContainText('4 guests');
   });
 
-  test('a description is rendered as text, never as markup', async ({ page }) => {
+  test('unsafe description markup is removed before it reaches the editor', async ({ page }) => {
     // Anyone who knows the user's email can put an event on their calendar,
     // description included, and this webview can invoke Tauri commands.
     await open(page, 'nasty-description');
     await expect(page.locator('img')).toHaveCount(0);
-    // And byte for byte: sanitising on the way *in* would rewrite what the
-    // author typed and then save the rewrite back over the real event —
-    // `stripTags` alone would leave this field empty.
-    await expect(page.getByLabel('Description', { exact: true }))
-      .toHaveValue('<img src=x onerror=alert(1)>');
+    await expect(page.getByLabel('Description', { exact: true })).toBeEmpty();
+  });
+
+  test('safe existing HTML is editable as formatted content', async ({ page }) => {
+    await open(page, 'rich-description');
+    const editor = page.getByLabel('Description', { exact: true });
+    await expect(editor.getByRole('heading', { name: 'Preparation' })).toBeVisible();
+    await expect(editor.locator('strong')).toHaveText('quarterly numbers');
+  });
+
+  test('the compact toolbar authors bold, italic, underline, heading and links', async ({ page }) => {
+    await open(page, 'create');
+    const box = page.getByTestId('description-editor');
+    const editor = page.getByLabel('Description', { exact: true });
+    await editor.fill('Agenda');
+
+    await editor.selectText();
+    await box.getByRole('button', { name: 'Bold' }).click();
+    await expect(editor.locator('b, strong')).toHaveText('Agenda');
+
+    await editor.selectText();
+    await box.getByRole('button', { name: 'Italic' }).click();
+    await expect(editor.locator('i, em')).toHaveText('Agenda');
+
+    await editor.selectText();
+    await box.getByRole('button', { name: 'Underline' }).click();
+    await expect(editor.locator('u')).toHaveText('Agenda');
+
+    await editor.selectText();
+    await box.getByRole('button', { name: 'Heading' }).click();
+    await expect(editor.locator('h3')).toContainText('Agenda');
+
+    await editor.selectText();
+    await box.getByRole('button', { name: 'Link' }).click();
+    await box.getByLabel('Link URL').fill('example.com/agenda');
+    await box.getByRole('button', { name: 'Apply' }).click();
+    await expect(editor.getByRole('link')).toHaveAttribute('href', 'https://example.com/agenda');
+
+    await page.getByRole('button', { name: 'Create' }).click();
+    const [saved] = await saves(page);
+    expect(saved.fields.description).toContain('href="https://example.com/agenda"');
+    expect(saved.fields.description).not.toContain('style=');
+  });
+
+  test('dropped rich text is sanitised before it enters the editor', async ({ page }) => {
+    await open(page, 'create');
+    const editor = page.getByLabel('Description', { exact: true });
+    await editor.evaluate((element) => {
+      const transfer = new DataTransfer();
+      transfer.setData(
+        'text/html',
+        '<img src=x onerror="window.__dropped = true"><strong>Agenda</strong>',
+      );
+      const rect = element.getBoundingClientRect();
+      element.dispatchEvent(new DragEvent('drop', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer: transfer,
+        clientX: rect.left + 8,
+        clientY: rect.top + 8,
+      }));
+    });
+    await expect(editor.locator('img')).toHaveCount(0);
+    await expect(editor.locator('strong')).toHaveText('Agenda');
+    expect(await page.evaluate(() => (window as any).__dropped)).toBeUndefined();
+  });
+
+  test('reminders use the guest-list remove control and no redundant heading', async ({ page }) => {
+    await open(page, 'with-guests');
+    await page.getByRole('button', { name: '+ Add notification' }).click();
+    await expect(page.getByText('Notify', { exact: true })).toHaveCount(0);
+
+    const reminderX = page.getByRole('button', { name: 'Remove reminder' });
+    const guestX = page.getByRole('button', { name: 'Remove petya@x.com' });
+    await expect(reminderX).toHaveText('×');
+    await expect(guestX).toHaveText('×');
+    await expect(reminderX).toHaveClass(/\bx\b/);
+    await expect(guestX).toHaveClass(/\bx\b/);
+  });
+
+  test('every guest reserves the remove column so Optional stays aligned', async ({ page }) => {
+    await open(page, 'with-guests');
+    const rows = page.locator('[data-testid="guests"] .guest');
+    await expect(rows).toHaveCount(5);
+    await expect(rows.locator(':scope > .x, :scope > .xslot')).toHaveCount(5);
+
+    const optionalX = await rows.locator('.opt').evaluateAll((labels) =>
+      labels.map((label) => Math.round(label.getBoundingClientRect().x)),
+    );
+    expect(Math.max(...optionalX) - Math.min(...optionalX)).toBeLessThanOrEqual(1);
   });
 
   test('a new event opens at the next half hour', async ({ page }) => {

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -4180,6 +4180,74 @@ test.describe('EventForm', () => {
     }
   });
 
+  test('Shift+Tab outdents a nested item from the front, middle, or end of its line', async ({ page }) => {
+    const cases = [
+      { position: 'front', expected: 'XChild' },
+      { position: 'middle', expected: 'ChXild' },
+      { position: 'end', expected: 'ChildX' },
+    ] as const;
+
+    for (const { position, expected } of cases) {
+      await open(page, 'create');
+      const editor = page.getByLabel('Description', { exact: true });
+      await editor.pressSequentially('- ');
+      await page.keyboard.type('Parent');
+      await editor.press('Enter');
+      await page.keyboard.type('Child');
+      await editor.press('Tab');
+
+      await editor.evaluate((element, caretPosition) => {
+        const nestedList = element.querySelector('ul > li > ul');
+        const item = nestedList?.querySelector(':scope > li');
+        const text = item?.firstChild;
+        if (!nestedList || !item || !(text instanceof Text)) throw new Error('expected a nested list item');
+
+        (element as HTMLElement).focus();
+        const range = document.createRange();
+        if (caretPosition === 'front') range.setStart(nestedList, 0);
+        else if (caretPosition === 'middle') range.setStart(text, 2);
+        else range.setStart(nestedList, 1);
+        range.collapse(true);
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+      }, position);
+
+      await editor.press('Shift+Tab');
+      await page.keyboard.type('X');
+      const topItems = editor.locator('ul').first().locator(':scope > li');
+      await expect(topItems).toHaveCount(2);
+      await expect(topItems.nth(1)).toHaveText(expected);
+      await expect(editor).toBeFocused();
+    }
+  });
+
+  test('WebKitGTK reverse Tab outdents instead of focusing the formatting toolbar', async ({ page }) => {
+    await open(page, 'create');
+    const editor = page.getByLabel('Description', { exact: true });
+    await editor.pressSequentially('- ');
+    await page.keyboard.type('Parent');
+    await editor.press('Enter');
+    await page.keyboard.type('Child');
+    await editor.press('Tab');
+
+    expect(await editor.evaluate((element) => {
+      const event = new KeyboardEvent('keydown', {
+        key: 'ISO_Left_Tab',
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      return { dispatched: element.dispatchEvent(event), prevented: event.defaultPrevented };
+    })).toEqual({ dispatched: false, prevented: true });
+
+    const topItems = editor.locator('ul').first().locator(':scope > li');
+    await expect(topItems).toHaveCount(2);
+    await expect(topItems.nth(1)).toHaveText('Child');
+    await expect(editor).toBeFocused();
+    await expect(page.getByRole('button', { name: 'Link' })).not.toBeFocused();
+  });
+
   test('list indent controls preserve normal Tab navigation and cannot eject a first item', async ({ page }) => {
     await open(page, 'create');
     const editor = page.getByLabel('Description', { exact: true });

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -4008,6 +4008,84 @@ test.describe('EventForm', () => {
     expect(saved.fields.description).not.toContain('style=');
   });
 
+  test('the compact toolbar authors bulleted and numbered lists', async ({ page }) => {
+    await open(page, 'create');
+    const box = page.getByTestId('description-editor');
+    const editor = page.getByLabel('Description', { exact: true });
+
+    await editor.fill('Bullet item');
+    await editor.selectText();
+    await box.getByRole('button', { name: 'Bulleted list' }).click();
+    await expect(editor.locator('ul > li')).toHaveText('Bullet item');
+
+    await editor.fill('Numbered item');
+    await editor.selectText();
+    await box.getByRole('button', { name: 'Numbered list' }).click();
+    await expect(editor.locator('ol > li')).toHaveText('Numbered item');
+
+    await page.getByRole('button', { name: 'Create' }).click();
+    const [saved] = await saves(page);
+    expect(saved.fields.description).toContain('<ol>');
+    expect(saved.fields.description).toContain('<li>Numbered item</li>');
+  });
+
+  test('Markdown-style line starters immediately become lists and a heading', async ({ page }) => {
+    await open(page, 'create');
+    const editor = page.getByLabel('Description', { exact: true });
+
+    await editor.pressSequentially('- ');
+    await page.keyboard.type('Dash item');
+    await expect(editor.locator('ul > li')).toHaveText('Dash item');
+    await expect(editor).not.toContainText('- Dash item');
+
+    await open(page, 'create');
+    await editor.pressSequentially('* ');
+    await page.keyboard.type('Star item');
+    await expect(editor.locator('ul > li')).toHaveText('Star item');
+    await expect(editor).not.toContainText('* Star item');
+
+    await open(page, 'create');
+    await editor.pressSequentially('1. ');
+    await page.keyboard.type('Ordered item');
+    await expect(editor.locator('ol > li')).toHaveText('Ordered item');
+    await expect(editor).not.toContainText('1. Ordered item');
+
+    await open(page, 'create');
+    await editor.pressSequentially('# ');
+    await page.keyboard.type('Planning');
+    await expect(editor.getByRole('heading', { name: 'Planning' })).toBeVisible();
+    await expect(editor).not.toContainText('# Planning');
+
+    // Markers only act as a complete line prefix, never in ordinary prose.
+    await editor.fill('Budget -');
+    await editor.press('Space');
+    await expect(editor.locator('ul, ol')).toHaveCount(0);
+    await expect(editor).toHaveText('Budget - ');
+  });
+
+  test('completed inline Markdown-style runs format immediately without retaining markers', async ({ page }) => {
+    await open(page, 'create');
+    const editor = page.getByLabel('Description', { exact: true });
+
+    await editor.pressSequentially('*bold* _italic_ ++underlined++ **also bold**');
+    await expect(editor.locator('strong')).toHaveCount(2);
+    await expect(editor.locator('strong').nth(0)).toHaveText('bold');
+    await expect(editor.locator('strong').nth(1)).toHaveText('also bold');
+    await expect(editor.locator('em')).toHaveText('italic');
+    await expect(editor.locator('u')).toHaveText('underlined');
+    await expect(editor).toHaveText('bold italic underlined also bold');
+
+    await page.getByRole('button', { name: 'Create' }).click();
+    const [saved] = await saves(page);
+    expect(saved.fields.description).toContain('<strong>bold</strong>');
+    expect(saved.fields.description).toContain('<em>italic</em>');
+    expect(saved.fields.description).toContain('<u>underlined</u>');
+    expect(saved.fields.description).not.toContain('*bold*');
+    expect(saved.fields.description).not.toContain('++underlined++');
+    expect(saved.fields.description).not.toContain('\u200b');
+    expect(saved.fields.description).not.toContain('<span');
+  });
+
   test('Ctrl+U underlines the selection without requiring the Linux Unicode chord', async ({ page }) => {
     await open(page, 'create');
     const editor = page.getByLabel('Description', { exact: true });

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -4141,6 +4141,45 @@ test.describe('EventForm', () => {
     expect(saved.fields.description).not.toContain('style=');
   });
 
+  test('Tab indents a list item from the front, middle, or end of its line', async ({ page }) => {
+    const cases = [
+      { position: 'front', expected: 'XChild' },
+      { position: 'middle', expected: 'ChXild' },
+      { position: 'end', expected: 'ChildX' },
+    ] as const;
+
+    for (const { position, expected } of cases) {
+      await open(page, 'create');
+      const editor = page.getByLabel('Description', { exact: true });
+      await editor.pressSequentially('- ');
+      await page.keyboard.type('Parent');
+      await editor.press('Enter');
+      await page.keyboard.type('Child');
+
+      await editor.evaluate((element, caretPosition) => {
+        const list = element.querySelector('ul');
+        const item = list?.querySelectorAll(':scope > li')[1];
+        const text = item?.firstChild;
+        if (!list || !item || !(text instanceof Text)) throw new Error('expected a two-item list');
+
+        (element as HTMLElement).focus();
+        const range = document.createRange();
+        if (caretPosition === 'front') range.setStart(list, 1);
+        else if (caretPosition === 'middle') range.setStart(text, 2);
+        else range.setStart(list, 2);
+        range.collapse(true);
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+      }, position);
+
+      await editor.press('Tab');
+      await page.keyboard.type('X');
+      await expect(editor.locator('ul > li > ul > li')).toHaveText(expected);
+      await expect(editor).toBeFocused();
+    }
+  });
+
   test('list indent controls preserve normal Tab navigation and cannot eject a first item', async ({ page }) => {
     await open(page, 'create');
     const editor = page.getByLabel('Description', { exact: true });

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -4248,6 +4248,75 @@ test.describe('EventForm', () => {
     await expect(page.getByRole('button', { name: 'Link' })).not.toBeFocused();
   });
 
+  test('Shift+Tab resolves list carets exposed at parent and editor boundaries', async ({ page }) => {
+    for (const boundary of ['parent', 'editor'] as const) {
+      await open(page, 'create');
+      const editor = page.getByLabel('Description', { exact: true });
+      await editor.evaluate((element, kind) => {
+        element.innerHTML = '<h3>Heading</h3><ul><li id="parent">Parent<ul><li>Child</li></ul></li></ul>';
+        const parent = element.querySelector('#parent');
+        if (!parent) throw new Error('expected a parent list item');
+        (element as HTMLElement).focus();
+        const range = document.createRange();
+        if (kind === 'parent') range.setStart(parent, 1);
+        else range.setStart(element, 2);
+        range.collapse(true);
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+      }, boundary);
+
+      await editor.press('Shift+Tab');
+      const topItems = editor.locator('ul').first().locator(':scope > li');
+      await expect(topItems).toHaveCount(2);
+      await expect(topItems.nth(1)).toHaveText('Child');
+      await expect(editor).toBeFocused();
+      await expect(page.getByRole('button', { name: 'Link' })).not.toBeFocused();
+    }
+  });
+
+  test('Shift+Tab restores a displaced WebKit list caret while Description still owns focus', async ({ page }) => {
+    await open(page, 'create');
+    const editor = page.getByLabel('Description', { exact: true });
+    await editor.pressSequentially('- ');
+    await page.keyboard.type('Parent');
+    await editor.press('Enter');
+    await page.keyboard.type('Child');
+    await editor.press('Tab');
+
+    const result = await editor.evaluate((element) => {
+      const childText = element.querySelector('ul > li > ul > li')?.firstChild;
+      const outsideText = document.querySelector('[aria-label="Link"]')?.firstChild;
+      if (!(childText instanceof Text) || !(outsideText instanceof Text)) throw new Error('expected probe text nodes');
+      const selection = window.getSelection();
+      const listCaret = document.createRange();
+      listCaret.setStart(childText, 2);
+      listCaret.collapse(true);
+      selection?.removeAllRanges();
+      selection?.addRange(listCaret);
+      document.dispatchEvent(new Event('selectionchange'));
+
+      // Match WebKit's observed transient state: the contenteditable remains
+      // focused but the document Selection points at text outside it.
+      const displaced = document.createRange();
+      displaced.setStart(outsideText, 0);
+      displaced.collapse(true);
+      selection?.removeAllRanges();
+      selection?.addRange(displaced);
+      document.dispatchEvent(new Event('selectionchange'));
+      const event = new KeyboardEvent('keydown', {
+        key: 'Unidentified', code: 'Tab', shiftKey: true, bubbles: true, cancelable: true,
+      });
+      element.dispatchEvent(event);
+      return { dispatched: !event.defaultPrevented, active: document.activeElement?.getAttribute('aria-label') };
+    });
+
+    expect(result).toEqual({ dispatched: false, active: 'Description' });
+    const topItems = editor.locator('ul').first().locator(':scope > li');
+    await expect(topItems).toHaveCount(2);
+    await expect(topItems.nth(1)).toHaveText('Child');
+  });
+
   test('list indent controls preserve normal Tab navigation and cannot eject a first item', async ({ page }) => {
     await open(page, 'create');
     const editor = page.getByLabel('Description', { exact: true });

--- a/ui/tests/fixtures.ts
+++ b/ui/tests/fixtures.ts
@@ -2264,13 +2264,19 @@ export const FIXTURES: Record<string, Record<string, any>> = {
       onclose: noop, onresponded: noop, onedit: noop, ondelete: noop,
     },
     // The raw description is already entity-encoded, as a hostile calendar
-    // invite's would be — `descriptionSegments` decodes it back to the
-    // literal string `<script>alert(1)</script>` as inert *text*, never as
-    // markup (see sanitize.spec.ts). Rendering that string via `{@html}`
-    // instead of `{#each}` would turn it back into a real (if inert)
-    // `<script>` element — exactly the regression Step 7 breaks on purpose.
+    // invite's would be. The rich renderer must keep it literal while still
+    // allowing real formatting tags in the fixture immediately below.
     'nasty-description': {
       detail: detail({ id: 2, description: '&lt;script&gt;alert(1)&lt;/script&gt;' }),
+      anchor: ANCHOR, occurrenceStartMs: MON + 9 * H, occurrenceEndMs: MON + 9 * H + 30 * 60_000,
+      onclose: noop, onresponded: noop, onedit: noop, ondelete: noop,
+    },
+    'rich-description': {
+      detail: detail({
+        id: 3,
+        description: '<h3>Preparation</h3><p>Review the <strong>quarterly numbers</strong> '
+          + 'and <a href="https://example.com/agenda">agenda</a>.</p>',
+      }),
       anchor: ANCHOR, occurrenceStartMs: MON + 9 * H, occurrenceEndMs: MON + 9 * H + 30 * 60_000,
       onclose: noop, onresponded: noop, onedit: noop, ondelete: noop,
     },
@@ -2603,15 +2609,20 @@ export const FIXTURES: Record<string, Record<string, any>> = {
       })),
       calendars: FORM_CALENDARS,
     },
-    // A description that is live markup if anything ever renders it, and that
-    // must survive the round trip through the form byte for byte — sanitising
-    // it on the way *in* would silently rewrite what its author typed and then
-    // save the rewrite back over the real event.
+    // A description that is live markup if inserted without sanitising.
     'nasty-description': {
       anchor: ANCHOR,
       initial: editing(detail({
         id: 12, title: 'Notes', can_edit: true,
         description: '<img src=x onerror=alert(1)>',
+      })),
+      calendars: FORM_CALENDARS,
+    },
+    'rich-description': {
+      anchor: ANCHOR,
+      initial: editing(detail({
+        id: 15, title: 'Planning', can_edit: true,
+        description: '<h3>Preparation</h3><p>Review the <strong>quarterly numbers</strong>.</p>',
       })),
       calendars: FORM_CALENDARS,
     },

--- a/ui/tests/sanitize.spec.ts
+++ b/ui/tests/sanitize.spec.ts
@@ -164,6 +164,28 @@ test.describe('rich description HTML', () => {
     );
   });
 
+  test('saved HTML auto-links safe URL shapes and leaves active schemes inert', async ({ page }) => {
+    const clean = await inBrowser(page, 'sanitizeDescriptionHtml',
+      'See extremelabs.io/docs, www.example.com, https://example.org/a_(b), '
+      + 'or person@example.com. Never javascript:example.net, '
+      + 'data:text/html,example.edu, or vbscript:www.example.gov.',
+    );
+    expect(clean).toContain('<a href="https://extremelabs.io/docs">extremelabs.io/docs</a>,');
+    expect(clean).toContain('<a href="https://www.example.com">www.example.com</a>,');
+    expect(clean).toContain('<a href="https://example.org/a_(b)">https://example.org/a_(b)</a>,');
+    expect(clean).toContain('<a href="mailto:person@example.com">person@example.com</a>.');
+    expect(clean).toContain('javascript:example.net');
+    expect(clean).toContain('data:text/html,example.edu');
+    expect(clean).toContain('vbscript:www.example.gov');
+    expect(clean).not.toContain('href="javascript:');
+    expect(clean).not.toContain('href="data:');
+  });
+
+  test('auto-linking is stable when sanitised more than once', async ({ page }) => {
+    const once = await inBrowser(page, 'sanitizeDescriptionHtml', 'Visit https://example.com/docs');
+    expect(await inBrowser(page, 'sanitizeDescriptionHtml', once)).toBe(once);
+  });
+
   test('friendly link input supports domains and email but refuses active schemes', () => {
     expect(normalizeDescriptionHref('example.com/agenda')).toBe('https://example.com/agenda');
     expect(normalizeDescriptionHref('person@example.com')).toBe('mailto:person@example.com');

--- a/ui/tests/sanitize.spec.ts
+++ b/ui/tests/sanitize.spec.ts
@@ -1,5 +1,8 @@
 import { test, expect } from '@playwright/test';
-import { descriptionSegments, stripTags, MAX_DESCRIPTION_LENGTH } from '../src/lib/sanitize';
+import {
+  MAX_DESCRIPTION_LENGTH, descriptionSegments, normalizeDescriptionHref,
+  stripTags,
+} from '../src/lib/sanitize';
 
 const text = (raw: string | null) =>
   descriptionSegments(raw).map((s) => s.value).join('');
@@ -109,5 +112,70 @@ test.describe('descriptionSegments', () => {
     // No '>' anywhere in the input, so nothing is a tag — the whole run is
     // kept as literal text, same as the old (slow) implementation produced.
     expect(out).toBe(input);
+  });
+});
+
+test.describe('rich description HTML', () => {
+  const inBrowser = async (
+    page: import('@playwright/test').Page,
+    method: 'sanitizeDescriptionHtml' | 'renderedDescriptionHtml',
+    raw: string,
+  ) => {
+    await page.goto('/tests/harness/index.html');
+    return page.evaluate(async ({ method, raw }) => {
+      const path = '/src/lib/sanitize.ts';
+      const module = await import(path);
+      return module[method](raw) as string;
+    }, { method, raw });
+  };
+
+  test('keeps only the formatting the editor offers', async ({ page }) => {
+    expect(await inBrowser(page, 'sanitizeDescriptionHtml',
+      '<h3>Agenda</h3><p><strong>Bold</strong> <em>italic</em> <u>under</u></p>',
+    )).toBe('<h3>Agenda</h3><p><strong>Bold</strong> <em>italic</em> <u>under</u></p>');
+  });
+
+  test('removes executable and visual payloads while keeping their safe words', async ({ page }) => {
+    const clean = await inBrowser(page, 'sanitizeDescriptionHtml',
+      '<script>alert(1)</script><img src=x onerror=alert(2)>'
+      + '<p style="position:fixed" onclick="alert(3)">Meeting notes</p>',
+    );
+    expect(clean).toBe('<p>Meeting notes</p>');
+    expect(clean).not.toContain('script');
+    expect(clean).not.toContain('onerror');
+    expect(clean).not.toContain('style');
+  });
+
+  test('unwraps unsafe anchors and preserves safe links', async ({ page }) => {
+    expect(await inBrowser(page, 'sanitizeDescriptionHtml', '<a href="javascript:alert(1)">notes</a>'))
+      .toBe('notes');
+    expect(await inBrowser(page, 'sanitizeDescriptionHtml', '<a href="https://example.com/agenda">notes</a>'))
+      .toBe('<a href="https://example.com/agenda">notes</a>');
+  });
+
+  test('read-only HTML linkifies a bare URL and hardens every anchor', async ({ page }) => {
+    const shown = await inBrowser(page, 'renderedDescriptionHtml',
+      '<strong>Join</strong> https://meet.google.com/abc',
+    );
+    expect(shown).toContain('<strong>Join</strong>');
+    expect(shown).toContain(
+      '<a href="https://meet.google.com/abc" target="_blank" rel="noopener noreferrer">'
+      + 'https://meet.google.com/abc</a>',
+    );
+  });
+
+  test('friendly link input supports domains and email but refuses active schemes', () => {
+    expect(normalizeDescriptionHref('example.com/agenda')).toBe('https://example.com/agenda');
+    expect(normalizeDescriptionHref('person@example.com')).toBe('mailto:person@example.com');
+    expect(normalizeDescriptionHref('data:text/html,hello')).toBeNull();
+  });
+
+  test('rich descriptions retain the same hard input bound', async ({ page }) => {
+    const clean = await inBrowser(
+      page,
+      'sanitizeDescriptionHtml',
+      `<strong>${'a'.repeat(MAX_DESCRIPTION_LENGTH * 2)}</strong>`,
+    );
+    expect(clean.length).toBeLessThanOrEqual(MAX_DESCRIPTION_LENGTH + '<strong></strong>'.length);
   });
 });


### PR DESCRIPTION
## Summary

- replace the raw description textarea with a compact rich-text editor for bold, italic, underline, headings, and links
- render safe description formatting in event details while sanitizing calendar-supplied, pasted, and dropped HTML through a strict DOMPurify allowlist
- remove the redundant Notify heading and reuse the guest-list remove control for reminders
- reserve a remove-control column for every guest so Optional stays aligned
- add modest spacing between fields and major form sections

## Security

Calendar descriptions are invitation-controlled input inside a Tauri webview. The editor and read-only renderer allow only lightweight text formatting, strip executable and visual payloads, validate link schemes, cap input size, and sanitize before untrusted pasted or dropped HTML enters the editable DOM.

## Testing

- `npm run check` — 0 errors and 0 warnings
- `npm run build`
- `npx playwright test --project=chromium` — 783 passed
- `npm audit --omit=dev` — 0 vulnerabilities
