### PR TITLE
chore: an unused dependency, a dead helper, and a word on spec-only exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3187,7 +3187,6 @@ dependencies = [
  "anyhow",
  "jiff",
  "omacal-caldav",
- "omacal-core",
  "omacal-google",
  "omacal-store",
  "reqwest 0.12.28",

--- a/crates/omacal-core/src/layout.rs
+++ b/crates/omacal-core/src/layout.rs
@@ -7,13 +7,6 @@ pub struct Interval {
     pub end_ms: i64,
 }
 
-impl Interval {
-    #[allow(dead_code)]
-    fn overlaps(&self, other: &Interval) -> bool {
-        self.start_ms < other.end_ms && other.start_ms < self.end_ms
-    }
-}
-
 /// Computed geometry for one event in a day column.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize)]
 pub struct Placed {

--- a/crates/omacal-sync/Cargo.toml
+++ b/crates/omacal-sync/Cargo.toml
@@ -8,7 +8,6 @@ license.workspace = true
 [dependencies]
 anyhow.workspace = true
 jiff = "0.2.35"
-omacal-core = { version = "0.1.0", path = "../omacal-core" }
 omacal-google = { version = "0.1.0", path = "../omacal-google" }
 omacal-caldav = { path = "../omacal-caldav" }
 omacal-store = { version = "0.1.0", path = "../omacal-store" }

--- a/docs/testing-standard.md
+++ b/docs/testing-standard.md
@@ -146,3 +146,13 @@ rule was tested. It was also false, twice, somewhere else.
 Not by reading output. `grep` over a log has reported "clean" over a real
 failure, `${PIPESTATUS[0]}` is empty under zsh, and a stale output file has
 described a run that never happened.
+
+## 10. A symbol exported only for a spec stays a plain export
+
+Twenty-odd functions under `ui/src/lib` have no caller but a spec —
+`ambiguousLocalTime` in `eventform.ts` is one. The 2026-09-06 review counted
+them and asked whether they belong behind a `__test` namespace or a re-export
+barrel. They do not. The bundle is an application, not a library: an export
+costs nothing at its boundary, and a second surface for specs would be one
+more thing to keep in step with the first. A spec imports the module the way
+the app does, and a reader who finds no caller in `src` looks in `tests` next.


### PR DESCRIPTION
First of the 2026-09-06 review's hygiene items, the ones that touch no open PR.

- `omacal-sync` declared `omacal-core` and never used it: dropped from its Cargo.toml and the lock.
- `Interval::overlaps` in core's layout module had no caller and an `allow(dead_code)`: both gone.
- The testing standard gains §10: a symbol exported for no caller but a spec stays a plain export. That is the answer to the review's question about a `__test` namespace.

No behaviour change. Clippy with `-D warnings` and the whole workspace suite are green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GabzsFfyts4eNZMbTkhtkQ