### PR TITLE
feat(import): drop an .ics on the calendar to import it (#67)

### DIFF
--- a/src-tauri/src/import.rs
+++ b/src-tauri/src/import.rs
@@ -1,0 +1,613 @@
+//! Importing events from an `.ics` file (#67).
+//!
+//! **Planning is separate from doing, and the plan is the product.** An
+//! import is the one operation here that writes many events at once, from a
+//! file the app did not write, so the thing that matters is knowing what it
+//! will do before it does it: this module reads a file and answers with one
+//! [`Planned`] per VEVENT — imported with these fields, or skipped with this
+//! reason. The surfaces show that plan (`--dry-run`, and the dialog's
+//! preview) and then hand the same plan back to be executed.
+//!
+//! Three rules decide what is skipped, and all three are the same rule:
+//! **never silently alter what the file said.**
+//!
+//! - A **repeat rule the app cannot express** is not downgraded to a single
+//!   event. `write::EventInput` carries the form's vocabulary — daily,
+//!   weekdays, weekly, monthly, yearly — rather than an RRULE, deliberately
+//!   (see its doc comment), so a rule outside that set has no honest
+//!   representation here. Importing the first occurrence and calling it the
+//!   series would be a lie about the user's data.
+//! - **Guests are never imported.** A create carries its guest list to the
+//!   server, and a server invites the people on it. Importing a colleague's
+//!   exported year would email everyone they ever met, about meetings that
+//!   already happened. The events come in; the guest lists stay out, and the
+//!   plan says so per event.
+//! - An event whose **UID is already in the database** is skipped, so the
+//!   same file imported twice does not double anything.
+//!
+//! Everything the plan does import goes through `events::create_event_body`,
+//! the path the window and the CLI already write through. No second write
+//! path, and no raw resource PUT: a lossless CalDAV import would be one, and
+//! it would be the only way into the database that none of this repo's
+//! guards cover.
+
+use omacal_caldav::ics;
+use sqlx::Row;
+
+/// What an import will do with one VEVENT.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum Planned {
+    /// Will be created, with these fields.
+    Import {
+        summary: String,
+        /// When it starts, as the row will read it: ms epoch.
+        start_ms: i64,
+        all_day: bool,
+        /// The repeat the form's vocabulary can express, when the file
+        /// carried one at all.
+        repeat: Option<String>,
+        /// How many guests the file listed and this import will not carry.
+        /// Zero for an ordinary event; the count is what the preview shows,
+        /// so the omission is stated rather than discovered.
+        dropped_guests: usize,
+    },
+    /// Will not be created, and why — in the words the surfaces print.
+    Skip { summary: String, reason: String },
+}
+
+impl Planned {
+    pub fn summary(&self) -> &str {
+        match self {
+            Planned::Import { summary, .. } | Planned::Skip { summary, .. } => summary,
+        }
+    }
+}
+
+/// The reasons a plan gives, as constants so a surface and a test cannot
+/// disagree about the wording.
+pub const SKIP_ALREADY_HERE: &str = "already in this calendar";
+pub const SKIP_UNEXPRESSIBLE_REPEAT: &str =
+    "repeats in a way this version cannot store; import it from the app that wrote it";
+pub const SKIP_NO_START: &str = "no usable start time";
+pub const SKIP_AN_OCCURRENCE: &str = "an exception to a series, which cannot be imported on its own";
+
+/// The RRULE shapes `write::rrule_for` can produce, inverted.
+///
+/// Deliberately exact rather than clever: the point is to recognise only
+/// what the app can store *and* re-emit unchanged, so a rule that merely
+/// looks close (`FREQ=WEEKLY;INTERVAL=2`, a `BYDAY` that is not the working
+/// week, a `COUNT`) is not one of these and is skipped. The inverse of a
+/// five-entry table is a five-entry table.
+pub fn repeat_for_rrule(lines: &[String]) -> Option<Option<&'static str>> {
+    // An event with EXDATE or RDATE has a rule the form cannot carry either,
+    // whatever its RRULE says.
+    if lines.iter().any(|l| {
+        let name = l.split([':', ';']).next().unwrap_or("").to_ascii_uppercase();
+        name == "EXDATE" || name == "RDATE"
+    }) {
+        return None;
+    }
+    let mut rules = lines.iter().filter(|l| {
+        l.split([':', ';']).next().unwrap_or("").eq_ignore_ascii_case("RRULE")
+    });
+    let Some(rule) = rules.next() else {
+        return Some(None); // no rule at all: a single event, importable
+    };
+    if rules.next().is_some() {
+        return None; // two rules is not a shape the form has
+    }
+    let body = rule.split_once(':').map(|(_, v)| v).unwrap_or("").to_ascii_uppercase();
+    let normalised = body.replace(' ', "");
+    Some(Some(match normalised.as_str() {
+        "FREQ=DAILY" => "daily",
+        "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR" => "weekdays",
+        "FREQ=WEEKLY" => "weekly",
+        "FREQ=MONTHLY" => "monthly",
+        "FREQ=YEARLY" => "yearly",
+        _ => return None,
+    }))
+}
+
+/// Plans an import of `src` into a calendar whose zone is `cal_tz`, given
+/// the UIDs that calendar already holds.
+///
+/// A file that is not iCalendar at all answers `None`; a file with no
+/// events answers an empty plan, which the surfaces report as such rather
+/// than as a failure.
+pub fn plan(src: &str, cal_tz: &str, existing_uids: &[String]) -> Option<Vec<Planned>> {
+    let root = ics::parse(src)?;
+    let events = ics::events_in(&root);
+    Some(
+        events
+            .into_iter()
+            .map(|ev| {
+                let summary = ev.summary.clone().unwrap_or_else(|| "(no title)".into());
+                if ev.recurrence_id.is_some() {
+                    return Planned::Skip { summary, reason: SKIP_AN_OCCURRENCE.into() };
+                }
+                if existing_uids.contains(&ev.uid) {
+                    return Planned::Skip { summary, reason: SKIP_ALREADY_HERE.into() };
+                }
+                let Some(repeat) = repeat_for_rrule(&ev.recurrence) else {
+                    return Planned::Skip { summary, reason: SKIP_UNEXPRESSIBLE_REPEAT.into() };
+                };
+                let Some((start_ms, _tz, all_day)) = ics::resolve(&ev.start, cal_tz) else {
+                    return Planned::Skip { summary, reason: SKIP_NO_START.into() };
+                };
+                Planned::Import {
+                    summary,
+                    start_ms,
+                    all_day,
+                    repeat: repeat.map(str::to_string),
+                    dropped_guests: ev.attendees.len(),
+                }
+            })
+            .collect(),
+    )
+}
+
+/// One planned event, as the create path takes it.
+///
+/// Built only for an event the plan already accepted, so every refusal has
+/// happened before this point: this function maps, it does not judge.
+/// Guests are absent by construction rather than by omission — see the
+/// module doc for why importing them would email people.
+pub(crate) fn input_for(
+    ev: &ics::CalEvent,
+    cal_tz: &str,
+    repeat: Option<&str>,
+) -> Option<crate::write::EventInput> {
+    let (start_ms, _tz, all_day) = ics::resolve(&ev.start, cal_tz)?;
+    let when = if all_day {
+        // The dates as the form holds them: an inclusive start and the
+        // exclusive end iCalendar already uses. A missing DTEND is the
+        // RFC's one day.
+        let start_date = all_day_date(&ev.start)?;
+        let end_date = ev
+            .end
+            .as_ref()
+            .and_then(all_day_date)
+            .or_else(|| next_day(&start_date))?;
+        crate::write::WhenInput::AllDay { start_date, end_date }
+    } else {
+        // DTEND, else DTSTART plus DURATION, else the RFC's instant event.
+        let end_ms = ev
+            .end
+            .as_ref()
+            .and_then(|e| ics::resolve(e, cal_tz))
+            .map(|(ms, _, _)| ms)
+            .or_else(|| ev.duration_ms.map(|d| start_ms + d))
+            .unwrap_or(start_ms);
+        crate::write::WhenInput::Timed { start_ms, end_ms }
+    };
+    Some(crate::write::EventInput {
+        summary: ev.summary.clone(),
+        location: ev.location.clone(),
+        description: ev.description.clone(),
+        when,
+        tz: cal_tz.to_string(),
+        repeat: repeat.map(str::to_string),
+        weekly_days: None,
+        repeat_end: None,
+        // Never. The module doc has the whole of the reason.
+        guests: None,
+        reminders: reminders_for(ev),
+        conference: None,
+    })
+}
+
+/// The popup reminders an event carries, or `None` to leave the calendar's
+/// own defaults alone.
+///
+/// **Popup only.** A VALARM with `EMAIL` asks a server to send mail, and an
+/// import is the last place to start doing that on somebody's behalf; those
+/// alarms are dropped with the guests. A trigger after the start (a positive
+/// offset here) is not something the form can hold, so it is dropped too
+/// rather than flipped into a reminder before.
+fn reminders_for(ev: &ics::CalEvent) -> Option<crate::write::RemindersInput> {
+    let overrides: Vec<crate::write::ReminderInput> = ev
+        .alarms
+        .iter()
+        .filter(|(method, minutes)| method == "popup" && *minutes >= 0)
+        .map(|(_, minutes)| crate::write::ReminderInput {
+            method: "popup".into(),
+            minutes: *minutes,
+        })
+        .collect();
+    if overrides.is_empty() {
+        None
+    } else {
+        Some(crate::write::RemindersInput { use_default: false, overrides })
+    }
+}
+
+/// `YYYY-MM-DD` for a `VALUE=DATE` property, and nothing for any other
+/// shape — an all-day event whose DTEND is a date-time is not one this maps.
+fn all_day_date(t: &ics::IcsTime) -> Option<String> {
+    match t {
+        ics::IcsTime::Date(d) => Some(d.to_string()),
+        _ => None,
+    }
+}
+
+/// The day after `date`, for an all-day event with no DTEND: the RFC says
+/// one day, and the form's end is exclusive.
+fn next_day(date: &str) -> Option<String> {
+    let d: jiff::civil::Date = date.parse().ok()?;
+    Some(d.tomorrow().ok()?.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ONE: &str = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\n\
+        BEGIN:VEVENT\r\nUID:a@x\r\nSUMMARY:Lunch\r\nDTSTART:20260907T113000Z\r\n\
+        DTEND:20260907T123000Z\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+    fn ics_with(body: &str) -> String {
+        format!("BEGIN:VCALENDAR\r\nVERSION:2.0\r\n{body}END:VCALENDAR\r\n")
+    }
+
+    #[test]
+    fn a_plain_event_is_planned_for_import() {
+        let plan = plan(ONE, "UTC", &[]).unwrap();
+        assert_eq!(plan.len(), 1);
+        // The instant DTSTART names, derived rather than written out: a
+        // magic number here would be checking my arithmetic, not the parse.
+        let expected: jiff::Timestamp = "2026-09-07T11:30:00Z".parse().unwrap();
+        assert_eq!(
+            plan[0],
+            Planned::Import {
+                summary: "Lunch".into(),
+                start_ms: expected.as_millisecond(),
+                all_day: false,
+                repeat: None,
+                dropped_guests: 0,
+            }
+        );
+    }
+
+    /// The five shapes the form can store come through as repeats; anything
+    /// else is skipped rather than quietly imported as a single event, which
+    /// would be this module telling the user something their file did not
+    /// say.
+    #[test]
+    fn only_the_repeats_the_form_can_store_are_carried_and_the_rest_are_refused() {
+        for (rule, expected) in [
+            ("FREQ=DAILY", Some("daily")),
+            ("FREQ=WEEKLY", Some("weekly")),
+            ("FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR", Some("weekdays")),
+            ("FREQ=MONTHLY", Some("monthly")),
+            ("FREQ=YEARLY", Some("yearly")),
+        ] {
+            assert_eq!(
+                repeat_for_rrule(&[format!("RRULE:{rule}")]),
+                Some(expected),
+                "{rule}"
+            );
+        }
+        for rule in [
+            "FREQ=WEEKLY;INTERVAL=2",
+            "FREQ=DAILY;COUNT=10",
+            "FREQ=MONTHLY;BYDAY=3TH",
+            "FREQ=WEEKLY;BYDAY=MO,WE",
+            "FREQ=HOURLY",
+        ] {
+            assert_eq!(repeat_for_rrule(&[format!("RRULE:{rule}")]), None, "{rule}");
+        }
+        // A rule the app could store, next to dates the form cannot hold.
+        assert_eq!(
+            repeat_for_rrule(&["RRULE:FREQ=DAILY".into(), "EXDATE:20260909T113000Z".into()]),
+            None,
+            "an exception list is part of the rule",
+        );
+        assert_eq!(repeat_for_rrule(&[]), Some(None), "no rule is a single event");
+    }
+
+    #[test]
+    fn an_unstorable_repeat_is_skipped_by_name() {
+        let src = ics_with(
+            "BEGIN:VEVENT\r\nUID:b@x\r\nSUMMARY:Third Thursday\r\n\
+             DTSTART:20260903T090000Z\r\nRRULE:FREQ=MONTHLY;BYDAY=3TH\r\nEND:VEVENT\r\n",
+        );
+        let plan = plan(&src, "UTC", &[]).unwrap();
+        assert_eq!(
+            plan[0],
+            Planned::Skip {
+                summary: "Third Thursday".into(),
+                reason: SKIP_UNEXPRESSIBLE_REPEAT.into(),
+            }
+        );
+    }
+
+    /// Guests are counted and left behind, and the count is in the plan so
+    /// the surfaces can say so before anything is written. Importing them
+    /// would invite the people on them.
+    #[test]
+    fn guests_are_counted_and_not_carried() {
+        let src = ics_with(
+            "BEGIN:VEVENT\r\nUID:c@x\r\nSUMMARY:Retro\r\nDTSTART:20260907T090000Z\r\n\
+             ATTENDEE;CN=A:mailto:a@x.com\r\nATTENDEE;CN=B:mailto:b@x.com\r\nEND:VEVENT\r\n",
+        );
+        let plan = plan(&src, "UTC", &[]).unwrap();
+        let Planned::Import { dropped_guests, .. } = &plan[0] else { panic!("{:?}", plan[0]) };
+        assert_eq!(*dropped_guests, 2);
+    }
+
+    /// The same file twice does not double anything.
+    #[test]
+    fn an_event_already_here_is_skipped() {
+        let plan = plan(ONE, "UTC", &["a@x".to_string()]).unwrap();
+        assert_eq!(
+            plan[0],
+            Planned::Skip { summary: "Lunch".into(), reason: SKIP_ALREADY_HERE.into() }
+        );
+    }
+
+    /// One occurrence of a series, exported on its own, has no series here
+    /// to attach to.
+    #[test]
+    fn a_lone_exception_is_skipped() {
+        let src = ics_with(
+            "BEGIN:VEVENT\r\nUID:d@x\r\nSUMMARY:Moved standup\r\n\
+             RECURRENCE-ID:20260908T090000Z\r\nDTSTART:20260908T100000Z\r\nEND:VEVENT\r\n",
+        );
+        let plan = plan(&src, "UTC", &[]).unwrap();
+        assert_eq!(plan[0], Planned::Skip {
+            summary: "Moved standup".into(),
+            reason: SKIP_AN_OCCURRENCE.into(),
+        });
+    }
+
+    /// An all-day event keeps its all-day shape, and a titleless one is
+    /// still named in the plan rather than showing as a blank row.
+    #[test]
+    fn all_day_and_untitled_events_still_plan() {
+        let src = ics_with(
+            "BEGIN:VEVENT\r\nUID:e@x\r\nDTSTART;VALUE=DATE:20260910\r\n\
+             DTEND;VALUE=DATE:20260911\r\nEND:VEVENT\r\n",
+        );
+        let plan = plan(&src, "UTC", &[]).unwrap();
+        let Planned::Import { all_day, summary, .. } = &plan[0] else { panic!() };
+        assert!(all_day);
+        assert_eq!(summary, "(no title)");
+    }
+
+    fn only_event(src: &str) -> ics::CalEvent {
+        ics::events_in(&ics::parse(src).unwrap()).remove(0)
+    }
+
+    /// A timed event takes its own end; without one it takes DURATION; with
+    /// neither it is the RFC's instant, not a guess at a length.
+    #[test]
+    fn a_timed_events_end_comes_from_dtend_then_duration_then_the_rfc() {
+        let with_end = only_event(ONE);
+        let crate::write::WhenInput::Timed { start_ms, end_ms } =
+            input_for(&with_end, "UTC", None).unwrap().when
+        else { panic!("timed") };
+        assert_eq!(end_ms - start_ms, 3_600_000);
+
+        let dur = only_event(&ics_with(
+            "BEGIN:VEVENT\r\nUID:f@x\r\nDTSTART:20260907T113000Z\r\n\
+             DURATION:PT45M\r\nEND:VEVENT\r\n",
+        ));
+        let crate::write::WhenInput::Timed { start_ms, end_ms } =
+            input_for(&dur, "UTC", None).unwrap().when
+        else { panic!("timed") };
+        assert_eq!(end_ms - start_ms, 45 * 60_000);
+
+        let bare = only_event(&ics_with(
+            "BEGIN:VEVENT\r\nUID:g@x\r\nDTSTART:20260907T113000Z\r\nEND:VEVENT\r\n",
+        ));
+        let crate::write::WhenInput::Timed { start_ms, end_ms } =
+            input_for(&bare, "UTC", None).unwrap().when
+        else { panic!("timed") };
+        assert_eq!(start_ms, end_ms, "an instant, not an invented hour");
+    }
+
+    /// An all-day event keeps iCalendar's exclusive end, and one without a
+    /// DTEND gets the RFC's single day rather than a zero-length span.
+    #[test]
+    fn an_all_day_event_keeps_its_dates() {
+        let two = only_event(&ics_with(
+            "BEGIN:VEVENT\r\nUID:h@x\r\nDTSTART;VALUE=DATE:20260910\r\n\
+             DTEND;VALUE=DATE:20260912\r\nEND:VEVENT\r\n",
+        ));
+        let crate::write::WhenInput::AllDay { start_date, end_date } =
+            input_for(&two, "UTC", None).unwrap().when
+        else { panic!("all-day") };
+        assert_eq!((start_date.as_str(), end_date.as_str()), ("2026-09-10", "2026-09-12"));
+        let one = only_event(&ics_with(
+            "BEGIN:VEVENT\r\nUID:i@x\r\nDTSTART;VALUE=DATE:20260910\r\nEND:VEVENT\r\n",
+        ));
+        let crate::write::WhenInput::AllDay { start_date, end_date } =
+            input_for(&one, "UTC", None).unwrap().when
+        else { panic!("all-day") };
+        assert_eq!((start_date.as_str(), end_date.as_str()), ("2026-09-10", "2026-09-11"),
+            "no DTEND is the RFC's one day, not a zero-length span");
+    }
+
+    /// Guests never reach the create path, whatever the file said, and the
+    /// text fields that are safe to carry do.
+    #[test]
+    fn the_mapped_input_carries_the_text_and_never_the_guests() {
+        let ev = only_event(&ics_with(
+            "BEGIN:VEVENT\r\nUID:j@x\r\nSUMMARY:Retro\r\nLOCATION:Room 3\r\n\
+             DESCRIPTION:Bring notes\r\nDTSTART:20260907T090000Z\r\n\
+             ATTENDEE;CN=A:mailto:a@x.com\r\nEND:VEVENT\r\n",
+        ));
+        assert_eq!(ev.attendees.len(), 1, "the file really does carry one");
+        let input = input_for(&ev, "UTC", Some("weekly")).unwrap();
+        assert_eq!(input.summary.as_deref(), Some("Retro"));
+        assert_eq!(input.location.as_deref(), Some("Room 3"));
+        assert_eq!(input.description.as_deref(), Some("Bring notes"));
+        assert_eq!(input.repeat.as_deref(), Some("weekly"));
+        assert!(input.guests.is_none(), "a create with guests would invite them");
+        assert!(input.conference.is_none());
+    }
+
+    /// Popup alarms come through as reminders; an email alarm does not,
+    /// because honouring it would have a server send mail on an import.
+    #[test]
+    fn popup_alarms_become_reminders_and_email_alarms_do_not() {
+        let ev = only_event(&ics_with(
+            "BEGIN:VEVENT\r\nUID:k@x\r\nSUMMARY:Call\r\nDTSTART:20260907T090000Z\r\n\
+             BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER:-PT15M\r\nEND:VALARM\r\n\
+             BEGIN:VALARM\r\nACTION:EMAIL\r\nTRIGGER:-PT60M\r\nEND:VALARM\r\n\
+             END:VEVENT\r\n",
+        ));
+        let r = input_for(&ev, "UTC", None).unwrap().reminders.expect("reminders");
+        assert!(!r.use_default);
+        assert_eq!(r.overrides.len(), 1, "the email alarm is not carried");
+        assert_eq!(r.overrides[0].minutes, 15);
+        assert_eq!(r.overrides[0].method, "popup");
+
+        let none = only_event(ONE);
+        assert!(input_for(&none, "UTC", None).unwrap().reminders.is_none(),
+            "no alarms leaves the calendar's own defaults alone");
+    }
+
+    /// Not iCalendar at all is nothing to plan; iCalendar with no events is
+    /// an empty plan, which is a different answer and reads differently.
+    #[test]
+    fn rubbish_is_no_plan_and_an_empty_calendar_is_an_empty_one() {
+        assert!(plan("this is not a calendar", "UTC", &[]).is_none());
+        assert_eq!(plan(&ics_with(""), "UTC", &[]).unwrap(), vec![]);
+    }
+}
+
+/// What an import did, once it had done it.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Report {
+    pub imported: usize,
+    /// Planned but refused, with the reason — the same list the preview
+    /// showed, repeated here so the result stands on its own.
+    pub skipped: Vec<Planned>,
+    /// Planned, attempted, and turned down by the server. Named one by one:
+    /// a count would leave the user guessing which of their events is
+    /// missing.
+    pub failed: Vec<Planned>,
+}
+
+/// The identifiers the target calendar already holds.
+///
+/// On a CalDAV calendar these *are* the files' UIDs (`omacal-sync`'s
+/// `caldav` module stores `ev.uid` as the provider identifier), so importing
+/// the same file twice is a no-op there. On a Google calendar the column
+/// holds Google's own event id instead, which an `.ics` file does not carry,
+/// so a re-import cannot be recognised and will create the events again.
+/// That is a real limit and the reason this returns what it can see rather
+/// than claiming to answer the question in general.
+async fn existing_uids(pool: &sqlx::SqlitePool, calendar_id: i64) -> Vec<String> {
+    sqlx::query("SELECT google_id FROM events WHERE calendar_id = ?1")
+        .bind(calendar_id)
+        .fetch_all(pool)
+        .await
+        .map(|rows| rows.iter().map(|r| r.get::<String, _>("google_id")).collect())
+        .unwrap_or_default()
+}
+
+/// Reads `path` and says what importing it into `calendar_id` would do.
+pub(crate) async fn plan_file(
+    state: &crate::AppState,
+    calendar_id: i64,
+    path: &std::path::Path,
+) -> Result<Vec<Planned>, String> {
+    let src = read_ics(path)?;
+    let tz = calendar_zone(state, calendar_id).await?;
+    plan(&src, &tz, &existing_uids(&state.pool, calendar_id).await)
+        .ok_or_else(|| NOT_A_CALENDAR.to_string())
+}
+
+/// Imports `path` into `calendar_id`, and reports what happened.
+///
+/// The plan is taken again here rather than passed in from the preview:
+/// what gets written is decided by the file as it is now, and the report
+/// says what that was. Every create goes through `events::create_event_body`
+/// — the window's own path — with `send_updates` of `none`, which together
+/// with the absent guest list is the second of the two locks on an import
+/// mailing anybody.
+pub(crate) async fn run_file(
+    state: &crate::AppState,
+    calendar_id: i64,
+    path: &std::path::Path,
+) -> Result<Report, String> {
+    let src = read_ics(path)?;
+    let tz = calendar_zone(state, calendar_id).await?;
+    let uids = existing_uids(&state.pool, calendar_id).await;
+    let planned = plan(&src, &tz, &uids).ok_or_else(|| NOT_A_CALENDAR.to_string())?;
+
+    // Keyed by summary and start, which is what a `Planned::Import` carries;
+    // the events are re-read from the file so the full fields are to hand.
+    let root = ics::parse(&src).ok_or_else(|| NOT_A_CALENDAR.to_string())?;
+    let events = ics::events_in(&root);
+
+    let mut report = Report { imported: 0, skipped: Vec::new(), failed: Vec::new() };
+    for (i, p) in planned.into_iter().enumerate() {
+        let Planned::Import { ref repeat, .. } = p else {
+            report.skipped.push(p);
+            continue;
+        };
+        let Some(ev) = events.get(i) else {
+            report.failed.push(p);
+            continue;
+        };
+        let Some(input) = input_for(ev, &tz, repeat.as_deref()) else {
+            report.failed.push(p);
+            continue;
+        };
+        match crate::events::create_event_body(state, calendar_id, input, "none").await {
+            Ok(_) => report.imported += 1,
+            Err(e) => {
+                tracing::warn!(%e, summary = p.summary(), "import: one event refused");
+                report.failed.push(p);
+            }
+        }
+    }
+    Ok(report)
+}
+
+pub const NOT_A_CALENDAR: &str = "that file is not an iCalendar file";
+pub const NO_SUCH_CALENDAR: &str = "that calendar is not here any more";
+/// A guard, not a judgement about real files: an `.ics` is text, and a
+/// hundred megabytes of it is a mistake rather than a calendar.
+const MAX_BYTES: u64 = 32 * 1024 * 1024;
+
+fn read_ics(path: &std::path::Path) -> Result<String, String> {
+    let meta = std::fs::metadata(path).map_err(|_| "that file could not be read".to_string())?;
+    if meta.len() > MAX_BYTES {
+        return Err("that file is too large to import".into());
+    }
+    std::fs::read_to_string(path).map_err(|_| "that file could not be read".to_string())
+}
+
+async fn calendar_zone(state: &crate::AppState, calendar_id: i64) -> Result<String, String> {
+    omacal_store::calendar_for_write(&state.pool, calendar_id)
+        .await
+        .map_err(|e| e.to_string())?
+        .map(|(_, _, _, tz)| tz)
+        .ok_or_else(|| NO_SUCH_CALENDAR.to_string())
+}
+
+/// What dropping a file on the window asks: what would this do?
+#[tauri::command]
+pub(crate) async fn plan_ics_import(
+    state: tauri::State<'_, crate::AppState>,
+    calendar_id: i64,
+    path: String,
+) -> Result<Vec<Planned>, String> {
+    plan_file(&state, calendar_id, std::path::Path::new(&path)).await
+}
+
+/// And what confirming it does.
+#[tauri::command]
+pub(crate) async fn run_ics_import(
+    state: tauri::State<'_, crate::AppState>,
+    calendar_id: i64,
+    path: String,
+) -> Result<Report, String> {
+    run_file(&state, calendar_id, std::path::Path::new(&path)).await
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ mod fixtures;
 #[cfg(test)]
 mod golden;
 mod icu_tz;
+mod import;
 mod invites;
 mod ipc;
 mod notify;
@@ -1592,6 +1593,8 @@ pub fn run() {
             update::install_update,
             commands::open_conference,
             weather::get_weather,
+            import::plan_ics_import,
+            import::run_ics_import,
             calendars::get_calendars,
             calendars::set_calendar_selected,
             calendars::set_calendar_sync,

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -11,6 +11,8 @@
   import { getStatus, installUpdate, openLatestRelease, restartApp, signIn, syncNow, takeOpenDate, type AppStatus } from './lib/status';
   import { dateKey, freshness, getWeather, weatherByDate, type DayWeather, type WeatherReport } from './lib/weather';
   import WeatherPopover from './lib/WeatherPopover.svelte';
+  import ImportPanel from './lib/ImportPanel.svelte';
+  import { isIcs } from './lib/importics';
   import { changedMeetings, declinedGuests, pendingInvites } from './lib/invites';
   import { calendarColor, getCalendars, offerableCalendarId, setCalendarSelected, type Calendar } from './lib/calendars';
   import {
@@ -271,6 +273,23 @@
    *  Recomputed with the report and on each hourly poll, which is often
    *  enough for a six-hour threshold. */
   let weatherStale = $state(false);
+
+  /** The `.ics` a user dropped on the window, or null for no import in
+   *  progress (#67). Tauri delivers the drop as paths rather than as HTML5
+   *  drag events, which is why this listens for the runtime's own event and
+   *  not for `ondrop`. */
+  let importPath = $state<string | null>(null);
+  $effect(() => {
+    const un = listen<{ paths?: string[] }>('tauri://drag-drop', (e) => {
+      // One file, and one this can read. A folder or a screenshot dropped on
+      // a calendar is not an import attempt, so it is ignored rather than
+      // refused: a dialog nobody asked for is worse than nothing happening.
+      const paths = e.payload?.paths ?? [];
+      const ics = paths.filter(isIcs);
+      if (paths.length === 1 && ics.length === 1) importPath = ics[0];
+    });
+    return () => { un.then((f) => f()); };
+  });
   const openWeather = (dayStartMs: number, anchor: import('./lib/position').Rect) => {
     weatherCard = { dayStartMs, anchor };
   };
@@ -1971,6 +1990,15 @@
     today={dateKey(weatherCard.dayStartMs) === dateKey(Date.now())}
     anchor={weatherCard.anchor}
     onclose={() => (weatherCard = null)}
+  />
+{/if}
+
+{#if importPath}
+  <ImportPanel
+    path={importPath}
+    {calendars}
+    onclose={() => (importPath = null)}
+    onimported={() => { void refreshAfterWrite(); }}
   />
 {/if}
 

--- a/ui/src/lib/ImportPanel.svelte
+++ b/ui/src/lib/ImportPanel.svelte
@@ -1,0 +1,158 @@
+<!-- ui/src/lib/ImportPanel.svelte -->
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { escapeCloses } from './dismiss.svelte';
+  import { writableCalendars, type Calendar } from './calendars';
+  import {
+    fileName, planIcsImport, planSummary, runIcsImport,
+    type ImportReport, type Planned,
+  } from './importics';
+
+  /** Importing an `.ics` a user dropped on the window (#67).
+   *
+   *  The panel is a preview first and an action second: it says what will
+   *  happen — how many events, what is skipped and why, and how many guest
+   *  lists are being left behind — before there is anything to confirm.
+   *  That ordering is the feature. An import writes many events at once
+   *  from a file the app did not author, and the one thing worse than not
+   *  importing is importing something other than what the file said. */
+  let { path, calendars, onclose, onimported }: {
+    path: string;
+    calendars: Calendar[];
+    onclose: () => void;
+    /** Told when events landed, so the caller can refetch the view. */
+    onimported: () => void;
+  } = $props();
+
+  const options = $derived(writableCalendars(calendars));
+  let calendarId = $state<number | null>(null);
+  let plan = $state<Planned[] | null>(null);
+  let report = $state<ImportReport | null>(null);
+  let busy = $state(false);
+  let error = $state<string | null>(null);
+
+  onMount(() => {
+    if (calendarId === null && options.length > 0) calendarId = options[0].id;
+  });
+  escapeCloses(() => !busy, () => onclose());
+
+  // Re-planned whenever the calendar changes: the answer depends on it —
+  // its zone resolves floating times, and its own events are what "already
+  // here" means.
+  $effect(() => {
+    const id = calendarId;
+    if (id === null) return;
+    plan = null;
+    error = null;
+    void (async () => {
+      try {
+        plan = await planIcsImport(id, path);
+      } catch (e) {
+        error = String(e);
+      }
+    })();
+  });
+
+  async function run() {
+    if (busy || calendarId === null) return;
+    busy = true;
+    error = null;
+    try {
+      report = await runIcsImport(calendarId, path);
+      if (report.imported > 0) onimported();
+    } catch (e) {
+      error = String(e);
+    } finally {
+      busy = false;
+    }
+  }
+
+  const importing = $derived((plan ?? []).filter((p) => p.kind === 'import').length);
+  const skipped = $derived((plan ?? []).filter((p) => p.kind === 'skip'));
+</script>
+
+<div class="scrim" role="presentation" onclick={() => { if (!busy) onclose(); }}></div>
+<div class="panel" role="dialog" aria-modal="true" aria-label="Import {fileName(path)}">
+  <h2>Import {fileName(path)}</h2>
+
+  {#if report}
+    <p class="summary">
+      {report.imported} event{report.imported === 1 ? '' : 's'} imported.
+    </p>
+    {#if report.failed.length > 0}
+      <p class="note err">
+        {report.failed.length} could not be created:
+        {report.failed.map((f) => f.summary).join(', ')}
+      </p>
+    {/if}
+    <div class="actions">
+      <button class="go" onclick={onclose}>Done</button>
+    </div>
+  {:else}
+    {#if options.length === 0}
+      <p class="note">No calendar here can be written to.</p>
+    {:else}
+      <label class="pick">
+        Into
+        <select bind:value={calendarId} disabled={busy}>
+          {#each options as c (c.id)}
+            <option value={c.id}>{c.summary}</option>
+          {/each}
+        </select>
+      </label>
+    {/if}
+
+    {#if error}
+      <p class="note err" role="alert">{error}</p>
+    {:else if plan === null && options.length > 0}
+      <p class="note">Reading…</p>
+    {:else if plan}
+      <p class="summary">{planSummary(plan)}</p>
+      <!-- Named, not counted: a user who is told afterwards which of their
+           events did not arrive has been surprised rather than informed. -->
+      {#if skipped.length > 0}
+        <ul class="skipped">
+          {#each skipped as s (s.summary + s.reason)}
+            <li><span class="what">{s.summary}</span><span class="why">{s.reason}</span></li>
+          {/each}
+        </ul>
+      {/if}
+      <p class="fine">Guests are never invited by an import.</p>
+    {/if}
+
+    <div class="actions">
+      <button onclick={onclose} disabled={busy}>Cancel</button>
+      <button class="go" onclick={run} disabled={busy || importing === 0}>
+        {busy ? 'Importing…' : `Import ${importing}`}
+      </button>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .scrim { position: fixed; inset: 0; z-index: 40; background: rgba(0, 0, 0, .35); border: 0; }
+  .panel { position: fixed; z-index: 41; top: 50%; left: 50%; transform: translate(-50%, -50%);
+           width: 380px; max-height: 70vh; overflow-y: auto;
+           background: var(--surface); border: 1px solid var(--hairline);
+           border-radius: 10px; padding: 16px 18px; box-shadow: 0 10px 34px rgba(0, 0, 0, .5);
+           font-size: 12.5px; color: var(--text); }
+  h2 { margin: 0 0 12px; font-size: 14px; font-weight: 600; overflow-wrap: anywhere; }
+  .pick { display: flex; align-items: center; gap: 8px; color: var(--muted); }
+  .pick select { flex: 1; font: inherit; }
+  .summary { margin: 12px 0 6px; font-weight: 500; }
+  .note { margin: 8px 0; color: var(--muted); }
+  .note.err { color: var(--error); }
+  .skipped { list-style: none; margin: 6px 0 0; padding: 0; max-height: 30vh; overflow-y: auto;
+             scrollbar-width: none; }
+  .skipped::-webkit-scrollbar { display: none; }
+  .skipped li { display: flex; gap: 8px; padding: 3px 0; border-top: 1px solid var(--hairline); }
+  .what { flex: 0 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .why { flex: 1 1 auto; color: var(--muted); font-size: 11px; }
+  .fine { margin: 10px 0 0; color: var(--muted); font-size: 11px; }
+  .actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 14px; }
+  .actions button { font: inherit; padding: 5px 12px; border-radius: 6px;
+                    border: 1px solid var(--hairline); background: none; color: var(--text);
+                    cursor: pointer; }
+  .actions .go { background: var(--accent); color: var(--on-accent); border-color: transparent; }
+  .actions button:disabled { opacity: .5; cursor: default; }
+</style>

--- a/ui/src/lib/TasksPanel.svelte
+++ b/ui/src/lib/TasksPanel.svelte
@@ -15,7 +15,14 @@
   let busyIds = $state<Set<number>>(new Set());
 
   let newTitle = $state('');
-  let newListId = $state<number | null>(null);
+  /** The list the picker is on, or null for all of them.
+   *
+   *  One control, two jobs (#68): it filters the rows to that list *and*
+   *  it is where a new task lands. Null is the default and stays the
+   *  default — opening the panel shows every task, as it always has, and
+   *  a picker that started on one list would look like the others had
+   *  gone. */
+  let filterListId = $state<number | null>(null);
   let adding = $state(false);
 
   $effect(() => {
@@ -24,7 +31,6 @@
         const [t, l] = await Promise.all([listTasks(), taskLists()]);
         tasks = t;
         lists = l;
-        if (newListId === null && l.length > 0) newListId = l[0].calendarId;
       } catch (e) {
         note = String(e);
         tasks = [];
@@ -34,8 +40,28 @@
 
   escapeCloses(() => true, () => onclose());
 
-  const open = $derived((tasks ?? []).filter((t) => !t.completed));
-  const done = $derived((tasks ?? []).filter((t) => t.completed));
+  /** Where a new task lands: the chosen list, or the first when the picker
+   *  is on "All lists". `taskLists` only ever offers lists a task can be
+   *  created on, so the first is a safe target rather than a guess — and
+   *  the input names it either way, so it is never a silent one. */
+  const targetList = $derived(
+    filterListId === null
+      ? (lists[0] ?? null)
+      : (lists.find((l) => l.calendarId === filterListId) ?? null),
+  );
+  const shown = $derived(
+    filterListId === null
+      ? (tasks ?? [])
+      : (tasks ?? []).filter((t) => t.calendarId === filterListId),
+  );
+  const open = $derived(shown.filter((t) => !t.completed));
+  const done = $derived(shown.filter((t) => t.completed));
+  /** A list chosen from the picker that holds nothing — different from
+   *  having no tasks at all, and told apart so the empty panel does not
+   *  claim there are no task lists. */
+  const emptyList = $derived(
+    tasks !== null && tasks.length > 0 && shown.length === 0 ? targetList : null,
+  );
 
   async function toggle(task: Task) {
     if (busyIds.has(task.id)) return;
@@ -62,11 +88,11 @@
   }
 
   async function add() {
-    if (adding || newListId === null || newTitle.trim() === '') return;
+    if (adding || targetList === null || newTitle.trim() === '') return;
     note = null;
     adding = true;
     try {
-      tasks = await createTask(newListId, newTitle, null);
+      tasks = await createTask(targetList.calendarId, newTitle, null);
       newTitle = '';
     } catch (e) {
       note = String(e);
@@ -108,15 +134,21 @@
         void add();
       }}
     >
+      <!-- The placeholder names the target whenever the picker does not —
+           on "All lists" a task still has to land somewhere, and a guess
+           the user cannot see is the thing worth avoiding. -->
       <input
         type="text"
-        placeholder="Add a task…"
+        placeholder={filterListId === null && lists.length > 1 && targetList
+          ? `Add to ${targetList.name}…`
+          : 'Add a task…'}
         aria-label="New task title"
         bind:value={newTitle}
         disabled={adding}
       />
       {#if lists.length > 1}
-        <select aria-label="Task list" bind:value={newListId} disabled={adding}>
+        <select aria-label="Task list" bind:value={filterListId} disabled={adding}>
+          <option value={null}>All lists</option>
           {#each lists as l (l.calendarId)}
             <option value={l.calendarId}>{l.name}</option>
           {/each}
@@ -132,6 +164,8 @@
       No tasks yet. Task lists arrive with an iCloud or CalDAV account
       (Settings → Accounts).
     </p>
+  {:else if emptyList}
+    <p class="empty">Nothing in {emptyList.name}.</p>
   {:else}
     <ul>
       {#each open as t (t.id)}

--- a/ui/src/lib/importics.ts
+++ b/ui/src/lib/importics.ts
@@ -1,0 +1,55 @@
+import { invoke } from '@tauri-apps/api/core';
+
+/** What an import will do with one event, as `import::Planned` serialises. */
+export type Planned =
+  | {
+      kind: 'import';
+      summary: string;
+      start_ms: number;
+      all_day: boolean;
+      repeat: string | null;
+      /** How many guests the file listed and the import will not carry. */
+      dropped_guests: number;
+    }
+  | { kind: 'skip'; summary: string; reason: string };
+
+/** What it did, once it had done it. */
+export type ImportReport = {
+  imported: number;
+  skipped: Planned[];
+  /** Attempted and turned down by the server, named one by one. */
+  failed: Planned[];
+};
+
+export const planIcsImport = (calendarId: number, path: string) =>
+  invoke<Planned[]>('plan_ics_import', { calendarId, path });
+
+export const runIcsImport = (calendarId: number, path: string) =>
+  invoke<ImportReport>('run_ics_import', { calendarId, path });
+
+/** The sentence above the preview.
+ *
+ *  It names the guest count because that is the one thing an import quietly
+ *  leaves behind: the events come in, their guest lists do not, and a user
+ *  who is told afterwards has been surprised rather than informed. Written
+ *  here rather than in Rust so the wording lives with the panel that shows
+ *  it, and is tested with it. */
+export const planSummary = (plan: Planned[]): string => {
+  const importing = plan.filter((p) => p.kind === 'import').length;
+  const skipped = plan.length - importing;
+  const guests = plan.reduce(
+    (n, p) => n + (p.kind === 'import' ? p.dropped_guests : 0), 0,
+  );
+  let s = `${importing} event${importing === 1 ? '' : 's'} to import, ${skipped} skipped`;
+  if (guests > 0) s += `, ${guests} guest ${guests === 1 ? 'entry' : 'entries'} left behind`;
+  return s;
+};
+
+/** The last path segment, for naming the file in the panel's title. */
+export const fileName = (path: string): string =>
+  path.split(/[\\/]/).filter(Boolean).pop() ?? path;
+
+/** Whether a dropped path is one this can import at all. Extension only:
+ *  the backend reads and judges the contents, and a file that lies about
+ *  its name is refused there rather than here. */
+export const isIcs = (path: string): boolean => /\.ics$/i.test(path.trim());

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -4945,3 +4945,27 @@ test.describe('the tasks panel', () => {
     await expect(panel.getByText('No tasks yet.')).toHaveCount(0);
   });
 });
+
+/**
+ * The drop itself (#67): Tauri hands the webview paths rather than HTML5
+ * drag events, so the app listens for the runtime's own event. One `.ics`
+ * opens the panel; anything else is ignored rather than refused, because a
+ * dialog nobody asked for is worse than nothing happening.
+ */
+test.describe('dropping a file on the calendar', () => {
+  const drop = (page: import('@playwright/test').Page, paths: string[]) =>
+    page.evaluate((p) => (window as any).__harness.emit('tauri://drag-drop', { paths: p }), paths);
+
+  test('one .ics opens the import panel', async ({ page }) => {
+    await page.goto(app());
+    await drop(page, ['/home/u/Downloads/work.ics']);
+    await expect(page.getByRole('dialog', { name: 'Import work.ics' })).toBeVisible();
+  });
+
+  test('anything else is ignored', async ({ page }) => {
+    await page.goto(app());
+    await drop(page, ['/home/u/Pictures/shot.png']);
+    await drop(page, ['/home/u/a.ics', '/home/u/b.ics']);
+    await expect(page.getByRole('dialog', { name: /^Import / })).toHaveCount(0);
+  });
+});

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -4867,3 +4867,81 @@ test.describe("App: showing today's date", () => {
     await expect(modal.getByLabel("Show today's date")).toBeChecked();
   });
 });
+
+/**
+ * The tasks panel's list picker, which does two jobs (#68, @xmha97): it
+ * chooses where a new task lands *and* filters the rows to that list.
+ *
+ * The panel had no coverage at all before this; these are its first specs,
+ * so they pin the default view as well as the filtering, because "shows
+ * every task until you say otherwise" is the behaviour a filter is most
+ * likely to break.
+ */
+test.describe('the tasks panel', () => {
+  const openTasks = async (page: import('@playwright/test').Page) => {
+    await page.goto(app());
+    await page.getByRole('button', { name: 'Menu' }).click();
+    await page.getByRole('button', { name: 'Tasks…' }).click();
+    return page.getByRole('dialog', { name: 'Tasks' });
+  };
+
+  test('opens on every list, and the picker filters to one', async ({ page }) => {
+    const panel = await openTasks(page);
+    await expect(panel.getByText('Buy milk')).toBeVisible();
+    await expect(panel.getByText('Ship the release')).toBeVisible();
+    await expect(panel.getByText('Old standup note')).toBeVisible();
+    await expect(panel.getByRole('combobox', { name: 'Task list' })).toHaveValue('');
+
+    await panel.getByRole('combobox', { name: 'Task list' }).selectOption({ label: 'Work' });
+    await expect(panel.getByText('Buy milk')).toHaveCount(0);
+    await expect(panel.getByText('Ship the release')).toBeVisible();
+    // The Done section is filtered by the same rule, not left behind.
+    await expect(panel.getByText('Old standup note')).toBeVisible();
+
+    await panel.getByRole('combobox', { name: 'Task list' }).selectOption({ label: 'Personal' });
+    await expect(panel.getByText('Buy milk')).toBeVisible();
+    await expect(panel.getByText('Ship the release')).toHaveCount(0);
+    await expect(panel.getByText('Old standup note')).toHaveCount(0);
+
+    await panel.getByRole('combobox', { name: 'Task list' }).selectOption({ label: 'All lists' });
+    await expect(panel.getByText('Buy milk')).toBeVisible();
+    await expect(panel.getByText('Ship the release')).toBeVisible();
+  });
+
+  test('a new task lands on the chosen list, and the filter keeps it in view', async ({ page }) => {
+    const panel = await openTasks(page);
+    await panel.getByRole('combobox', { name: 'Task list' }).selectOption({ label: 'Work' });
+    await panel.getByRole('textbox', { name: 'New task title' }).fill('Cut 2.3.0');
+    await panel.getByRole('textbox', { name: 'New task title' }).press('Enter');
+
+    await expect(panel.getByText('Cut 2.3.0')).toBeVisible();
+    // It landed on Work, so Personal does not have it.
+    await panel.getByRole('combobox', { name: 'Task list' }).selectOption({ label: 'Personal' });
+    await expect(panel.getByText('Cut 2.3.0')).toHaveCount(0);
+  });
+
+  /** On "All lists" a task still has to land somewhere, and the input says
+   *  where rather than leaving it to be discovered afterwards. */
+  test('on every list, the input names where a new task will land', async ({ page }) => {
+    const panel = await openTasks(page);
+    const input = panel.getByRole('textbox', { name: 'New task title' });
+    await expect(input).toHaveAttribute('placeholder', 'Add to Personal…');
+
+    await panel.getByRole('combobox', { name: 'Task list' }).selectOption({ label: 'Work' });
+    await expect(input).toHaveAttribute('placeholder', 'Add a task…');
+  });
+
+  /** A list with nothing in it is not the same as having no task lists,
+   *  and the empty panel must not claim the second. */
+  test('an empty list says it is empty, not that there are no lists', async ({ page }) => {
+    const panel = await openTasks(page);
+    await panel.getByRole('combobox', { name: 'Task list' }).selectOption({ label: 'Personal' });
+    await expect(panel.getByText('Buy milk')).toBeVisible();
+
+    // The delete button is hidden until its row is hovered.
+    await panel.locator('li', { hasText: 'Buy milk' }).hover();
+    await panel.getByRole('button', { name: 'Delete Buy milk' }).click();
+    await expect(panel.getByText('Nothing in Personal.')).toBeVisible();
+    await expect(panel.getByText('No tasks yet.')).toHaveCount(0);
+  });
+});

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -5715,3 +5715,47 @@ test.describe('quiet scrolling', () => {
     expect(await pop.evaluate((el) => getComputedStyle(el).scrollbarWidth)).toBe('auto');
   });
 });
+
+/**
+ * Importing a dropped `.ics` (#67). The panel is a preview first and an
+ * action second, and these pin that order: what will happen, what will not,
+ * and what is being left behind, all before there is anything to confirm.
+ */
+test.describe('the ICS import panel', () => {
+  const panel = (page: import('@playwright/test').Page, file: string) =>
+    page.getByRole('dialog', { name: `Import ${file}` });
+
+  test('says what it will import, what it will skip and why, and what it drops', async ({ page }) => {
+    await page.goto(show('ImportPanel', 'mixed'));
+    const p = panel(page, 'work.ics');
+    await expect(p).toBeVisible();
+    await expect(p.getByText('2 events to import, 1 skipped, 2 guest entries left behind')).toBeVisible();
+    // The refusal is named, not counted.
+    await expect(p.getByText('Third Thursday')).toBeVisible();
+    await expect(p.getByText(/repeats in a way this version cannot store/)).toBeVisible();
+    await expect(p.getByText('Guests are never invited by an import.')).toBeVisible();
+    await expect(p.getByRole('button', { name: 'Import 2' })).toBeEnabled();
+  });
+
+  test('a file with nothing to import cannot be imported', async ({ page }) => {
+    await page.goto(show('ImportPanel', 'nothing'));
+    const p = panel(page, 'nothing.ics');
+    await expect(p.getByText('0 events to import, 0 skipped')).toBeVisible();
+    await expect(p.getByRole('button', { name: 'Import 0' })).toBeDisabled();
+  });
+
+  test('a file that is not a calendar says so instead of a plan', async ({ page }) => {
+    await page.goto(show('ImportPanel', 'unreadable'));
+    const p = panel(page, 'bad.ics');
+    await expect(p.getByRole('alert')).toContainText('not an iCalendar file');
+    await expect(p.getByRole('button', { name: /^Import/ })).toBeDisabled();
+  });
+
+  test('importing reports what landed', async ({ page }) => {
+    await page.goto(show('ImportPanel', 'mixed'));
+    const p = panel(page, 'work.ics');
+    await p.getByRole('button', { name: 'Import 2' }).click();
+    await expect(p.getByText('2 events imported.')).toBeVisible();
+    await expect(p.getByRole('button', { name: 'Done' })).toBeVisible();
+  });
+});

--- a/ui/tests/fixtures.ts
+++ b/ui/tests/fixtures.ts
@@ -1985,6 +1985,22 @@ POPOVER_DETAILS[XZONE_ID] = detail({
  *  would leak into the next `get_week` of the same run. */
 export const crossZoneWeek = (): WeekPayload => structuredClone(XZONE_GOLDEN);
 
+/** Two task lists with tasks on both, which is the only shape in which a
+ *  picker that filters can be told from one that does not (#68). `Work`
+ *  carries a done row as well, so the Done section is filtered too. */
+export const TASK_LISTS = [
+  { calendarId: 1, name: 'Personal', color: '#5b8def' },
+  { calendarId: 2, name: 'Work', color: '#2dd4bf' },
+];
+export const TASKS = [
+  { id: 11, calendarId: 1, summary: 'Buy milk', notes: null, dueMs: null, dueAllDay: false,
+    completed: false, calendar: 'Personal', color: '#5b8def', priority: 0, canWrite: true },
+  { id: 12, calendarId: 2, summary: 'Ship the release', notes: null, dueMs: null, dueAllDay: false,
+    completed: false, calendar: 'Work', color: '#2dd4bf', priority: 0, canWrite: true },
+  { id: 13, calendarId: 2, summary: 'Old standup note', notes: null, dueMs: null, dueAllDay: false,
+    completed: true, calendar: 'Work', color: '#2dd4bf', priority: 0, canWrite: true },
+];
+
 export const FIXTURES: Record<string, Record<string, any>> = {
   WeatherPopover: WEATHER_CARD_FIXTURES,
   WeekGrid: {

--- a/ui/tests/fixtures.ts
+++ b/ui/tests/fixtures.ts
@@ -2001,8 +2001,40 @@ export const TASKS = [
     completed: true, calendar: 'Work', color: '#2dd4bf', priority: 0, canWrite: true },
 ];
 
+/** What `plan_ics_import` answers, by the shape a spec asks for: a file
+ *  with something to import and something refused, and one with nothing.
+ *  Two guest entries, because the panel's whole job is saying that out
+ *  loud before anything is written. */
+export const IMPORT_PLANS: Record<string, any[]> = {
+  mixed: [
+    { kind: 'import', summary: 'Lunch', start_ms: 1788910200000, all_day: false,
+      repeat: null, dropped_guests: 2 },
+    { kind: 'import', summary: 'Standup', start_ms: 1788910200000, all_day: false,
+      repeat: 'weekdays', dropped_guests: 0 },
+    { kind: 'skip', summary: 'Third Thursday',
+      reason: 'repeats in a way this version cannot store; import it from the app that wrote it' },
+  ],
+  nothing: [],
+};
+
+export const IMPORT_PANEL_FIXTURES = {
+  mixed: {
+    path: '/home/u/Downloads/work.ics', calendars: APP_WRITE_CALENDARS,
+    onclose: () => {}, onimported: () => {},
+  },
+  nothing: {
+    path: '/home/u/Downloads/nothing.ics', calendars: APP_WRITE_CALENDARS,
+    onclose: () => {}, onimported: () => {},
+  },
+  unreadable: {
+    path: '/home/u/Downloads/bad.ics', calendars: APP_WRITE_CALENDARS,
+    onclose: () => {}, onimported: () => {},
+  },
+};
+
 export const FIXTURES: Record<string, Record<string, any>> = {
   WeatherPopover: WEATHER_CARD_FIXTURES,
+  ImportPanel: IMPORT_PANEL_FIXTURES,
   WeekGrid: {
     empty: { week: emptyWeek() },
     /* A padded payload (2026-09-03): a week either side of the window, with

--- a/ui/tests/harness/mount.svelte.ts
+++ b/ui/tests/harness/mount.svelte.ts
@@ -11,6 +11,7 @@ import Header from '../../src/lib/Header.svelte';
 import CalendarPopover from '../../src/lib/CalendarPopover.svelte';
 import EventPopover from '../../src/lib/EventPopover.svelte';
 import WeatherPopover from '../../src/lib/WeatherPopover.svelte';
+import ImportPanel from '../../src/lib/ImportPanel.svelte';
 import EventForm from '../../src/lib/EventForm.svelte';
 import DeleteConfirm from '../../src/lib/DeleteConfirm.svelte';
 import * as eventform from '../../src/lib/eventform';
@@ -83,7 +84,7 @@ if (name === 'App') {
 
 const COMPONENTS: Record<string, any> = {
   WeekGrid, MonthGrid, YearGrid, BigYearRibbon, Filmstrip, EventBlock, AllDayBand, Header,
-  CalendarPopover, EventPopover, EventForm, DeleteConfirm, WeatherPopover,
+  CalendarPopover, EventPopover, EventForm, DeleteConfirm, WeatherPopover, ImportPanel,
 };
 const target = document.getElementById('app')!;
 
@@ -171,6 +172,9 @@ if (name === 'App') {
     // since it is opening the modal and not the fixture that decides whether
     // anything reaches `invoke`.
     if (name === 'Header') installTauriStub(fixture);
+    // `ImportPanel` reads its whole plan over the IPC — the file is the
+    // backend's to parse — so it needs the stub as much as `Header` does.
+    if (name === 'ImportPanel') installTauriStub(fixture);
     if (name === 'WeekGrid') {
       // Clicking one of its blocks opens a real `EventPopover` that calls
       // `event_detail`/`refresh_event`/`respond_to_event` itself — installed

--- a/ui/tests/harness/tauri.ts
+++ b/ui/tests/harness/tauri.ts
@@ -21,7 +21,7 @@ import type { TemperatureUnit } from '../../src/lib/temperature';
 import { sliceWeek } from '../../src/lib/weekwindow';
 import {
   labelledWeek, weekLabel, APP_FIVE_MIN_AGO, APP_NOW, APP_SERIES_ID, APP_SERIES_OCCURRENCE,
-  TASK_LISTS, TASKS,
+  TASK_LISTS, TASKS, IMPORT_PLANS,
   APP_ONE_OFF_ID, APP_ONE_OFF_START, APP_GUESTS_ID, APP_SOLO_SERIES_ID,
   POPOVER_DETAILS, busyDayMonth,
   appWritableWeek, APP_WRITE_CALENDARS, APP_WEATHER, CREATED_DETAIL, crossZoneWeek,
@@ -1106,6 +1106,15 @@ export function installTauriStub(scenario: string): Harness {
       // The tasks panel reads and writes its own rows; the stub keeps them
       // in memory for the life of the page, so a create is visible to the
       // next `list_tasks` exactly as the backend's would be.
+      // The import panel's two calls. The plan is fixed per path, so a
+      // spec picks a shape by the name it drops.
+      case 'plan_ics_import': {
+        const path = args.path as string;
+        if (path.includes('bad')) throw new Error('that file is not an iCalendar file');
+        return IMPORT_PLANS[path.includes('nothing') ? 'nothing' : 'mixed'];
+      }
+      case 'run_ics_import':
+        return { imported: 2, skipped: IMPORT_PLANS.mixed.filter((p) => p.kind === 'skip'), failed: [] };
       case 'list_tasks':
         return taskRows;
       case 'task_lists':

--- a/ui/tests/harness/tauri.ts
+++ b/ui/tests/harness/tauri.ts
@@ -21,6 +21,7 @@ import type { TemperatureUnit } from '../../src/lib/temperature';
 import { sliceWeek } from '../../src/lib/weekwindow';
 import {
   labelledWeek, weekLabel, APP_FIVE_MIN_AGO, APP_NOW, APP_SERIES_ID, APP_SERIES_OCCURRENCE,
+  TASK_LISTS, TASKS,
   APP_ONE_OFF_ID, APP_ONE_OFF_START, APP_GUESTS_ID, APP_SOLO_SERIES_ID,
   POPOVER_DETAILS, busyDayMonth,
   appWritableWeek, APP_WRITE_CALENDARS, APP_WEATHER, CREATED_DETAIL, crossZoneWeek,
@@ -589,6 +590,9 @@ type StubSettings = {
   windowFrame: WindowFrame | null;
 };
 
+/** The stub's task rows, mutable for the life of the page. */
+let taskRows: typeof TASKS = [...TASKS];
+
 const SETTINGS_KEY = 'omacal-stub-settings';
 
 /** What `list_timezones` answers and `set_second_timezone` validates
@@ -1099,6 +1103,30 @@ export function installTauriStub(scenario: string): Harness {
           return 'me@x.com';
         }
         return 'me@x.com';
+      // The tasks panel reads and writes its own rows; the stub keeps them
+      // in memory for the life of the page, so a create is visible to the
+      // next `list_tasks` exactly as the backend's would be.
+      case 'list_tasks':
+        return taskRows;
+      case 'task_lists':
+        return TASK_LISTS;
+      case 'create_task': {
+        const listId = args.calendarId as number;
+        const list = TASK_LISTS.find((l) => l.calendarId === listId)!;
+        taskRows = [...taskRows, {
+          id: 900 + taskRows.length, calendarId: listId, summary: args.summary as string,
+          notes: null, dueMs: null, dueAllDay: false, completed: false,
+          calendar: list.name, color: list.color, priority: 0, canWrite: true,
+        }];
+        return taskRows;
+      }
+      case 'set_task_completed':
+        taskRows = taskRows.map((t) =>
+          t.id === args.id ? { ...t, completed: args.completed as boolean } : t);
+        return taskRows;
+      case 'delete_task_cmd':
+        taskRows = taskRows.filter((t) => t.id !== args.id);
+        return taskRows;
       default:
         throw new Error(`unstubbed command: ${cmd}`);
     }


### PR DESCRIPTION
Closes #67.

Drop an `.ics` on the window; a panel says what will happen before anything is written.

**The preview is the feature.** An import writes many events at once from a file the app did not author, so nothing is silently altered:

- **A repeat rule the app cannot express is refused**, not downgraded to a single event. The create path carries the form's repeat vocabulary rather than an RRULE, by design, so five shapes come through and the rest are named as skipped.
- **Guests are never imported.** A create carries its guest list to the server and the server invites those people; importing someone's exported year would mail everyone about meetings that already happened. The count is shown before the import, and `send_updates` is `none` besides.
- **An event already here is skipped.** That works on CalDAV, where the stored identity is the file's own UID; on Google it is Google's id, so a re-import cannot be recognised. The limit is documented, not papered over.
- **Popup alarms become reminders**; email alarms do not, for the same reason as the guests.

Everything goes through `events::create_event_body`, the path the window and CLI already use. No second write path and no raw CalDAV PUT, which would be the only way into the database none of the repo's guards cover.

**Not in this cut:** a menu entry with a file dialog (the drop needs no new dependency, a dialog would), and `omacal import` for the CLI. Say if you want either.

**Tests.** The plan and its four refusals; the mapping (end from DTEND then DURATION then the RFC's instant, all-day dates, text carried, guests never, popup-only alarms); the panel's preview, empty and unreadable cases and its report; the drop itself. Mutations: carrying guests reddens the mapping test, downgrading an unknown rule reddens two. Rust 903, UI 1922.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GabzsFfyts4eNZMbTkhtkQ