### PR TITLE
chore(deps): rand 0.10 in omacal-google

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3170,7 +3170,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "rand 0.9.5",
+ "rand 0.10.2",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/crates/omacal-google/Cargo.toml
+++ b/crates/omacal-google/Cargo.toml
@@ -13,7 +13,7 @@ serde_json.workspace = true
 reqwest = { version = "0.12", features = ["json", "rustls-tls-webpki-roots", "rustls-tls-native-roots"], default-features = false }
 base64 = "0.22"
 sha2 = "0.10"
-rand = "0.9"
+rand = "0.10"
 url = "2"
 
 [dev-dependencies]

--- a/crates/omacal-google/src/auth.rs
+++ b/crates/omacal-google/src/auth.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Context};
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
-use rand::RngCore;
+use rand::Rng;
 use sha2::{Digest, Sha256};
 
 pub const AUTH_ENDPOINT: &str = "https://accounts.google.com/o/oauth2/v2/auth";


### PR DESCRIPTION
Supersedes #57. rand 0.10 renames its core trait (`RngCore` → `Rng`, the old extension trait → `RngExt`); the PKCE bytes are filled through `fill_bytes` on the renamed trait, so only the import changes. Clippy and the crate's tests are green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GabzsFfyts4eNZMbTkhtkQ