### PR TITLE
fix(bigyear): a pale calendar's pills are readable again

### DIFF
--- a/ui/src/lib/BigYearRibbon.svelte
+++ b/ui/src/lib/BigYearRibbon.svelte
@@ -421,10 +421,22 @@
       var(--event-fill) var(--event-fill-opacity),
       transparent
     );
-    /* `--ink` is chosen for a solid calendar-colour fill. Once that fill is
-       translucent, theme text mixed toward the calendar colour is the stable
-       contrast target instead. */
-    color: color-mix(in srgb, var(--cal) 60%, var(--text));
+    /* `--ink` was chosen against the solid calendar colour. The fill is that
+       colour at `--event-fill-opacity` over the canvas, so while most of it
+       is there the ink still fits it, and once most of it has gone the
+       theme's own text — chosen for the canvas — fits better. A step at
+       half, not a blend: halfway between a near-black and a near-white ink
+       is a grey that reads on neither. The `clamp` is that step in CSS:
+       any fill over 50% resolves to all `--ink`, any under to all `--text`.
+       At 0% transparency — the default off Omarchy — and at Omarchy's 4%,
+       this is exactly `--ink`. (1.9.0 mixed the *calendar colour* into the
+       theme text here, which on a pale calendar drew pale on pale; the
+       tooltip was the only way to read the pill.) */
+    color: color-mix(
+      in srgb,
+      var(--ink) clamp(0%, calc((var(--event-fill-opacity) - 50%) * 1000), 100%),
+      var(--text)
+    );
   }
   :global(:root[data-event-transparency]) .pill.cl { border-left-color: currentColor; }
   :global(:root[data-event-transparency]) .pill.lit {

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -829,6 +829,82 @@ test.describe('EventBlock hover occludes what it covers', () => {
   });
 });
 
+/**
+ * A Big Year pill is the one place a calendar's own colour is the fill, so
+ * its ink is chosen per event from that colour's luminance (`ink.ts`). 1.9.0
+ * replaced that ink, whenever the transparency attribute was present — which
+ * is always — with the calendar colour mixed into the theme text: on a pale
+ * calendar, pale on pale, and a Mac user read the pills by their tooltips.
+ * The property that matters is contrast, so that is what is asserted, from
+ * the computed colours composited the way the screen does it.
+ */
+test.describe('Big Year pill ink', () => {
+  type RGBA = [number, number, number, number];
+  /** A computed colour in either serialisation an engine uses: legacy
+   *  `rgb()`/`rgba()`, or `color(srgb r g b / a)` for a `color-mix()`. */
+  const rgba = (css: string): RGBA => {
+    let m = /^rgba?\(([^)]+)\)$/.exec(css.trim());
+    if (m) {
+      const [r, g, b, a = '1'] = m[1].split(/[\s,/]+/).filter(Boolean);
+      return [Number(r), Number(g), Number(b), Number(a)];
+    }
+    m = /^color\(srgb\s+([^)]+)\)$/.exec(css.trim());
+    if (m) {
+      const [r, g, b, a = '1'] = m[1].split(/[\s/]+/).filter(Boolean);
+      return [Number(r) * 255, Number(g) * 255, Number(b) * 255, Number(a)];
+    }
+    throw new Error(`not a computed colour: ${css}`);
+  };
+  const over = (fg: RGBA, bg: RGBA): RGBA => [
+    fg[0] * fg[3] + bg[0] * (1 - fg[3]),
+    fg[1] * fg[3] + bg[1] * (1 - fg[3]),
+    fg[2] * fg[3] + bg[2] * (1 - fg[3]),
+    1,
+  ];
+  const luminance = ([r, g, b]: RGBA): number => {
+    const lin = (v: number) => { const s = v / 255; return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4; };
+    return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+  };
+  const contrast = (a: RGBA, b: RGBA): number => {
+    const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+    return (hi + 0.05) / (lo + 0.05);
+  };
+
+  for (const [name, transparency, fill] of [
+    ['solid', '0', '100%'],
+    ["Omarchy's default", '4', '96%'],
+    ['half faded', '50', '50%'],
+    ['faded away', '100', '0%'],
+  ] as const) {
+    test(`a pale calendar's pill stays readable on a ${name} fill`, async ({ page }) => {
+      await page.goto(show('BigYearRibbon', 'two-pills'));
+      const pill = page.getByRole('button', { name: 'Team offsite' });  // #2dd4bf, needs dark ink
+      await expect(pill).toBeVisible();
+      await page.evaluate(([t, f]) => {
+        const root = document.documentElement;
+        root.dataset.eventTransparency = t;
+        root.style.setProperty('--event-fill-opacity', f);
+      }, [transparency, fill]);
+      const { ink, pillFill, canvas } = await pill.evaluate((el) => {
+        const cs = getComputedStyle(el);
+        const canvasEl = el.closest('.ribbon') ?? document.body;
+        return {
+          ink: cs.color,
+          pillFill: cs.backgroundColor,
+          canvas: getComputedStyle(canvasEl).backgroundColor,
+        };
+      });
+      // What the eye meets: the fill over the canvas, then the ink over that.
+      let ground = rgba(canvas);
+      if (ground[3] === 0) ground = [24, 24, 24, 1];  // the harness's dark canvas when unset
+      const surface = over(rgba(pillFill), ground);
+      const text = over(rgba(ink), surface);
+      expect(contrast(text, surface), `${name}: ink ${ink} on ${pillFill} over ${canvas}`)
+        .toBeGreaterThanOrEqual(3);
+    });
+  }
+});
+
 test.describe('event appearance reaches every calendar representation', () => {
   const cases = [
     ['timed block', show('EventBlock', 'rsvp-accepted-15'), '.ev', true],


### PR DESCRIPTION
Found by Plamen on the Mac while checking the v2.0.0 draft: Big Year pills on a pale calendar were unreadable, the tooltip being the only way to read them.

**Cause.** #21 added a rule that applies whenever the transparency attribute is present, which is always, replacing the luminance-chosen pill ink with the calendar colour mixed into the theme text. On a pale calendar that is pale on pale. It shipped in 1.9.0.

**Fix.** The ink is chosen against the fill again. While most of the fill is there the luminance ink fits it; once most of it has gone, the theme text fits better. The switch is a step at half via a CSS `clamp`, not a blend, because halfway between a near-black and a near-white ink is a grey that reads on neither. At the defaults, 0 and Omarchy's 4, it is exactly the solid-fill ink.

**Test.** A contrast assertion from the computed colours, composited the way the screen does it, at four fill levels in both engines. Against 1.9.0's rule the solid and Omarchy-default cases fail. Full suite green at 1874.

Goes into the 2.0.0 draft, which is re-cut after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GabzsFfyts4eNZMbTkhtkQ