### PR TITLE
fix(views): the calendar's scrollers draw no bar

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -166,3 +166,14 @@ textarea,
   -webkit-user-select: text;
   user-select: text;
 }
+
+/* The calendar's own scrollers draw no bar (2026-09-07, by request). The
+   wheel, the trackpad, the keys and the sideways pan all still move them,
+   and the hour ruler and the now line already say where you are — a bar
+   beside the week was a second ruler nobody read, and on macOS a louder one
+   than the content it measured. Only the views carry the class: a settings
+   page or a guest list has no ruler of its own, so their dialogs keep the
+   bar. Two declarations because the engines split: `scrollbar-width` is the
+   standard one, the pseudo-element is what WebKit honoured first. */
+.quiet-scroll { scrollbar-width: none; }
+.quiet-scroll::-webkit-scrollbar { display: none; }

--- a/ui/src/lib/AllDayBand.svelte
+++ b/ui/src/lib/AllDayBand.svelte
@@ -61,7 +61,7 @@
 {#if lanes.length || overflow.length}
   <div class="band" class:expanded style="--gutter:{gutterWidth()}">
     <div class="label">ALL-DAY</div>
-    <div class="track">
+    <div class="track quiet-scroll">
     <div class="rows" class:sliding style="--cols:{columns}; --visible:{visible}; --vis:{vis}; --pan:{pan}">
       <!-- Keyed by the event's index, so a re-pack moves a chip's node rather
            than tearing it down and building another where it lands. -->

--- a/ui/src/lib/BigYearRibbon.svelte
+++ b/ui/src/lib/BigYearRibbon.svelte
@@ -115,7 +115,7 @@
 </script>
 
 <div class="ribbon" data-year={ribbon.year}>
-  <div class="rows">
+  <div class="rows quiet-scroll">
     {#each ribbon.rows as row, r (r)}
       <div class="rrow">
         <!-- The day cells come first and the pills second, and the order is

--- a/ui/src/lib/Filmstrip.svelte
+++ b/ui/src/lib/Filmstrip.svelte
@@ -124,7 +124,7 @@
 <!-- **No drag handlers anywhere below, and that is the feature** (spec §6): a
      list has no geometry to drop onto, so they are absent rather than disabled.
      Creating still works through `n` and through the form. -->
-<div class="strip" bind:this={stripEl}>
+<div class="strip quiet-scroll" bind:this={stripEl}>
   {#if days.length === 0}
     <!-- Spec §3: a period with nothing in it says so, plainly, rather than
          rendering as blank. Empty days being skipped is exactly what makes an

--- a/ui/src/lib/MonthGrid.svelte
+++ b/ui/src/lib/MonthGrid.svelte
@@ -94,7 +94,7 @@
   {#each DOW as d}<span>{d}</span>{/each}
 </div>
 
-<div class="grid">
+<div class="grid quiet-scroll">
   {#each month.rows as row}
     <div class="mrow">
       <div class="bars">

--- a/ui/src/lib/WeekGrid.svelte
+++ b/ui/src/lib/WeekGrid.svelte
@@ -1379,7 +1379,7 @@
   onopen={openPopover}
 />
 
-<div class="grid body" style="--cols:{renderedDays.length}; --visible:{visible}; --vis:{renderVis}; --pan:{panDays}; --gutter:{gutterWidth()}; --hour-px:{Math.round(hourPx)}px" bind:this={bodyEl} data-testid="week-body" onwheel={wheelPan}>
+<div class="grid body quiet-scroll" style="--cols:{renderedDays.length}; --visible:{visible}; --vis:{renderVis}; --pan:{panDays}; --gutter:{gutterWidth()}; --hour-px:{Math.round(hourPx)}px" bind:this={bodyEl} data-testid="week-body" onwheel={wheelPan}>
   <div class="gutter">
     {#each HOURS as h}
       {#if secondZone()}

--- a/ui/src/lib/YearGrid.svelte
+++ b/ui/src/lib/YearGrid.svelte
@@ -36,7 +36,7 @@
   });
 </script>
 
-<div class="ygrid" data-year={year.year}>
+<div class="ygrid quiet-scroll" data-year={year.year}>
   {#each year.months as month (month.month)}
     <div class="ymonth">
       <div class="mname">{MONTH_NAMES[month.month - 1]}</div>

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -5652,3 +5652,31 @@ test.describe('Weather card', () => {
     await expect(c).toContainText('High 92° · Low 77°');
   });
 });
+
+/**
+ * The calendar's scrollers draw no bar (2026-09-07); the dialogs keep
+ * theirs. Hiding the bar must not cost the scrolling itself, so the week
+ * body is moved and read back.
+ */
+test.describe('quiet scrolling', () => {
+  test('the week body and the filmstrip scroll without a bar, and still scroll', async ({ page }) => {
+    await page.goto(show('WeekGrid', 'populated'));
+    const body = page.locator('.body');
+    expect(await body.evaluate((el) => getComputedStyle(el).scrollbarWidth)).toBe('none');
+    const moved = await body.evaluate((el) => {
+      el.scrollTop = 200;
+      return el.scrollTop;
+    });
+    expect(moved).toBe(200);
+
+    await page.goto(show('Filmstrip', 'week'));
+    expect(await page.locator('.strip').evaluate((el) => getComputedStyle(el).scrollbarWidth)).toBe('none');
+  });
+
+  test('a dialog keeps its bar', async ({ page }) => {
+    await page.goto(show('EventPopover', 'standup'));
+    const pop = page.getByRole('dialog').first();
+    await expect(pop).toBeVisible();
+    expect(await pop.evaluate((el) => getComputedStyle(el).scrollbarWidth)).toBe('auto');
+  });
+});


### PR DESCRIPTION
Plamen: the vertical scrollbar is not needed, and it is louder on macOS.

The calendar views (week body, filmstrip, month and year grids, Big Year rows, the expanded all-day band) carry a `quiet-scroll` class that hides the bar in both engines (`scrollbar-width: none` and the WebKit pseudo-element). Scrolling itself is unchanged: wheel, trackpad, keys and the sideways pan. Dialogs keep their bar, since a settings page or a guest list has no ruler of its own.

Spec: the week body and the filmstrip report no bar and the body still scrolls when moved; a dialog reports its bar. Against the rule removed, the spec reddens. Full suite green at 1894 with the goldens untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GabzsFfyts4eNZMbTkhtkQ