### PR TITLE
feat(weather): show the forecast high in Fahrenheit or Celsius

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1489,6 +1489,7 @@ pub fn run() {
             settings::set_default_calendar,
             settings::set_default_event_duration,
             settings::set_time_format,
+            settings::set_temperature_unit,
             settings::set_week_start,
             settings::set_week_starts_today,
             settings::set_week_view_days,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -25,6 +25,7 @@ const TRAY_ICON_KEY: &str = "tray_icon";
 const QUIT_ON_CLOSE_KEY: &str = "quit_on_close";
 const AUTOSTART_KEY: &str = "autostart";
 const WEATHER_KEY: &str = "weather_enabled";
+const TEMPERATURE_UNIT_KEY: &str = "temperature_unit";
 const DISPLAY_TZ_KEY: &str = "display_timezone";
 const SECOND_TZ_KEY: &str = "second_timezone";
 
@@ -74,6 +75,31 @@ impl TimeFormat {
         match self {
             TimeFormat::H24 => "24h",
             TimeFormat::H12 => "12h",
+        }
+    }
+}
+
+/// Whether a temperature is drawn as `22°` or `72°` — Celsius or Fahrenheit.
+///
+/// [`TimeFormat`]'s reason, twice over: the set is closed, so [`set_temperature_unit`]
+/// needs no refusal path, and `weather::DayWeather` carries unrounded Celsius
+/// so this side can round once, in whichever unit this names, rather than
+/// rounding at fetch and converting a rounded number.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TemperatureUnit {
+    #[serde(rename = "celsius")]
+    Celsius,
+    #[serde(rename = "fahrenheit")]
+    Fahrenheit,
+}
+
+impl TemperatureUnit {
+    /// The stored spelling. The same strings the wire uses, so a row read by
+    /// eye in `sqlite3` says what the settings modal says.
+    fn as_str(self) -> &'static str {
+        match self {
+            TemperatureUnit::Celsius => "celsius",
+            TemperatureUnit::Fahrenheit => "fahrenheit",
         }
     }
 }
@@ -285,6 +311,11 @@ pub struct AppSettings {
     /// destination beyond the calendar providers, which is why the off
     /// switch exists and the settings hint names where the data comes from.
     pub weather_enabled: bool,
+    /// Whether the day headers' forecast high is drawn in Celsius or
+    /// Fahrenheit — Celsius by default, so no installed copy changes under
+    /// its user. Read by the same components as `weather_enabled` guards,
+    /// and only meaningful while that toggle is on.
+    pub temperature_unit: TemperatureUnit,
     /// Whether times are drawn as `13:30` or `1:30 PM`, everywhere the app
     /// prints one — event blocks, the filmstrip, the popover and the Week and
     /// Day hour gutter, which follows deliberately: a 12-hour reader given a
@@ -449,6 +480,13 @@ pub async fn read_settings(pool: &SqlitePool) -> AppSettings {
         // `notifications_enabled`'s polarity and reasoning: on unless
         // somebody turned it off.
         weather_enabled: weather_enabled(pool).await,
+        // Same "only a spelling this version writes moves the setting" rule
+        // as `week_start`: absent, garbage and a future spelling all land on
+        // Celsius, the unit omacal has always drawn.
+        temperature_unit: match read(pool, TEMPERATURE_UNIT_KEY).await.as_deref() {
+            Some("fahrenheit") => TemperatureUnit::Fahrenheit,
+            _ => TemperatureUnit::Celsius,
+        },
     }
 }
 
@@ -826,6 +864,21 @@ pub async fn set_time_format(
     Ok(read_settings(&state.pool).await)
 }
 
+/// Stores the temperature unit. Like [`set_time_format`] nothing is refused
+/// and the cache needs no refetch: `weather::DayWeather` carries unrounded
+/// Celsius regardless of this setting, so a toggle changes only how the
+/// headers round what is already cached.
+#[tauri::command]
+pub async fn set_temperature_unit(
+    state: tauri::State<'_, AppState>,
+    unit: TemperatureUnit,
+) -> Result<AppSettings, String> {
+    write(&state.pool, TEMPERATURE_UNIT_KEY, unit.as_str())
+        .await
+        .map_err(|e| crate::errors::user_facing(&e))?;
+    Ok(read_settings(&state.pool).await)
+}
+
 /// Stores the day a calendar-aligned week begins on and leaves rolling mode.
 /// Nothing to refuse: [`WeekStart`] has three variants and the select offers
 /// all three. The two writes are one user choice; the helper keeps that shape
