### PR TITLE
ci: current action majors, the UI job per engine, Dependabot and a weekly audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,14 @@
+# cargo-audit's exceptions. Each names the advisory and the reason, and the
+# reason is a claim about this tree with the command that re-checks it
+# beside it. Remove an entry when the advisory gains a fix; the next audit
+# run says whether the entry was still needed.
+[advisories]
+ignore = [
+    # rsa 0.9's Marvin timing side channel has no fixed release. rsa is in
+    # Cargo.lock only because a lockfile resolves every feature of every
+    # dependency, and sqlx's mysql feature depends on it; no build of this
+    # workspace enables that feature, so no rsa code is compiled here.
+    # Check: `cargo tree --workspace --all-features --target all -i rsa`
+    # prints nothing.
+    "RUSTSEC-2023-0071",
+]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+# Monthly, grouped. Everything semver-compatible in an ecosystem arrives as
+# one PR; a major arrives as a PR of its own, because a major is a migration
+# and should pass or fail alone. Advisories in between are the audit
+# workflow's job, not this file's.
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      cargo-compatible:
+        patterns: ["*"]
+        update-types: [minor, patch]
+
+  - package-ecosystem: npm
+    directory: /ui
+    schedule:
+      interval: monthly
+    groups:
+      npm-compatible:
+        patterns: ["*"]
+        update-types: [minor, patch]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      actions:
+        patterns: ["*"]
+    ignore:
+      # Held at v0 on purpose: action-v1 renames the macOS bundle with the
+      # version and rewrites latest.json's URLs, which the release workflow's
+      # rename step and manifest job both build on. See release.yml.
+      - dependency-name: tauri-apps/tauri-action
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,35 @@
+# Advisories, on a schedule rather than in the PR gate: a new advisory
+# against a crate nobody touched should not turn an unrelated PR red. A red
+# run here is a fix or an entry in .cargo/audit.toml with the reason written
+# beside it, never a silence.
+#
+# cargo-audit is built on the runner rather than fetched: one more
+# third-party action is a worse trade than two minutes a week.
+
+name: audit
+
+on:
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  cargo:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo install cargo-audit --locked
+      - run: cargo audit
+
+  npm:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+      # From the lockfile alone; the registry answers without an install.
+      - run: npm --prefix ui audit --audit-level=high

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     # into a fast, named failure instead of an hour of runner smoke.
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -45,19 +45,28 @@ jobs:
       - run: cargo test --workspace --no-fail-fast
 
   ui:
+    # One runner per engine. The two projects share nothing at run time,
+    # and a runner that installs one browser and runs one project finishes
+    # in about half the time of one that does both; the checks before the
+    # suite are cheap enough to repeat. fail-fast is off so a failure in one
+    # engine still shows what the other did.
+    strategy:
+      fail-fast: false
+      matrix:
+        engine: [webkit, chromium]
     runs-on: ubuntu-22.04
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: ui/package-lock.json
       - run: npm --prefix ui ci
       - run: npm --prefix ui run check
-      - name: Install Playwright browsers
-        run: cd ui && npx playwright install --with-deps webkit chromium
+      - name: Install Playwright ${{ matrix.engine }}
+        run: cd ui && npx playwright install --with-deps ${{ matrix.engine }}
       # One spec is skipped by name, its debt on record rather than hidden
       # in a green run: "a standalone view gets the same box the app gives
       # it" — its APP_CHROME_PX constant bakes a macOS font metric and reads
@@ -65,7 +74,7 @@ jobs:
       # delete the filter so it gates again. (The create_event specs used to
       # be here too; their cause — a form that grew past the viewport after
       # placement — was found and fixed on 2026-08-14.)
-      - name: UI suite
+      - name: UI suite (${{ matrix.engine }})
         run: |
-          cd ui && npx playwright test --ignore-snapshots \
+          cd ui && npx playwright test --project=${{ matrix.engine }} --ignore-snapshots \
             --grep-invert "a standalone view gets the same box the app gives it"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,9 @@ jobs:
           - platform: macos-latest
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
 
@@ -101,6 +101,12 @@ jobs:
             echo "APPLE_API_KEY_PATH=$RUNNER_TEMP/apple-api-key.p8" >> "$GITHUB_ENV"
           fi
 
+      # Held at v0 on purpose (2026-09-06). action-v1 names the macOS
+      # `.app.tar.gz` and its `.sig` with the version, and writes GitHub API
+      # URLs into latest.json in place of browser download URLs; the rename
+      # step and the manifest job below both build on v0's names. Moving to
+      # v1 is a change to those two, not a version edit, and Dependabot is
+      # told the same in .github/dependabot.yml.
       - name: Build the bundles
         uses: tauri-apps/tauri-action@v0
         env:
@@ -298,7 +304,7 @@ jobs:
       # them a few days, long enough to hand one to a tester.
       - name: Upload artifacts (smoke test)
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: omacal-${{ matrix.platform }}
           path: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -981,7 +981,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1182,7 +1182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1751,9 +1751,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2661,7 +2661,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.19",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2741,7 +2741,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3663,7 +3663,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4023,7 +4023,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4080,7 +4080,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4535,7 +4535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5344,7 +5344,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5763,7 +5763,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.19",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5792,7 +5792,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6232,7 +6232,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1467,9 +1467,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
The 2026-09-06 review's CI items, in two commits.

**Actions and the UI job.** checkout, setup-node and upload-artifact go v4 → v7 (Node 24). tauri-action stays on v0 on purpose: action-v1 renames the macOS bundle with the version and rewrites latest.json's URLs, and the release workflow's rename step and manifest job both build on v0's names. The note is in release.yml beside the line, and Dependabot is told the same. The UI job becomes one runner per engine, which should roughly halve its wall time.

**Dependabot and audits.** Monthly Dependabot over cargo, npm and actions, grouped by ecosystem with majors on their own. A weekly `audit` workflow runs cargo audit and npm audit, deliberately off the PR gate. Run locally first, it found two advisories: h2 gets its compatible fix (0.4.15 → 0.4.19), and rsa's Marvin advisory, which has no fix and reaches the lock only through sqlx's mysql feature that nothing here enables, is excepted in `.cargo/audit.toml` with the reason and the re-check command. npm's one high finding (nanoid) is a lockfile bump.

Locally: clippy with `-D warnings` and the workspace suite green, the UI suite green as CI runs it, both audits clean. The release workflow's bumps are only exercised by a tag or a dispatch; a `workflow_dispatch` of release.yml on this branch is the smoke test for those.

Dependabot alerts were switched on for the repo today, so the security tab is live too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GabzsFfyts4eNZMbTkhtkQ