### PR TITLE
fix(sync): a meeting link in the description becomes a Join button

### DIFF
--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -408,10 +408,12 @@ pub(crate) async fn rows_in_window(
                     names.get(&src.calendar_id).map(|(_, email)| email.as_str()).unwrap_or(""),
                     cal_gids.get(&src.calendar_id).map(String::as_str).unwrap_or(""),
                 ),
-                conference: src
-                    .conference_uri
-                    .clone()
-                    .or_else(|| crate::upcoming::location_meeting_url(src.location.as_deref())),
+                conference: src.conference_uri.clone().or_else(|| {
+                    crate::upcoming::conference_join_url(
+                        src.location.as_deref(),
+                        src.description.as_deref(),
+                    )
+                }),
             });
         }
     }
@@ -500,10 +502,9 @@ pub(crate) async fn detail_by_id(pool: &SqlitePool, id: i64) -> anyhow::Result<O
         organizer: is_organizer(ev.organizer_email.as_deref(), &account_email, &cal_gid),
         organizer_email: ev.organizer_email.clone(),
         response: ev.self_response.clone(),
-        conference: ev
-            .conference_uri
-            .clone()
-            .or_else(|| crate::upcoming::location_meeting_url(ev.location.as_deref())),
+        conference: ev.conference_uri.clone().or_else(|| {
+            crate::upcoming::conference_join_url(ev.location.as_deref(), ev.description.as_deref())
+        }),
         guests: ev
             .attendees
             .iter()

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -813,27 +813,28 @@ pub fn assemble_big_year(
 /// never chooses what the browser is pointed at, it can only name an event
 /// the user can already see.
 ///
-/// The URL comes from the same two places the popover's own derivation
-/// reads, in the same order: structured conference data first, then a
-/// recognised meeting link sitting in `location` (`location_meeting_url` —
-/// the widget feed's helper, so all three surfaces agree on what is
-/// joinable).
+/// The URL comes from the same places the popover's own derivation reads,
+/// in the same order: structured conference data first, then a recognised
+/// meeting link in `location`, then one in `description`
+/// (`conference_join_url` — the widget feed's helper, so this, the feed and
+/// the CLI all agree on what is joinable).
 #[tauri::command]
 pub(crate) async fn open_conference(
     state: tauri::State<'_, crate::AppState>,
     id: i64,
 ) -> Result<(), String> {
-    let row: Option<(Option<String>, Option<String>)> =
-        sqlx::query_as("SELECT conference_uri, location FROM events WHERE id = ?1")
-            .bind(id)
-            .fetch_optional(&state.pool)
-            .await
-            .map_err(|e| crate::errors::user_facing(&e.into()))?;
-    let Some((conference, location)) = row else {
+    let row: Option<(Option<String>, Option<String>, Option<String>)> = sqlx::query_as(
+        "SELECT conference_uri, location, description FROM events WHERE id = ?1",
+    )
+    .bind(id)
+    .fetch_optional(&state.pool)
+    .await
+    .map_err(|e| crate::errors::user_facing(&e.into()))?;
+    let Some((conference, location, description)) = row else {
         return Err("This event is no longer on the calendar.".into());
     };
     let url = conference
-        .or_else(|| crate::upcoming::location_meeting_url(location.as_deref()))
+        .or_else(|| crate::upcoming::conference_join_url(location.as_deref(), description.as_deref()))
         .ok_or_else(|| "This event has no meeting link.".to_string())?;
     crate::browser::open_external(&url).map_err(|e| {
         tracing::warn!(%e, "could not open the meeting link");

--- a/src-tauri/src/upcoming.rs
+++ b/src-tauri/src/upcoming.rs
@@ -94,10 +94,90 @@ pub struct FeedEvent {
     pub calendar: Option<String>,
 }
 
-/// The joinable meeting URL a location field holds, or `None` — the Rust
-/// half of `ui/src/lib/location.ts`'s `meetingUrl`, and deliberately the
-/// same rules so the widget's Join button and the popover's agree about
-/// what is joinable.
+const MEETING_PROVIDERS: &[&str] = &[
+    "zoom.us", "meet.google.com", "teams.microsoft.com",
+    "teams.live.com", "webex.com", "meet.jit.si",
+];
+
+/// Walks every URL in `text`, in order, and returns the first one whose host
+/// is a recognised meeting provider — the shared scan behind
+/// [`location_meeting_url`] and [`conference_join_url`]'s description half,
+/// and the Rust twin of `ui/src/lib/location.ts`'s `meetingUrl`.
+///
+/// The URL character class excludes whitespace, `,`, `;`, and — this is the
+/// part that matters over HTML — `<`, `>`, `"` and `'`. `description` is raw
+/// HTML from Google, sanitised later by `descriptionSegments`/`sanitize.ts`,
+/// and an ordinary invite anchor is `<a href="https://…/j/123?pwd=x">Join
+/// Zoom Meeting</a>`: without excluding the quote the scan runs straight
+/// through it into the tag's own text and returns `…pwd=x">Join`, a URL that
+/// looks plausible and 404s. `location` is plain text, where none of those
+/// characters occur anyway, so the same class serves both without a
+/// second implementation to keep in step.
+///
+/// Every match is tried, not just the first: a description that opens with
+/// an agenda link or a shared doc before the meeting link would otherwise
+/// scan that first, unrecognised URL and give up.
+///
+/// The scheme search is case-insensitive — matching the `i` flag on the TS
+/// twin's regex — and takes whichever scheme's match sits earlier in the
+/// text. `rest.find("https://").or_else(|| rest.find("http://"))` looks
+/// equivalent but is not: `.find` searches the whole remainder for each
+/// scheme independently, so a *later* `https://` still wins over an
+/// *earlier* `http://` whenever both are present, and the loop then advances
+/// past that later match — silently dropping the earlier URL for good
+/// rather than revisiting it next iteration.
+fn first_recognised_url(text: &str) -> Option<String> {
+    let mut rest = text;
+    loop {
+        let lower = rest.to_ascii_lowercase();
+        let at = match (lower.find("https://"), lower.find("http://")) {
+            (Some(a), Some(b)) => a.min(b),
+            (Some(a), None) => a,
+            (None, Some(b)) => b,
+            (None, None) => return None,
+        };
+        let tail = &rest[at..];
+        let end = tail
+            .find(|c: char| {
+                c.is_whitespace() || matches!(c, ',' | ';' | '<' | '>' | '"' | '\'')
+            })
+            .unwrap_or(tail.len());
+        let url = tail[..end].trim_end_matches([')', ',', '.', ';', ':', '!', '?', ']']);
+
+        // The hostname: after the scheme, before any path/query/fragment,
+        // with userinfo and port stripped — enough of a parse for an
+        // allow-list.
+        let host = url
+            .split_once("://")
+            .and_then(|(_, after_scheme)| after_scheme.split(['/', '?', '#']).next())
+            .map(|authority| {
+                authority
+                    .rsplit('@')
+                    .next()
+                    .unwrap_or("")
+                    .split(':')
+                    .next()
+                    .unwrap_or("")
+                    .to_ascii_lowercase()
+            })
+            .unwrap_or_default();
+
+        if !host.is_empty()
+            && MEETING_PROVIDERS.iter().any(|p| host == *p || host.ends_with(&format!(".{p}")))
+        {
+            return Some(url.to_string());
+        }
+
+        // Not a recognised link (or not parseable) — keep scanning past it.
+        let consumed = at + end.max(1);
+        if consumed >= rest.len() {
+            return None;
+        }
+        rest = &rest[consumed..];
+    }
+}
+
+/// The joinable meeting URL a location field holds, or `None`.
 ///
 /// **Recognised providers only**, which is the whole of the restraint: a
 /// location is as likely to hold a map pin or a venue's homepage as a
@@ -106,43 +186,20 @@ pub struct FeedEvent {
 /// written into a sentence ("dial in at https://…/j/123.") otherwise
 /// carries the full stop into the URL and 404s.
 pub(crate) fn location_meeting_url(raw: Option<&str>) -> Option<String> {
-    const PROVIDERS: &[&str] = [
-        "zoom.us", "meet.google.com", "teams.microsoft.com",
-        "teams.live.com", "webex.com", "meet.jit.si",
-    ].as_slice();
+    first_recognised_url(raw.unwrap_or("").trim())
+}
 
-    let text = raw.unwrap_or("").trim();
-    let at = text.find("https://").or_else(|| text.find("http://"))?;
-    // A URL runs to whitespace or a separator, matching the TS `URL_RE`.
-    let tail = &text[at..];
-    let end = tail
-        .find(|c: char| c.is_whitespace() || c == ',' || c == ';')
-        .unwrap_or(tail.len());
-    let url = tail[..end].trim_end_matches([')', ',', '.', ';', ':', '!', '?', ']']);
-
-    // The hostname: after the scheme, before any path/query/fragment, with
-    // userinfo and port stripped — enough of a parse for an allow-list.
-    let after_scheme = url.split_once("://")?.1;
-    let authority = after_scheme
-        .split(['/', '?', '#'])
-        .next()
-        .unwrap_or("");
-    let host = authority
-        .rsplit('@')
-        .next()
-        .unwrap_or("")
-        .split(':')
-        .next()
-        .unwrap_or("")
-        .to_ascii_lowercase();
-    if host.is_empty() {
-        return None;
-    }
-
-    let joinable = PROVIDERS.iter().any(|p| {
-        host == *p || host.ends_with(&format!(".{p}"))
-    });
-    joinable.then(|| url.to_string())
+/// The meeting to join, if any: a recognised link in `location`, and failing
+/// that, one in `description`.
+///
+/// Plenty of invites put their join link only in the description ("Join Zoom
+/// Meeting: https://…"), never in `location` — and this is the one place
+/// that answer is decided. `open_conference`, this feed, and the two
+/// `list`/`show` call sites in `cli.rs` all resolve through it, so the app,
+/// the widget and the CLI never disagree about whether an event has a
+/// meeting.
+pub(crate) fn conference_join_url(location: Option<&str>, description: Option<&str>) -> Option<String> {
+    location_meeting_url(location).or_else(|| first_recognised_url(description.unwrap_or("").trim()))
 }
 
 /// The pure assembly: stored rows in, feed out, no clock or filesystem.
@@ -182,17 +239,17 @@ pub(crate) fn assemble(
                 attendees: src.attendees.len() as u32,
                 response: src.self_response.clone(),
                 // Structured conference data first; failing that, a joinable
-                // link sitting in `location` — see `location_meeting_url`.
-                // Without the fallback the widget's Join button only ever lit
-                // for Google Meet: Google is the one host that files the link
-                // as conference data, while a Zoom or Teams invitation minted
-                // anywhere else arrives with its URL in `location` and
-                // nowhere structured (reported 2026-08-20 — the button
-                // existed and nobody had ever seen it).
-                conference: src
-                    .conference_uri
-                    .clone()
-                    .or_else(|| location_meeting_url(src.location.as_deref())),
+                // link in `location` or `description` — see
+                // `conference_join_url`. Without the fallback the widget's
+                // Join button only ever lit for Google Meet: Google is the
+                // one host that files the link as conference data, while a
+                // Zoom or Teams invitation minted anywhere else arrives with
+                // its URL in `location` or the invite text and nowhere
+                // structured (reported 2026-08-20 — the button existed and
+                // nobody had ever seen it).
+                conference: src.conference_uri.clone().or_else(|| {
+                    conference_join_url(src.location.as_deref(), src.description.as_deref())
+                }),
                 color: src.color_hex.clone(),
                 calendar: calendar_names.get(&src.calendar_id).cloned(),
             });
@@ -447,6 +504,92 @@ mod tests {
         );
         // A lookalike host does not ride the suffix check.
         assert_eq!(location_meeting_url(Some("https://notzoom.us/j/1")), None);
+    }
+
+    /// A description-only invite — the case the fallback exists for.
+    #[test]
+    fn a_description_only_link_is_joinable() {
+        let mut e = event("standalone", T0900Z, T0900Z + HOUR);
+        e.description = Some("Join Zoom Meeting: https://us02web.zoom.us/j/123?pwd=x".into());
+        let feed = assemble(&[e], &names(), T0900Z);
+        assert_eq!(
+            feed.events[0].conference.as_deref(),
+            Some("https://us02web.zoom.us/j/123?pwd=x"),
+        );
+    }
+
+    /// The bug the description fallback shipped with the first time: a real
+    /// Google description is HTML, and a naive scan across an anchor's
+    /// `href` swallows the closing quote and runs into the link text —
+    /// `…pwd=x">Join`, a URL that looks plausible and 404s. Excluding `<`,
+    /// `>`, `"` and `'` from the URL's character class stops the scan at the
+    /// attribute boundary instead.
+    #[test]
+    fn an_html_description_does_not_swallow_the_closing_quote() {
+        let mut e = event("html-invite", T0900Z, T0900Z + HOUR);
+        e.description = Some(
+            r#"<p>Hi team,</p><p><a href="https://us02web.zoom.us/j/123?pwd=x">Join Zoom Meeting</a></p>"#
+                .into(),
+        );
+        let feed = assemble(&[e], &names(), T0900Z);
+        assert_eq!(
+            feed.events[0].conference.as_deref(),
+            Some("https://us02web.zoom.us/j/123?pwd=x"),
+        );
+    }
+
+    /// A link earlier in the text that isn't a recognised provider (an
+    /// agenda doc, say) must not stop the scan before it reaches the real
+    /// meeting link further down.
+    #[test]
+    fn a_leading_unrecognised_link_does_not_shadow_a_later_one() {
+        assert_eq!(
+            first_recognised_url(
+                "Agenda: https://docs.example.com/agenda then join at https://us02web.zoom.us/j/123"
+            ),
+            Some("https://us02web.zoom.us/j/123".into()),
+        );
+    }
+
+    /// `location` still wins over `description` when both carry a link.
+    #[test]
+    fn conference_join_url_prefers_location_over_description() {
+        assert_eq!(
+            conference_join_url(
+                Some("https://us02web.zoom.us/j/111"),
+                Some("https://us02web.zoom.us/j/222"),
+            ),
+            Some("https://us02web.zoom.us/j/111".into()),
+        );
+    }
+
+    /// A regression on the walk itself: `rest.find("https://")
+    /// .or_else(|| rest.find("http://"))` looks like "whichever comes
+    /// first" but is not — `.find` runs against the whole remainder for
+    /// each scheme, so a *later* `https://` link still wins over an
+    /// *earlier* `http://` one whenever a description mixes schemes, and the
+    /// earlier link is then skipped for good rather than picked up on a
+    /// later pass. `meet.jit.si` here is a real allow-listed provider, not a
+    /// contrived host.
+    #[test]
+    fn an_earlier_http_link_is_not_shadowed_by_a_later_https_one() {
+        assert_eq!(
+            first_recognised_url(
+                "Dial in http://meet.jit.si/xyz backup https://docs.example.com/doc"
+            ),
+            Some("http://meet.jit.si/xyz".into()),
+        );
+    }
+
+    /// The scheme match is case-insensitive, matching the `i` flag on the TS
+    /// twin's regex (`location.ts`) — a real invite would not do this, but
+    /// the two implementations disagreeing on identical input is its own bug.
+    #[test]
+    fn the_scheme_match_is_case_insensitive() {
+        assert_eq!(
+            first_recognised_url("Join at HTTPS://us02web.ZOOM.US/j/123"),
+            Some("HTTPS://us02web.ZOOM.US/j/123".into()),
+        );
     }
 
     /// And a cancelled exception silently removes exactly its slot.

--- a/ui/src/lib/EventPopover.svelte
+++ b/ui/src/lib/EventPopover.svelte
@@ -209,15 +209,22 @@
   });
 
   /**
-   * The meeting to join, from Google's structured conference data if it is
-   * there and from the location field if it is not.
+   * The meeting to join: Google's structured conference data if it is there,
+   * else a recognised link in `location`, else one in the description text.
    *
    * One control, not two: an event carries at most one meeting, and a second
    * Join button for the second place a link can hide would make the popover
    * argue with itself about which is the real one. Google's own field wins
-   * because it is the only one that cannot be a coincidence.
+   * because it is the only one that cannot be a coincidence; `location`
+   * before `description` matches `open_conference`'s own order
+   * (`conference_join_url` in `upcoming.rs`), which is what actually runs
+   * when this is clicked — this derivation only has to agree with it, not
+   * decide anything, since it drives the displayed `href` and the
+   * `locationShown` echo check below, not the click itself.
    */
-  const joinUrl = $derived(detail.conference_uri ?? meetingUrl(detail.location));
+  const joinUrl = $derived(
+    detail.conference_uri ?? meetingUrl(detail.location) ?? meetingUrl(detail.description),
+  );
 
   async function ask(response: 'accepted' | 'tentative' | 'declined', e: MouseEvent) {
     if (!detail.is_recurring) {

--- a/ui/src/lib/location.ts
+++ b/ui/src/lib/location.ts
@@ -8,7 +8,10 @@ const PROVIDERS: Array<[RegExp, string]> = [
   [/(^|\.)meet\.jit\.si$/i, 'Jitsi'],
 ];
 
-const URL_RE = /https?:\/\/[^\s,;]+/i;
+const URL_RE = /https?:\/\/[^\s,;<>"']+/i;
+// Global counterpart for `meetingUrl`'s walk — see its own doc comment for
+// why the character class excludes `<`, `>`, `"` and `'`.
+const URL_RE_ALL = /https?:\/\/[^\s,;<>"']+/gi;
 
 /** The recognised meeting provider behind one URL, or `null`.
  *
@@ -28,19 +31,32 @@ export function meetingProvider(raw: string | null): string | null {
 }
 
 /**
- * The joinable meeting URL a location holds, or `null`.
+ * The joinable meeting URL a location or description holds, or `null`.
  *
  * **Recognised providers only**, and that is the whole of the restraint here.
  * Google puts a Meet link in structured conference data, which is where the
  * popover's Join control has always come from — but an invitation minted by
- * anybody else arrives with its Zoom or Teams link sitting in `location` and
- * nowhere else, so the app could name the provider (see `locationLabel`) and
- * still give you nothing to click. This closes that.
+ * anybody else arrives with its Zoom or Teams link sitting in `location` or
+ * the description text and nowhere else, so the app could name the provider
+ * (see `locationLabel`) and still give you nothing to click. This closes
+ * that. Rust twin: `location_meeting_url`/`conference_join_url` in
+ * `upcoming.rs`, which is what the Join button's click actually resolves
+ * through — this function only drives the displayed `href` and the
+ * location/description echo check, so keep the two in step rather than
+ * letting them quietly diverge on what counts as joinable.
  *
- * An *unrecognised* link stays unclickable on purpose: a location field is as
- * likely to hold a map pin, a venue's homepage or a ticket as a meeting, and a
- * button labelled "Join video call" that opens a restaurant is worse than no
- * button at all.
+ * An *unrecognised* link stays unclickable on purpose: a location or
+ * description is as likely to hold a map pin, an agenda doc or a ticket as a
+ * meeting, and a button labelled "Join video call" that opens a restaurant is
+ * worse than no button at all.
+ *
+ * Every URL in the text is tried, not just the first — a description that
+ * opens with an agenda link before the meeting link would otherwise give up
+ * on that first, unrecognised one. The character class excludes `<`, `>`,
+ * `"` and `'` so this is safe to call directly on raw HTML: without it, an
+ * invite anchor (`<a href="https://…/j/123?pwd=x">Join Zoom Meeting</a>`)
+ * scans straight through the closing quote into the link text and returns
+ * `…pwd=x">Join`, a URL that looks plausible and 404s.
  *
  * The trailing-punctuation trim matters more than it looks: a link written
  * into a sentence ("dial in at https://…/j/123.") otherwise carries the full
@@ -50,17 +66,19 @@ export function meetingUrl(raw: string | null): string | null {
   const text = (raw ?? '').trim();
   if (!text) return null;
 
-  const match = text.match(URL_RE);
-  if (!match) return null;
-  const url = match[0].replace(/[),.;:!?\]]+$/, '');
-
-  let host = '';
-  try {
-    host = new URL(url).hostname;
-  } catch {
-    return null;
+  URL_RE_ALL.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = URL_RE_ALL.exec(text))) {
+    const url = match[0].replace(/[),.;:!?\]]+$/, '');
+    let host = '';
+    try {
+      host = new URL(url).hostname;
+    } catch {
+      continue;
+    }
+    if (PROVIDERS.some(([re]) => re.test(host))) return url;
   }
-  return PROVIDERS.some(([re]) => re.test(host)) ? url : null;
+  return null;
 }
 
 /**

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -2086,6 +2086,51 @@ test.describe('EventPopover', () => {
     await expect(page.locator('.pop .loc')).toHaveCount(0);
   });
 
+  test('a meeting link only in the description still becomes a Join button', async ({ page }) => {
+    // Not every provider's invite puts its link in `location` — plenty put it
+    // only in the description, and until now nothing looked there at all.
+    await page.goto(show('description-holds-a-real-zoom-link'));
+    const conf = page.locator('.pop .conf');
+    await expect(conf).toBeVisible();
+    await expect(conf).toHaveText('Join video call');
+    await expect(conf).toHaveAttribute('href', 'https://us02web.zoom.us/j/123456?pwd=x');
+    // The location is an ordinary room, not the link, so it is still shown.
+    await expect(page.locator('.pop .loc')).toHaveText('Room 4A');
+  });
+
+  // Clicking never sends the displayed `href` anywhere — `open_conference`
+  // re-resolves the URL server-side by id, so a button that merely *looks*
+  // right (asserted by `href` alone) can still error on click if the two
+  // disagree. This is the case that broke that way once already: the join
+  // link lived only in the description, which the click path had to be
+  // taught to read too.
+  test('clicking a description-only Join button asks the backend for that event', async ({ page }) => {
+    await page.goto(show('description-holds-a-real-zoom-link'));
+    await page.locator('.pop .conf').click();
+    const calls = await page.evaluate(() => (window as any).__harness.calls);
+    expect(calls.filter((c: any) => c.cmd === 'open_conference')).toEqual([
+      expect.objectContaining({ args: { id: 69 } }),
+    ]);
+  });
+
+  // Real Google descriptions are HTML. The join link sits inside an anchor's
+  // `href`, and a scan that does not stop at the closing quote runs into the
+  // link text and reports a URL that looks plausible and 404s
+  // (`…pwd=x">Join`) — proven red against the code before this fix.
+  test('a meeting link inside an html description becomes a Join button', async ({ page }) => {
+    await page.goto(show('description-holds-an-html-zoom-link'));
+    const conf = page.locator('.pop .conf');
+    await expect(conf).toBeVisible();
+    await expect(conf).toHaveAttribute('href', 'https://us02web.zoom.us/j/123456?pwd=x');
+  });
+
+  test('a meeting link in the location wins over a different one in the description', async ({ page }) => {
+    await page.goto(show('location-and-description-both-hold-a-meeting-link'));
+    const conf = page.locator('.pop .conf');
+    await expect(conf).toBeVisible();
+    await expect(conf).toHaveAttribute('href', 'https://meet.google.com/abc-defg-hij');
+  });
+
   test('a map link in the location is not offered as a meeting', async ({ page }) => {
     await page.goto(show('location-holds-a-map-link'));
     // The popover rendered — otherwise the absence below proves nothing.

--- a/ui/tests/fixtures.ts
+++ b/ui/tests/fixtures.ts
@@ -2372,6 +2372,41 @@ export const FIXTURES: Record<string, Record<string, any>> = {
       anchor: ANCHOR, occurrenceStartMs: MON + 9 * H, occurrenceEndMs: MON + 9 * H + 30 * 60_000,
       onclose: noop, onresponded: noop, onedit: noop, ondelete: noop,
     },
+    // A join link that only lives in the description, with an ordinary room
+    // in `location`.
+    'description-holds-a-real-zoom-link': {
+      detail: detail({
+        id: 69,
+        description: 'Join Zoom Meeting: https://us02web.zoom.us/j/123456?pwd=x',
+        location: 'Room 4A',
+      }),
+      anchor: ANCHOR, occurrenceStartMs: MON + 9 * H, occurrenceEndMs: MON + 9 * H + 30 * 60_000,
+      onclose: noop, onresponded: noop, onedit: noop, ondelete: noop,
+    },
+    // The description as Google actually writes it: HTML, not plain text.
+    // The join link sits inside an anchor's `href`, which is exactly the
+    // shape a naive scan swallows past the closing quote into "…pwd=x">Join.
+    'description-holds-an-html-zoom-link': {
+      detail: detail({
+        id: 70,
+        description:
+          '<p>Hi team,</p><p><a href="https://us02web.zoom.us/j/123456?pwd=x">Join Zoom Meeting</a></p>',
+        location: null,
+      }),
+      anchor: ANCHOR, occurrenceStartMs: MON + 9 * H, occurrenceEndMs: MON + 9 * H + 30 * 60_000,
+      onclose: noop, onresponded: noop, onedit: noop, ondelete: noop,
+    },
+    // The location still wins when both fields carry a (different)
+    // recognised link — one control, not two arguing about which is real.
+    'location-and-description-both-hold-a-meeting-link': {
+      detail: detail({
+        id: 71,
+        description: 'Backup bridge: https://us02web.zoom.us/j/999999?pwd=y',
+        location: 'https://meet.google.com/abc-defg-hij',
+      }),
+      anchor: ANCHOR, occurrenceStartMs: MON + 9 * H, occurrenceEndMs: MON + 9 * H + 30 * 60_000,
+      onclose: noop, onresponded: noop, onedit: noop, ondelete: noop,
+    },
     'location-room-in-description': {
       detail: detail({
         id: 63,

--- a/ui/tests/location.spec.ts
+++ b/ui/tests/location.spec.ts
@@ -108,4 +108,25 @@ test.describe('meetingUrl', () => {
     expect(meetingUrl('   ')).toBe(null);
     expect(meetingUrl('zoom')).toBe(null);
   });
+
+  // The bug the description fallback shipped with the first time: raw HTML
+  // from Google, scanned with a character class built for plain-text
+  // `location`, swallows the closing quote of an anchor's `href` and runs
+  // into the link text — "…pwd=x">Join", a URL that looks plausible and
+  // 404s. Excluding `<`, `>`, `"` and `'` stops the scan at the attribute
+  // boundary, which is what makes it safe to call directly on `description`.
+  test('an html description does not swallow the closing quote', () => {
+    expect(
+      meetingUrl('<p>Hi team,</p><p><a href="https://us02web.zoom.us/j/123?pwd=x">Join Zoom Meeting</a></p>'),
+    ).toBe('https://us02web.zoom.us/j/123?pwd=x');
+  });
+
+  // Every URL in the text is tried, not just the first — a description that
+  // opens with an agenda link before the meeting link would otherwise give
+  // up on that first, unrecognised one.
+  test('a leading unrecognised link does not shadow a later one', () => {
+    expect(
+      meetingUrl('Agenda: https://docs.example.com/agenda then join at https://us02web.zoom.us/j/123'),
+    ).toBe('https://us02web.zoom.us/j/123');
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to #24. That PR's `conferenceData` half landed; this is the reworked description-link fallback that got sent back in review.

- The Join click never went through the frontend's `href` — it calls `open_conference`, which re-resolves the URL server-side from `conference_uri` then `location_meeting_url(location)` and never saw the description. The fallback now lives in Rust: a new `conference_join_url(location, description)` in `upcoming.rs`, which `open_conference` (`commands.rs`), the Omarchy widget feed's `assemble()`, and both `cli.rs` surfaces all resolve through, so the app, the widget and the CLI agree on what is joinable.
- The URL scan is safe over raw HTML: the character class excludes `<`, `>`, `"` and `'`, so an invite anchor's `href` (`<a href="https://…/j/123?pwd=x">Join Zoom Meeting</a>`) can't swallow its own closing quote and return `…pwd=x">Join`.
- Every URL in the text is tried, not just the first, so a description that opens with an agenda or doc link before the meeting link still resolves.
- `ui/src/lib/location.ts`'s `meetingUrl` — the deliberate TS twin — carries the same two fixes, and drives `EventPopover`'s displayed `href`/echo-check, falling back to the description after `location`.
- `location` still wins over `description` when both carry a link.

## Testing

- `cargo test --workspace --no-fail-fast` — 575 passed, including new `upcoming.rs` cases: an HTML-anchor description, a leading unrecognised link, location-over-description precedence, and two regressions caught in review (an earlier `http://` link no longer shadowed by a later `https://` one; the scheme match is case-insensitive, matching the TS twin's `i` flag)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `npm run check` — 0 errors, 0 warnings
- `npx playwright test --project=chromium --ignore-snapshots` — 868 passed, including a restored fixture for a description-only link, a new HTML-description fixture, and a test asserting the actual click path (`open_conference` invoked with the right id) rather than only the displayed `href` — the exact gap that broke the first attempt