@@ -937,6 +990,11 @@ mod tests {
             "absent is every install that predates this setting, and they all have the launch \
              entry already — landing anywhere else changes what their machine does at the \
              next login, without anybody asking for it"
+        );
+        assert_eq!(
+            s.temperature_unit,
+            TemperatureUnit::Celsius,
+            "the unit omacal has always drawn, so no installed copy changes under its user"
         );
     }
 
@@ -1205,6 +1263,26 @@ mod tests {
                 read_settings(&p).await.week_start,
                 WeekStart::Monday,
                 "{stored:?} is not a day this version writes",
+            );
+        }
+    }
+
+    /// Both spellings round-trip, and an unrecognised row reads as Celsius —
+    /// the same polarity rule [`the_week_start_round_trips_and_falls_back_to_monday`]
+    /// takes.
+    #[tokio::test]
+    async fn the_temperature_unit_round_trips_and_falls_back_to_celsius() {
+        let p = pool().await;
+        for unit in [TemperatureUnit::Fahrenheit, TemperatureUnit::Celsius] {
+            write(&p, TEMPERATURE_UNIT_KEY, unit.as_str()).await.unwrap();
+            assert_eq!(read_settings(&p).await.temperature_unit, unit);
+        }
+        for stored in ["", "Fahrenheit", "F", "kelvin", "🌡"] {
+            write(&p, TEMPERATURE_UNIT_KEY, stored).await.unwrap();
+            assert_eq!(
+                read_settings(&p).await.temperature_unit,
+                TemperatureUnit::Celsius,
+                "{stored:?} is not a spelling this version writes",
             );
         }
     }

--- a/src-tauri/src/weather.rs
+++ b/src-tauri/src/weather.rs
@@ -54,8 +54,13 @@ pub struct DayWeather {
     /// `fog` | `drizzle` | `rain` | `snow` | `thunder`. Decided here so the
     /// grouping is tested once, beside the table it was ported from.
     pub bucket: String,
-    pub tmax: i32,
-    pub tmin: i32,
+    /// **Celsius, unrounded** — the unit Open-Meteo answers in and the one
+    /// this side stays in, whichever unit the header ends up printing. The
+    /// rounding lives at the display end (`temperature.ts`) because it can
+    /// only happen once: rounding here and converting there turns 31.6°C
+    /// into 90°F, and 31.6°C is 89°F.
+    pub tmax: f64,
+    pub tmin: f64,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, serde::Deserialize, Default)]
@@ -135,8 +140,9 @@ pub(crate) fn parse_geocoding(raw: &str) -> Option<(f64, f64)> {
     Some((hit.get("latitude")?.as_f64()?, hit.get("longitude")?.as_f64()?))
 }
 
-/// Open-Meteo's daily forecast → our report. Temperatures round to whole
-/// degrees — a day header saying `31.6°` is a header showing off.
+/// Open-Meteo's daily forecast → our report. Temperatures pass through
+/// unrounded — the rounding happens once, at display, in whichever unit the
+/// header prints (see the note on `DayWeather::tmax`).
 pub(crate) fn parse_open_meteo(raw: &str, place: Option<String>) -> Option<WeatherReport> {
     let v: serde_json::Value = serde_json::from_str(raw).ok()?;
     let daily = v.get("daily")?;
@@ -158,8 +164,8 @@ pub(crate) fn parse_open_meteo(raw: &str, place: Option<String>) -> Option<Weath
         days.push(DayWeather {
             date: date.to_string(),
             bucket: bucket_for_code(code as u16).to_string(),
-            tmax: hi.round() as i32,
-            tmin: lo.round() as i32,
+            tmax: hi,
+            tmin: lo,
         });
     }
     (!days.is_empty()).then_some(WeatherReport { days, place })
