### PR TITLE
feat(tasks): the list picker filters the tasks it targets (#68)

### DIFF
--- a/ui/src/lib/TasksPanel.svelte
+++ b/ui/src/lib/TasksPanel.svelte
@@ -15,7 +15,14 @@
   let busyIds = $state<Set<number>>(new Set());
 
   let newTitle = $state('');
-  let newListId = $state<number | null>(null);
+  /** The list the picker is on, or null for all of them.
+   *
+   *  One control, two jobs (#68): it filters the rows to that list *and*
+   *  it is where a new task lands. Null is the default and stays the
+   *  default — opening the panel shows every task, as it always has, and
+   *  a picker that started on one list would look like the others had
+   *  gone. */
+  let filterListId = $state<number | null>(null);
   let adding = $state(false);
 
   $effect(() => {
@@ -24,7 +31,6 @@
         const [t, l] = await Promise.all([listTasks(), taskLists()]);
         tasks = t;
         lists = l;
-        if (newListId === null && l.length > 0) newListId = l[0].calendarId;
       } catch (e) {
         note = String(e);
         tasks = [];
@@ -34,8 +40,28 @@
 
   escapeCloses(() => true, () => onclose());
 
-  const open = $derived((tasks ?? []).filter((t) => !t.completed));
-  const done = $derived((tasks ?? []).filter((t) => t.completed));
+  /** Where a new task lands: the chosen list, or the first when the picker
+   *  is on "All lists". `taskLists` only ever offers lists a task can be
+   *  created on, so the first is a safe target rather than a guess — and
+   *  the input names it either way, so it is never a silent one. */
+  const targetList = $derived(
+    filterListId === null
+      ? (lists[0] ?? null)
+      : (lists.find((l) => l.calendarId === filterListId) ?? null),
+  );
+  const shown = $derived(
+    filterListId === null
+      ? (tasks ?? [])
+      : (tasks ?? []).filter((t) => t.calendarId === filterListId),
+  );
+  const open = $derived(shown.filter((t) => !t.completed));
+  const done = $derived(shown.filter((t) => t.completed));
+  /** A list chosen from the picker that holds nothing — different from
+   *  having no tasks at all, and told apart so the empty panel does not
+   *  claim there are no task lists. */
+  const emptyList = $derived(
+    tasks !== null && tasks.length > 0 && shown.length === 0 ? targetList : null,
+  );
 
   async function toggle(task: Task) {
     if (busyIds.has(task.id)) return;
@@ -62,11 +88,11 @@
   }
 
   async function add() {
-    if (adding || newListId === null || newTitle.trim() === '') return;
+    if (adding || targetList === null || newTitle.trim() === '') return;
     note = null;
     adding = true;
     try {
-      tasks = await createTask(newListId, newTitle, null);
+      tasks = await createTask(targetList.calendarId, newTitle, null);
       newTitle = '';
     } catch (e) {
       note = String(e);
@@ -108,15 +134,21 @@
         void add();
       }}
     >
+      <!-- The placeholder names the target whenever the picker does not —
+           on "All lists" a task still has to land somewhere, and a guess
+           the user cannot see is the thing worth avoiding. -->
       <input
         type="text"
-        placeholder="Add a task…"
+        placeholder={filterListId === null && lists.length > 1 && targetList
+          ? `Add to ${targetList.name}…`
+          : 'Add a task…'}
         aria-label="New task title"
         bind:value={newTitle}
         disabled={adding}
       />
       {#if lists.length > 1}
-        <select aria-label="Task list" bind:value={newListId} disabled={adding}>
+        <select aria-label="Task list" bind:value={filterListId} disabled={adding}>
+          <option value={null}>All lists</option>
           {#each lists as l (l.calendarId)}
             <option value={l.calendarId}>{l.name}</option>
           {/each}
@@ -132,6 +164,8 @@
       No tasks yet. Task lists arrive with an iCloud or CalDAV account
       (Settings → Accounts).
     </p>
+  {:else if emptyList}
+    <p class="empty">Nothing in {emptyList.name}.</p>
   {:else}
     <ul>
       {#each open as t (t.id)}

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -4867,3 +4867,81 @@ test.describe("App: showing today's date", () => {
     await expect(modal.getByLabel("Show today's date")).toBeChecked();
   });
 });
+
+/**
+ * The tasks panel's list picker, which does two jobs (#68, @xmha97): it
+ * chooses where a new task lands *and* filters the rows to that list.
+ *
+ * The panel had no coverage at all before this; these are its first specs,
+ * so they pin the default view as well as the filtering, because "shows
+ * every task until you say otherwise" is the behaviour a filter is most
+ * likely to break.
+ */
+test.describe('the tasks panel', () => {
+  const openTasks = async (page: import('@playwright/test').Page) => {
+    await page.goto(app());
+    await page.getByRole('button', { name: 'Menu' }).click();
+    await page.getByRole('button', { name: 'Tasks…' }).click();
+    return page.getByRole('dialog', { name: 'Tasks' });
+  };
+
+  test('opens on every list, and the picker filters to one', async ({ page }) => {
+    const panel = await openTasks(page);
+    await expect(panel.getByText('Buy milk')).toBeVisible();
+    await expect(panel.getByText('Ship the release')).toBeVisible();
+    await expect(panel.getByText('Old standup note')).toBeVisible();
+    await expect(panel.getByRole('combobox', { name: 'Task list' })).toHaveValue('');
+
+    await panel.getByRole('combobox', { name: 'Task list' }).selectOption({ label: 'Work' });
+    await expect(panel.getByText('Buy milk')).toHaveCount(0);
+    await expect(panel.getByText('Ship the release')).toBeVisible();
+    // The Done section is filtered by the same rule, not left behind.
+    await expect(panel.getByText('Old standup note')).toBeVisible();
+
+    await panel.getByRole('combobox', { name: 'Task list' }).selectOption({ label: 'Personal' });
+    await expect(panel.getByText('Buy milk')).toBeVisible();
+    await expect(panel.getByText('Ship the release')).toHaveCount(0);
+    await expect(panel.getByText('Old standup note')).toHaveCount(0);
+
+    await panel.getByRole('combobox', { name: 'Task list' }).selectOption({ label: 'All lists' });
+    await expect(panel.getByText('Buy milk')).toBeVisible();
+    await expect(panel.getByText('Ship the release')).toBeVisible();
+  });
+
+  test('a new task lands on the chosen list, and the filter keeps it in view', async ({ page }) => {
+    const panel = await openTasks(page);
+    await panel.getByRole('combobox', { name: 'Task list' }).selectOption({ label: 'Work' });
+    await panel.getByRole('textbox', { name: 'New task title' }).fill('Cut 2.3.0');
+    await panel.getByRole('textbox', { name: 'New task title' }).press('Enter');
+
+    await expect(panel.getByText('Cut 2.3.0')).toBeVisible();
+    // It landed on Work, so Personal does not have it.
+    await panel.getByRole('combobox', { name: 'Task list' }).selectOption({ label: 'Personal' });
+    await expect(panel.getByText('Cut 2.3.0')).toHaveCount(0);
+  });
+
+  /** On "All lists" a task still has to land somewhere, and the input says
+   *  where rather than leaving it to be discovered afterwards. */
+  test('on every list, the input names where a new task will land', async ({ page }) => {
+    const panel = await openTasks(page);
+    const input = panel.getByRole('textbox', { name: 'New task title' });
+    await expect(input).toHaveAttribute('placeholder', 'Add to Personal…');
+
+    await panel.getByRole('combobox', { name: 'Task list' }).selectOption({ label: 'Work' });
+    await expect(input).toHaveAttribute('placeholder', 'Add a task…');
+  });
+
+  /** A list with nothing in it is not the same as having no task lists,
+   *  and the empty panel must not claim the second. */
+  test('an empty list says it is empty, not that there are no lists', async ({ page }) => {
+    const panel = await openTasks(page);
+    await panel.getByRole('combobox', { name: 'Task list' }).selectOption({ label: 'Personal' });
+    await expect(panel.getByText('Buy milk')).toBeVisible();
+
+    // The delete button is hidden until its row is hovered.
+    await panel.locator('li', { hasText: 'Buy milk' }).hover();
+    await panel.getByRole('button', { name: 'Delete Buy milk' }).click();
+    await expect(panel.getByText('Nothing in Personal.')).toBeVisible();
+    await expect(panel.getByText('No tasks yet.')).toHaveCount(0);
+  });
+});

--- a/ui/tests/fixtures.ts
+++ b/ui/tests/fixtures.ts
@@ -1985,6 +1985,22 @@ POPOVER_DETAILS[XZONE_ID] = detail({
  *  would leak into the next `get_week` of the same run. */
 export const crossZoneWeek = (): WeekPayload => structuredClone(XZONE_GOLDEN);
 
+/** Two task lists with tasks on both, which is the only shape in which a
+ *  picker that filters can be told from one that does not (#68). `Work`
+ *  carries a done row as well, so the Done section is filtered too. */
+export const TASK_LISTS = [
+  { calendarId: 1, name: 'Personal', color: '#5b8def' },
+  { calendarId: 2, name: 'Work', color: '#2dd4bf' },
+];
+export const TASKS = [
+  { id: 11, calendarId: 1, summary: 'Buy milk', notes: null, dueMs: null, dueAllDay: false,
+    completed: false, calendar: 'Personal', color: '#5b8def', priority: 0, canWrite: true },
+  { id: 12, calendarId: 2, summary: 'Ship the release', notes: null, dueMs: null, dueAllDay: false,
+    completed: false, calendar: 'Work', color: '#2dd4bf', priority: 0, canWrite: true },
+  { id: 13, calendarId: 2, summary: 'Old standup note', notes: null, dueMs: null, dueAllDay: false,
+    completed: true, calendar: 'Work', color: '#2dd4bf', priority: 0, canWrite: true },
+];
+
 export const FIXTURES: Record<string, Record<string, any>> = {
   WeatherPopover: WEATHER_CARD_FIXTURES,
   WeekGrid: {

--- a/ui/tests/harness/tauri.ts
+++ b/ui/tests/harness/tauri.ts
@@ -21,6 +21,7 @@ import type { TemperatureUnit } from '../../src/lib/temperature';
 import { sliceWeek } from '../../src/lib/weekwindow';
 import {
   labelledWeek, weekLabel, APP_FIVE_MIN_AGO, APP_NOW, APP_SERIES_ID, APP_SERIES_OCCURRENCE,
+  TASK_LISTS, TASKS,
   APP_ONE_OFF_ID, APP_ONE_OFF_START, APP_GUESTS_ID, APP_SOLO_SERIES_ID,
   POPOVER_DETAILS, busyDayMonth,
   appWritableWeek, APP_WRITE_CALENDARS, APP_WEATHER, CREATED_DETAIL, crossZoneWeek,
@@ -589,6 +590,9 @@ type StubSettings = {
   windowFrame: WindowFrame | null;
 };
 
+/** The stub's task rows, mutable for the life of the page. */
+let taskRows: typeof TASKS = [...TASKS];
+
 const SETTINGS_KEY = 'omacal-stub-settings';
 
 /** What `list_timezones` answers and `set_second_timezone` validates
@@ -1099,6 +1103,30 @@ export function installTauriStub(scenario: string): Harness {
           return 'me@x.com';
         }
         return 'me@x.com';
+      // The tasks panel reads and writes its own rows; the stub keeps them
+      // in memory for the life of the page, so a create is visible to the
+      // next `list_tasks` exactly as the backend's would be.
+      case 'list_tasks':
+        return taskRows;
+      case 'task_lists':
+        return TASK_LISTS;
+      case 'create_task': {
+        const listId = args.calendarId as number;
+        const list = TASK_LISTS.find((l) => l.calendarId === listId)!;
+        taskRows = [...taskRows, {
+          id: 900 + taskRows.length, calendarId: listId, summary: args.summary as string,
+          notes: null, dueMs: null, dueAllDay: false, completed: false,
+          calendar: list.name, color: list.color, priority: 0, canWrite: true,
+        }];
+        return taskRows;
+      }
+      case 'set_task_completed':
+        taskRows = taskRows.map((t) =>
+          t.id === args.id ? { ...t, completed: args.completed as boolean } : t);
+        return taskRows;
+      case 'delete_task_cmd':
+        taskRows = taskRows.filter((t) => t.id !== args.id);
+        return taskRows;
       default:
         throw new Error(`unstubbed command: ${cmd}`);
     }


### PR DESCRIPTION
Closes #68.

@xmha97 asked for one control to do both jobs: choose where a new task lands and narrow the rows to that list. It now does, with an **All lists** entry that stays the default, since a picker starting on one list would look like the others had gone.

Two decisions worth naming:
- On "All lists" a task still has to land somewhere, so the input says where: "Add to Personal…". That is the only new guess this adds, and it is visible.
- A chosen list holding nothing says so by name, rather than falling through to the "no tasks yet" text, which claims there are no task lists at all.

Note the control is the **task list** picker (`aria-label="Task list"`), not an account picker; each list belongs to an account, and filtering by list is the finer of the two readings. Say if you meant per-account grouping instead.

**Tests.** The panel had none before this. These are its first: the default view, filtering across both the open and Done sections, a create landing on the chosen list, the named target, and the empty-list wording. They needed a harness stub for the five task commands, which did not exist. A picker that filters nothing reddens six of the eight. Full UI suite green at 1910.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GabzsFfyts4eNZMbTkhtkQ