### PR TITLE
security(webview): a Content-Security-Policy, and the suite runs under it

### DIFF
--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -50,6 +50,14 @@ precedence pinned by four tests proven against two mutations):**
   secret at release-build time. It is extractable from binaries regardless —
   keeping it out of source dodges scrapers and keeps rotation meaningful.
 
+**The webview runs under a Content Security Policy** (`app.security.csp` in
+`tauri.conf.json`, since 2026-09-06): the bundled scripts and styles, no
+remote loads, and the IPC origins the backend answers on. Inline styles stay
+allowed because Svelte positions events with them. The UI suite runs under
+the same policy (`ui/tests/harness/index.html`, held to the config by
+`ui/tests/csp.spec.ts`), so a change that would need loosening it fails a
+test before it blanks a window.
+
 ## 2. The Google consent screen, per audience
 
 All users of the official binaries share one Cloud project, so its state is

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,8 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; connect-src 'self' ipc: http://ipc.localhost; object-src 'none'; base-uri 'self'",
+      "devCsp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; connect-src 'self' ipc: http://ipc.localhost ws://localhost:1420; object-src 'none'; base-uri 'self'"
     }
   },
   "bundle": {

--- a/ui/tests/csp.spec.ts
+++ b/ui/tests/csp.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const app = () => '/tests/harness/index.html?c=App&f=default';
+
+/**
+ * The harness runs the whole suite under the app's Content-Security-Policy
+ * (tests/harness/index.html), so a new inline script, remote image or eval
+ * fails a test here rather than blanking a user's window. This is the one
+ * place the two copies are held together: the harness's may differ from
+ * tauri.conf.json's only by Vite's HMR socket, and the dev policy only by
+ * the dev server's.
+ */
+const IPC = "connect-src 'self' ipc: http://ipc.localhost;";
+
+test("the harness runs under the app's own Content-Security-Policy", async ({ page }) => {
+  const conf = JSON.parse(readFileSync(
+    fileURLToPath(new URL('../../src-tauri/tauri.conf.json', import.meta.url)), 'utf8',
+  ));
+  const app: string = conf.app.security.csp;
+  expect(app, 'the app policy names the IPC origins the backend answers on').toContain(IPC);
+  expect(conf.app.security.devCsp).toBe(app.replace(IPC, IPC.replace(';', ' ws://localhost:1420;')));
+
+  await page.goto('/tests/harness/index.html');
+  const meta = page.locator('meta[http-equiv="Content-Security-Policy"]');
+  await expect(meta).toHaveCount(1);
+  expect(await meta.getAttribute('content')).toBe(app.replace(IPC, IPC.replace(';', ' ws://localhost:5199;')));
+});
+
+/**
+ * A violation is not an error the suite would otherwise see: a blocked
+ * stylesheet or socket degrades the page without failing an assertion. The
+ * document reports each one as an event, so the app page is loaded and
+ * driven a little with a listener in place, and the list must stay empty.
+ */
+test('the app page raises no policy violation', async ({ page }) => {
+  await page.addInitScript(() => {
+    (window as any).__cspViolations = [];
+    document.addEventListener('securitypolicyviolation', (e) => {
+      (window as any).__cspViolations.push(`${e.violatedDirective} ${e.blockedURI}`);
+    });
+  });
+  await page.goto(app());
+  await expect(page.locator('.ev').first()).toBeVisible();
+  await page.locator('.ev').first().click();
+  await page.getByRole('button', { name: 'Menu' }).click();
+  await page.getByRole('button', { name: 'Settings…' }).click();
+  await expect(page.getByRole('dialog', { name: 'Settings' })).toBeVisible();
+  expect(await page.evaluate(() => (window as any).__cspViolations)).toEqual([]);
+});

--- a/ui/tests/harness/index.html
+++ b/ui/tests/harness/index.html
@@ -1,6 +1,14 @@
 <!doctype html>
 <html>
-  <head><meta charset="utf-8" /><title>omacal harness</title></head>
+  <head>
+    <meta charset="utf-8" />
+    <!-- The app's Content-Security-Policy from tauri.conf.json, plus Vite's
+         HMR socket. The suite runs under it so a new inline script, remote
+         image or eval fails here and not as a blank window on a user's
+         desktop; csp.spec.ts holds this copy and the config together. -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; connect-src 'self' ipc: http://ipc.localhost ws://localhost:5199; object-src 'none'; base-uri 'self'" />
+    <title>omacal harness</title>
+  </head>
   <body style="margin:0">
     <div id="app"></div>
     <script type="module" src="/tests/harness/mount.svelte.ts"></script>


### PR DESCRIPTION
Batch 2 of the 2026-09-06 review: the webview had `csp: null`.

**The policy.** Bundled scripts and styles, no remote loads, and the IPC origins the backend answers on (`ipc:` on Linux, `http://ipc.localhost` on macOS), which Tauri does not add by itself. Inline styles stay allowed: Svelte positions events with style attributes, and with no nonce beside it the allowance holds. The dev policy adds Vite's HMR socket.

**The suite runs under it.** The test harness carries the same policy plus its own HMR socket, so a new inline script, remote image or eval fails a test before it blanks a window. `csp.spec.ts` holds the three copies together and drives the app page with a `securitypolicyviolation` listener that must stay empty. Under the policy every test passes as before and the goldens compare pixel-identical, which says the styles still apply.

**Verification.** Linux: a release build from this branch, run live on the Omarchy box (result in a comment below). macOS: Plamen runs the branch build on the Mac; the checklist is in the session notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GabzsFfyts4eNZMbTkhtkQ