@@ -174,9 +180,9 @@ pub(crate) fn cache_is_fresh(now_ms: i64, at_ms: i64, ttl_ms: i64) -> bool {
 /// dated from today. Deterministic — a demo screenshot taken twice shows the
 /// same sky — and offline, which is demo's whole promise.
 pub(crate) fn synthetic_report(today: jiff::civil::Date) -> WeatherReport {
-    const CYCLE: &[(u16, i32, i32)] = &[
-        (0, 31, 24), (2, 29, 23), (3, 27, 22), (61, 26, 22),
-        (95, 25, 21), (71, 2, -3), (1, 28, 22), (0, 30, 23),
+    const CYCLE: &[(u16, f64, f64)] = &[
+        (0, 31.6, 24.0), (2, 29.0, 23.0), (3, 27.0, 22.0), (61, 26.0, 22.0),
+        (95, 25.0, 21.0), (71, 2.0, -3.0), (1, 28.0, 22.0), (0, 30.0, 23.0),
     ];
     let days = CYCLE
         .iter()
@@ -405,10 +411,13 @@ mod tests {
         assert_eq!(bucket_for_code(42), "overcast");
     }
 
-    /// A real Open-Meteo daily answer, cut to two days. Rounding is part of
-    /// the contract: a header saying `31.6°` is a header showing off.
+    /// A real Open-Meteo daily answer, cut to two days. Unrounded is part of
+    /// the contract: the caller (`temperature.ts`) is the one that rounds,
+    /// once, in whichever unit it is printing — pinning `32` here would have
+    /// hidden the very bug (rounding twice, in two units) this shape exists
+    /// to avoid.
     #[test]
-    fn an_open_meteo_answer_becomes_rounded_bucketed_days() {
+    fn an_open_meteo_answer_becomes_unrounded_bucketed_days() {
         let raw = r#"{"daily":{
             "time":["2026-08-24","2026-08-25"],
             "weather_code":[3,95],
@@ -419,8 +428,8 @@ mod tests {
         assert_eq!(r.days.len(), 2);
         assert_eq!(r.days[0].date, "2026-08-24");
         assert_eq!(r.days[0].bucket, "overcast");
-        assert_eq!(r.days[0].tmax, 32);
-        assert_eq!(r.days[0].tmin, 26);
+        assert_eq!(r.days[0].tmax, 31.6);
+        assert_eq!(r.days[0].tmin, 25.5);
         assert_eq!(r.days[1].bucket, "thunder");
     }
 

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -33,6 +33,7 @@
   import { setClockFormat } from './lib/clock.svelte';
   import { setSecondZone } from './lib/secondzone.svelte';
   import { setWeekStartDay } from './lib/weekstartstore.svelte';
+  import { setTemperatureUnit } from './lib/tempunit.svelte';
   import ShortcutSheet from './lib/ShortcutSheet.svelte';
   import { SHORTCUT_LIST, type ShortcutId } from './lib/shortcuts';
   import Filmstrip from './lib/Filmstrip.svelte';
@@ -583,6 +584,7 @@
         defaultEventDurationMinutes = s.defaultEventDurationMinutes;
         setClockFormat(s.timeFormat);
         setSecondZone(s.secondTimezone);
+        setTemperatureUnit(s.temperatureUnit);
         if (weekViewChoices === weekBefore) applyWeekSettings(s, false);
         if (listModeChoices !== before) return; // superseded by the user's own choice
         listMode = s.listMode;
@@ -1666,6 +1668,7 @@
       defaultEventDurationMinutes = s.defaultEventDurationMinutes;
       setClockFormat(s.timeFormat);
       setSecondZone(s.secondTimezone);
+      setTemperatureUnit(s.temperatureUnit);
       weekViewChoices += 1;
       applyWeekSettings(s, true);
       // The weather toggle lives in the same modal; refetching on every

--- a/ui/src/lib/Filmstrip.svelte
+++ b/ui/src/lib/Filmstrip.svelte
@@ -5,6 +5,8 @@
   import { openConference, type UiEvent } from './api';
   import type { Rect } from './position';
   import { locationLabel, meetingUrl } from './location';
+  import { temperatureUnit } from './tempunit.svelte';
+  import { formatTemp } from './temperature';
   import WeatherGlyph from './WeatherGlyph.svelte';
   import { dateKey, type DayWeather } from './weather';
   import type { ListDay } from './filmstrip';
@@ -136,7 +138,7 @@
           {#if weather?.get(dateKey(d.startMs))}
             {@const wx = weather.get(dateKey(d.startMs))!}
             <span class="wx">
-              <WeatherGlyph bucket={wx.bucket} size={12} />{wx.tmax}°
+              <WeatherGlyph bucket={wx.bucket} size={12} />{formatTemp(wx.tmax, temperatureUnit())}°
             </span>
           {/if}
         </h2>

--- a/ui/src/lib/SettingsModal.svelte
+++ b/ui/src/lib/SettingsModal.svelte
@@ -13,12 +13,13 @@
     getSettings, listTimezones, minutesOf, msOfMinutes, setDefaultCalendar,
     setDefaultEventDuration, setStartOnLogin, START_ON_LOGIN_OPTIONS,
     setDisplayTimezone, setFallbackReminders, setNotificationsEnabled,
-    setQuitOnClose, setSecondTimezone, setSyncInterval, setTimeFormat, setTrayIcon,
-    setWeatherEnabled, setWeekStart,
+    setQuitOnClose, setSecondTimezone, setSyncInterval, setTemperatureUnit, setTimeFormat,
+    setTrayIcon, setWeatherEnabled, setWeekStart,
     setWeekStartsToday, setWeekViewDays,
     type AppSettings, type StartOnLogin, type WeekViewDays,
   } from './settings';
   import { formatClock, type TimeFormat } from './timefmt';
+  import type { TemperatureUnit } from './temperature';
   import type { WeekStartDay } from './weekstart';
 
   let {
@@ -320,6 +321,17 @@
     } catch (e) {
       note = { text: String(e), kind: 'error' };
       settings = settings ? { ...settings } : null;
+    }
+  }
+
+  /** Same shape as `saveTimeFormat`: nothing to refuse, `TemperatureUnit` has
+   *  no third variant a select could send. */
+  async function saveTemperatureUnit(unit: TemperatureUnit) {
+    try {
+      settings = await setTemperatureUnit(unit);
+      onsettingschange?.(settings);
+    } catch (e) {
+      note = { text: String(e), kind: 'error' };
     }
   }
 
@@ -843,6 +855,33 @@
         address; turning this off ends the only network traffic omacal makes
         beyond your calendar providers.
       </p>
+
+      {#if settings?.weatherEnabled}
+        <div class="row">
+          <label class="lab" for="temperature-unit">Show temperature as</label>
+          <div class="inline">
+            <select
+              id="temperature-unit"
+              disabled={!settings}
+              value={settings?.temperatureUnit ?? 'celsius'}
+              onchange={(e) =>
+                saveTemperatureUnit(
+                  (e.currentTarget as HTMLSelectElement).value as TemperatureUnit,
+                )}
+            >
+              <!-- Each option prints a temperature rather than naming the
+                   scale, `time-format`'s reason: "Celsius" is a word you have
+                   to translate and `22°C` is the thing itself. -->
+              <option value="celsius">22°C</option>
+              <option value="fahrenheit">72°F</option>
+            </select>
+          </div>
+        </div>
+        <p class="hint">
+          The day headers stay a bare number, same as always — this only
+          decides which scale it's read in.
+        </p>
+      {/if}
 
     {:else if tab === 'Calendars'}
       <!-- **The same rows the header's popover shows, from the same

--- a/ui/src/lib/WeekGrid.svelte
+++ b/ui/src/lib/WeekGrid.svelte
@@ -2,6 +2,8 @@
 <script lang="ts">
   import { clockFormat } from './clock.svelte';
   import { gutterWidth, secondZone } from './secondzone.svelte';
+  import { temperatureUnit } from './tempunit.svelte';
+  import { formatTemp } from './temperature';
   import WeatherGlyph from './WeatherGlyph.svelte';
   import { dateKey, type DayWeather } from './weather';
   import { gutterLabel, zoneAbbrev, zoneGutterLabel } from './timefmt';
@@ -994,7 +996,7 @@
                Absent for any day the forecast does not cover — the past,
                the far future — so the header never guesses. -->
           <span class="wx">
-            <WeatherGlyph bucket={wx.bucket} size={15} />{wx.tmax}°
+            <WeatherGlyph bucket={wx.bucket} size={15} />{formatTemp(wx.tmax, temperatureUnit())}°
           </span>
         {/if}
       </span>

--- a/ui/src/lib/settings.ts
+++ b/ui/src/lib/settings.ts
@@ -1,5 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 
+import type { TemperatureUnit } from './temperature';
 import type { TimeFormat } from './timefmt';
 import type { WeekStartDay } from './weekstart';
 
@@ -90,6 +91,11 @@ export type AppSettings = {
    *  the Omarchy widget's location or the IP), because this is the one
    *  network destination beyond the calendar providers. */
   weatherEnabled: boolean;
+  /** Whether the forecast high is drawn in Celsius or Fahrenheit — Celsius by
+   *  default. Read by `WeekGrid` and `Filmstrip` through the
+   *  `tempunit.svelte.ts` rune, for `timeFormat`'s reason: both print a
+   *  temperature and neither owns the preference. */
+  temperatureUnit: TemperatureUnit;
   /** The IANA zone every time in the app reads in, or `null` for the
    *  system's. Applied by exporting `TZ` before the webview starts, which is
    *  why changing it restarts omacal — the JS engine and libc both capture
@@ -140,6 +146,12 @@ export const setStartOnLogin = (mode: StartOnLogin) =>
  *  so the headers change while the modal is still open. */
 export const setWeatherEnabled = (on: boolean) =>
   invoke<AppSettings>('set_weather_enabled', { on });
+
+/** Stores the temperature unit. Nothing is refetched: the cache is already
+ *  unrounded Celsius regardless of this setting, so the headers just round
+ *  differently on the next paint. */
+export const setTemperatureUnit = (unit: TemperatureUnit) =>
+  invoke<AppSettings>('set_temperature_unit', { unit });
 
 /** Stores the clock format. Nothing is refused: `settings::TimeFormat` has two
  *  variants and the select offers both, so there is no third value to turn

--- a/ui/src/lib/temperature.ts
+++ b/ui/src/lib/temperature.ts
@@ -1,0 +1,19 @@
+// Printing a temperature — the one place in the app that rounds a Celsius
+// reading and decides whether it prints as `72°` or `22°`.
+//
+// The backend (`weather::DayWeather`) carries the forecast unrounded and
+// always in Celsius, deliberately: rounding once, here, in whichever unit
+// this prints, is the only way `31.6°C` doesn't become `90°F` when the true
+// converted value is `89°F`. Converting an already-rounded `32°C` gets the
+// wrong answer about one time in two.
+
+/** The stored preference. The same two spellings the settings table holds and
+ *  `settings::TemperatureUnit` serialises, so no layer translates. */
+export type TemperatureUnit = 'celsius' | 'fahrenheit';
+
+/** A raw Celsius reading, rounded to the whole degree the header prints —
+ *  a day header saying `31.6°` is a header showing off, in either unit. */
+export function formatTemp(celsius: number, unit: TemperatureUnit): string {
+  const value = unit === 'fahrenheit' ? celsius * (9 / 5) + 32 : celsius;
+  return `${Math.round(value)}`;
+}

--- a/ui/src/lib/tempunit.svelte.ts
+++ b/ui/src/lib/tempunit.svelte.ts
@@ -1,0 +1,19 @@
+// The chosen temperature unit as the rest of the UI reads it.
+//
+// A module-level rune for `clock.svelte.ts`'s reason: `WeekGrid` and
+// `Filmstrip` both print a forecast high and neither owns the preference —
+// threading it as a prop means two components forwarding a value that is
+// really Settings'.
+//
+// Seeded and kept fresh by `App`, the only writer. A failure to read it
+// leaves the Celsius omacal has always drawn.
+import type { TemperatureUnit } from './temperature';
+
+const state = $state<{ unit: TemperatureUnit }>({ unit: 'celsius' });
+
+/** What to print. Read at render time, so a change repaints every forecast
+ *  high in the app without any of them subscribing to anything. */
+export const temperatureUnit = () => state.unit;
+
+/** `App` only. Called on startup and after every settings change. */
+export const setTemperatureUnit = (u: TemperatureUnit) => (state.unit = u);

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -3486,6 +3486,104 @@ test.describe('App: the clock format', () => {
 });
 
 /**
+ * The temperature unit, from the select in Settings to the forecast high in
+ * the day headings.
+ *
+ * Deliberately end-to-end rather than a second table beside
+ * `temperature.spec.ts`: the arithmetic is proved there, and what can still be
+ * wrong is the wiring. `App` seeds the `tempunit.svelte.ts` rune in **two**
+ * places — once from the startup read of settings, once from the settings
+ * modal's `onsettingschange` — and `components.spec.ts` reaches neither, since
+ * it mounts `WeekGrid` alone and drives the rune directly through
+ * `__setTemperatureUnit`. That proves the conversion and nothing about who
+ * calls it.
+ *
+ * The two call sites need separate instruments, because the rune's own default
+ * is Celsius: an `App` that never seeded it on startup draws exactly what one
+ * that did draws, so the opening headers can witness nothing. Only a session
+ * that *begins* with Fahrenheit already stored can tell those apart, which is
+ * what the reload case below is for.
+ */
+test.describe('App: the temperature unit', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.clock.setFixedTime(APP_NOW);
+  });
+
+  /** The forecast highs in Week's day headers. `APP_WEATHER` covers the Monday
+   *  the app opens on and no other day, so the count is part of the claim: a
+   *  lookup that painted every header the same sky would draw seven of these,
+   *  not one. (`components.spec.ts` pins the same premise with `toHaveCount(3)`
+   *  against its own three-day fixture.) */
+  const highs = (page: Page) => page.locator('.head .wx');
+
+  const chooseUnit = async (page: Page, label: string) => {
+    await page.getByRole('button', { name: 'Menu' }).click();
+    await page.getByRole('button', { name: 'Settings…' }).click();
+    const modal = page.getByRole('dialog', { name: 'Settings' });
+    await modal.locator('#temperature-unit').selectOption({ label });
+    await page.keyboard.press('Escape');
+    await expect(modal).toHaveCount(0);
+  };
+
+  test('the headers open on Celsius, on the covered day alone', async ({ page }) => {
+    await page.goto(app('weather'));
+    await expect(highs(page)).toHaveCount(1);
+    await expect(highs(page).first()).toHaveText('31°');
+  });
+
+  /**
+   * **Without a restart.** 31°C is 87.8°F, so a header that converted an
+   * already-rounded 31° would print 87° and redden here — the same pair
+   * `components.spec.ts` pins, arriving through the settings modal rather
+   * than through a direct call to the rune.
+   */
+  test('choosing Fahrenheit repaints the day header immediately', async ({ page }) => {
+    await page.goto(app('weather'));
+    await expect(highs(page).first()).toHaveText('31°');
+
+    await chooseUnit(page, '72°F');
+
+    await expect(highs(page).first()).toHaveText('88°');
+  });
+
+  /** And back again: a setting that could be turned on and not off is half a
+   *  setting, the rule the clock format above earns its own case for. */
+  test('choosing Celsius puts the headers back', async ({ page }) => {
+    await page.goto(app('weather'));
+    await chooseUnit(page, '72°F');
+    await expect(highs(page).first()).toHaveText('88°');
+
+    await chooseUnit(page, '22°C');
+    await expect(highs(page).first()).toHaveText('31°');
+  });
+
+  /** The **startup** seed, which nothing above can fail against for the reason
+   *  the block comment gives. A reload is the only way to begin a session with
+   *  the preference already stored — the stub's settings outlive one on
+   *  purpose (`loadSettings`, `harness/tauri.ts`). */
+  test('the chosen unit survives a reload', async ({ page }) => {
+    await page.goto(app('weather'));
+    await chooseUnit(page, '72°F');
+    await expect(highs(page).first()).toHaveText('88°');
+
+    await page.reload();
+    await expect(highs(page).first()).toHaveText('88°');
+  });
+
+  /** A second component, reading the same rune. Filmstrip prints the same
+   *  forecast high beside its day heading and rounds it with a `formatTemp`
+   *  call of its own, so Week being right says nothing about it — and
+   *  `components.spec.ts` covers that heading in Celsius only. */
+  test('the filmstrip heading follows the chosen unit too', async ({ page }) => {
+    await page.goto(app('weather'));
+    await chooseUnit(page, '72°F');
+
+    await page.keyboard.press('f');
+    await expect(page.locator('.sdate .wx').first()).toHaveText('88°');
+  });
+});
+
+/**
  * The keyboard sheet, and the table it and the handler both read.
  *
  * The point of the table is that it cannot drift from what the keys actually

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -109,6 +109,18 @@ test.describe('WeekGrid', () => {
     await expect(page.locator('.head .wx')).toHaveCount(0);
   });
 
+  // The same fixture as the test above, read through the Fahrenheit rune —
+  // 31°C → 87.8°F → 88°, 2°C → 35.6°F → 36°. Pins the conversion reaching
+  // the header, not just `temperature.ts`'s own arithmetic (`temperature.spec.ts`
+  // covers that directly).
+  test('a day header converts to Fahrenheit when that unit is chosen', async ({ page }) => {
+    await page.goto(show('WeekGrid', 'weather'));
+    await page.evaluate(() => (window as any).__setTemperatureUnit('fahrenheit'));
+    const wx = page.locator('.head .wx');
+    await expect(wx.nth(0)).toHaveText('88°');
+    await expect(wx.nth(2)).toHaveText('36°');
+  });
+
   // Without this, `WEEK_NOW` is unfalsifiable: a `WeekGrid` that had lost the
   // today-highlight and the current-time line entirely would satisfy every
   // other spec in this block and both baselines, because none of them ever

--- a/ui/tests/fixtures.ts
+++ b/ui/tests/fixtures.ts
@@ -3,7 +3,7 @@ import type {
   BigYearPayload, RibbonRow,
 } from '../src/lib/api';
 import type { AppStatus } from '../src/lib/status';
-import type { DayWeather } from '../src/lib/weather';
+import type { DayWeather, WeatherReport } from '../src/lib/weather';
 import type { Calendar } from '../src/lib/calendars';
 import type { Attendee, EventDetail } from '../src/lib/eventdetail';
 import type { Rect } from '../src/lib/position';
@@ -1471,6 +1471,27 @@ export const APP_ALLDAY_SERIES_DTSTART = APP_MON;
  *  on a real neighbouring day rather than on something obviously wrong, which
  *  is why the two are deliberately different days here. */
 export const APP_ALLDAY_OCCURRENCE = APP_MON + 2 * 24 * H;
+
+/** What `get_weather` answers for the `weather` scenario only — every other
+ *  scenario stays deliberately weatherless (see the stub's own `get_weather`
+ *  case). `tmax: 31` is `WEEK_WEATHER`'s own Monday reading, reused rather
+ *  than invented, so the header's `31°`/`88°` here matches the numbers
+ *  `components.spec.ts` already pins for the same conversion.
+ *
+ *  Dated through `utcDate` rather than written out, because the date is not a
+ *  fact of its own: it is whichever Monday the app opens on. The suite fixes
+ *  the browser to UTC (`playwright.config.ts`), so this is the same string
+ *  `dateKey` derives from the rendered column — which is the whole of why the
+ *  lookup hits. A literal would go on naming 29 January after `APP_MON` moved.
+ *
+ *  One day and not seven, so "every header drew the same sky" is a different
+ *  count rather than the same one. */
+export const APP_WEATHER: WeatherReport = {
+  days: [{ date: utcDate(APP_MON), bucket: 'clear', tmax: 31, tmin: 24 }],
+  // Null rather than a name: nothing in `ui/src` reads `place`, and the
+  // weatherless branch beside this one answers null already.
+  place: null,
+};
 
 /** The calendar a create must land on: the user's own primary. Third in the
  *  list below on purpose — a seed that took `calendars[0]` would pick the

--- a/ui/tests/harness/mount.svelte.ts
+++ b/ui/tests/harness/mount.svelte.ts
@@ -18,6 +18,7 @@ import { FIXTURES } from '../fixtures';
 import { installTauriStub } from './tauri';
 import { setPalette } from '../../src/lib/theme';
 import { setSecondZone } from '../../src/lib/secondzone.svelte';
+import { setTemperatureUnit } from '../../src/lib/tempunit.svelte';
 import { VIEW_BOX_CSS } from './viewbox';
 
 // The form's pure date functions, reachable from a spec.
@@ -40,6 +41,11 @@ import { VIEW_BOX_CSS } from './viewbox';
 // no App above it, so a spec that wants the second clock drawn plays App's
 // one line itself.
 (window as any).__setSecondZone = setSecondZone;
+
+// The temperature-unit rune's writer, reachable from a spec, for
+// `__setSecondZone`'s exact reason: in the app `App` is the only writer, and
+// a component mounted standalone has none above it.
+(window as any).__setTemperatureUnit = setTemperatureUnit;
 
 // Palette normally arrives from the Rust get_palette command; the harness
 // applies the same `fallback_dark` values (`src-tauri/src/theme.rs`) so

--- a/ui/tests/harness/tauri.ts
+++ b/ui/tests/harness/tauri.ts
@@ -21,7 +21,7 @@ import {
   labelledWeek, weekLabel, APP_FIVE_MIN_AGO, APP_NOW, APP_SERIES_ID, APP_SERIES_OCCURRENCE,
   APP_ONE_OFF_ID, APP_ONE_OFF_START, APP_GUESTS_ID, APP_SOLO_SERIES_ID,
   POPOVER_DETAILS, busyDayMonth,
-  appWritableWeek, APP_WRITE_CALENDARS, CREATED_DETAIL, crossZoneWeek,
+  appWritableWeek, APP_WRITE_CALENDARS, APP_WEATHER, CREATED_DETAIL, crossZoneWeek,
   XZONE_WEEK_START, keyboardWeek,
 } from '../fixtures';
 
@@ -802,9 +802,11 @@ export function installTauriStub(scenario: string): Harness {
       // Empty on purpose: App-level scenarios stay weatherless, so no
       // existing spec or screenshot grows a sky it never asked for. The
       // rendering itself is proven component-side, where the fixture hands
-      // the map in as a prop.
+      // the map in as a prop — except the `weather` scenario, which needs a
+      // real forecast for the day header's own live-repaint spec to have
+      // something to convert.
       case 'get_weather':
-        return { days: [], place: null };
+        return scenario === 'weather' ? APP_WEATHER : { days: [], place: null };
       case 'set_weather_enabled':
         settings = saveSettings({ ...settings, weatherEnabled: args.on as boolean });
         return { ...settings };

--- a/ui/tests/harness/tauri.ts
+++ b/ui/tests/harness/tauri.ts
@@ -16,6 +16,7 @@ import type { EventDetail } from '../../src/lib/eventdetail';
 import type { TimeFormat } from '../../src/lib/timefmt';
 import type { WeekStartDay } from '../../src/lib/weekstart';
 import type { StartOnLogin, WeekViewDays } from '../../src/lib/settings';
+import type { TemperatureUnit } from '../../src/lib/temperature';
 import {
   labelledWeek, weekLabel, APP_FIVE_MIN_AGO, APP_NOW, APP_SERIES_ID, APP_SERIES_OCCURRENCE,
   APP_ONE_OFF_ID, APP_ONE_OFF_START, APP_GUESTS_ID, APP_SOLO_SERIES_ID,
@@ -523,6 +524,7 @@ type StubSettings = {
   displayTimezone: string | null;
   secondTimezone: string | null;
   weatherEnabled: boolean;
+  temperatureUnit: TemperatureUnit;
   startOnLogin: StartOnLogin;
   quitOnClose: boolean;
 };
@@ -555,6 +557,8 @@ const DEFAULT_SETTINGS: StubSettings = {
   secondTimezone: null,
   // The backend's default: on unless somebody turned it off.
   weatherEnabled: true,
+  // The backend's default: Celsius, so no installed copy changes under its user.
+  temperatureUnit: 'celsius',
   // The backend's default too, and for a reason the stub has to reproduce
   // rather than merely copy: every install that predates the setting has the
   // launch entry, so absent must land on `open` or the upgrade changes what
@@ -803,6 +807,9 @@ export function installTauriStub(scenario: string): Harness {
         return { days: [], place: null };
       case 'set_weather_enabled':
         settings = saveSettings({ ...settings, weatherEnabled: args.on as boolean });
+        return { ...settings };
+      case 'set_temperature_unit':
+        settings = saveSettings({ ...settings, temperatureUnit: args.unit as TemperatureUnit });
         return { ...settings };
       case 'set_start_on_login':
         settings = saveSettings({ ...settings, startOnLogin: args.mode as StartOnLogin });

--- a/ui/tests/temperature.spec.ts
+++ b/ui/tests/temperature.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test';
+import { formatTemp } from '../src/lib/temperature';
+
+/** The one place a Celsius reading gets rounded — pinned in both units so a
+ *  regression to "round then convert" (off by a degree on a fraction like
+ *  31.6) fails here rather than only in a screenshot. */
+test.describe('formatTemp', () => {
+  test('celsius is a pass-through round', () => {
+    expect(formatTemp(31.6, 'celsius')).toBe('32');
+    expect(formatTemp(-3, 'celsius')).toBe('-3');
+    expect(formatTemp(0, 'celsius')).toBe('0');
+  });
+
+  test('fahrenheit converts before rounding, not after', () => {
+    // 31.6°C is 88.88°F, which rounds to 89 — not 90, the answer you get by
+    // rounding 31.6 to 32°C first and converting that.
+    expect(formatTemp(31.6, 'fahrenheit')).toBe('89');
+    expect(formatTemp(0, 'fahrenheit')).toBe('32');
+    expect(formatTemp(-3, 'fahrenheit')).toBe('27');
+    expect(formatTemp(100, 'fahrenheit')).toBe('212');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #32. Adds a temperature-unit setting (Celsius/Fahrenheit) beside "Weather in the day headers" in Settings → General. Celsius is the default, so no installed copy changes under its user.

- `weather::DayWeather.tmax`/`.tmin` now carry the unrounded Celsius reading from Open-Meteo instead of `.round() as i32`. Rounding moves to display time (`temperature.ts`'s `formatTemp`). Rounding then converting is wrong about half the time: `31.6°C` rounds to `32°C` and converts to `90°F`, but `31.6°C` is actually `89°F`.
- `settings::TemperatureUnit` mirrors `TimeFormat` field for field. Closed two-variant enum, no refusal path, same forgiving fallback to Celsius on an absent or hand-edited row.
- The day headers stay a bare `72°`/`22°`, matching the existing screenshot goldens. The settings dropdown does print the letter (`72°F`/`22°C`), since naming the scale is the one place it earns its keep. A hint underneath clarifies the headers themselves don't carry the letter, added after a demo-mode walkthrough showed the two could otherwise read as contradicting each other.

## Screenshots
<img width="1892" height="2083" alt="image" src="https://github.com/user-attachments/assets/b0fe17d6-5817-43c8-a706-5568ea5a8176" />
<img width="1892" height="2083" alt="image" src="https://github.com/user-attachments/assets/2aa69995-551a-4936-9c70-13c015500546" />
<img width="1892" height="2083" alt="image" src="https://github.com/user-attachments/assets/4c81b3e4-4abb-4173-94e2-d2aeac620187" />

## Test plan

- [x] `cargo test --workspace --no-fail-fast`: all 561 passing (main crate), full workspace green
- [x] `cargo clippy --workspace --all-targets -- -D warnings`: clean
- [x] `npm --prefix ui run check`: 0 errors
- [x] `npm --prefix ui run test:ui -- --ignore-snapshots`: 842 passing (Chromium)
- [x] Per `docs/testing-standard.md`, every new test proven red before trusting it. The Rust round-trip test (deleted the Fahrenheit match arm), the Rust parse test (reintroduced the old `.round()` before caching), `temperature.spec.ts` (reversed the round-then-convert order), and the new `components.spec.ts` Fahrenheit-header spec (reverted the header to the raw `wx.tmax`) each failed against the broken code, then passed once restored.
- [x] Manually exercised in `OMACAL_SEED_DEMO=1 cargo tauri dev`. Toggled Celsius and Fahrenheit in Settings and confirmed the Week headers and filmstrip repaint live with no restart, and that the "Show temperature as" row only appears while weather is enabled.