### PR TITLE
feat(tasks): due tasks on the week, and drag to another day

### DIFF
--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -13,6 +13,8 @@
   import WeatherPopover from './lib/WeatherPopover.svelte';
   import ImportPanel from './lib/ImportPanel.svelte';
   import TasksSidebar from './lib/TasksSidebar.svelte';
+  import { taskChips } from './lib/taskchips';
+  import { listTasks, setTaskCompleted, taskLists, updateTask, type Task, type TaskList } from './lib/tasks';
   import { isIcs } from './lib/importics';
   import { changedMeetings, declinedGuests, pendingInvites } from './lib/invites';
   import { calendarColor, getCalendars, offerableCalendarId, setCalendarSelected, type Calendar } from './lib/calendars';
@@ -279,6 +281,52 @@
    *  menu, closed from its own corner; the calendar keeps working either
    *  way, which is why this is a layout row and not a modal. */
   let tasksOpen = $state(false);
+
+  /** The tasks the grid draws, whether or not the sidebar is open: a task
+   *  due Thursday belongs on Thursday either way, and a row that appeared
+   *  only while a panel was open would be a panel's decoration rather than
+   *  part of the week. */
+  let taskRows = $state<Task[]>([]);
+  let taskListRows = $state<TaskList[]>([]);
+  const weekTasks = $derived(taskChips(taskRows, Date.now(), taskListRows));
+  async function refreshTasks() {
+    try {
+      const [t, l] = await Promise.all([listTasks(), taskLists()]);
+      taskRows = t;
+      taskListRows = l;
+    } catch { /* tasks are a side panel; a failure leaves the last set */ }
+  }
+  $effect(() => { void refreshTasks(); });
+
+  /** A chip dragged to another column. The grid says which day; what a due
+   *  date *becomes* is decided here, because only this side knows whether
+   *  the task had an hour worth keeping. */
+  async function moveTask(id: number, dayStartMs: number) {
+    const task = taskRows.find((t) => t.id === id);
+    if (!task) return;
+    const at = new Date(dayStartMs);
+    let dueMs = at.getTime();
+    if (!task.dueAllDay && task.dueMs !== null) {
+      // A task due at 18:00 stays due at 18:00 on its new day: the drag
+      // moved the day, and nothing about it said anything about the hour.
+      const was = new Date(task.dueMs);
+      at.setHours(was.getHours(), was.getMinutes(), 0, 0);
+      dueMs = at.getTime();
+    }
+    try {
+      taskRows = await updateTask(id, task.summary, dueMs, task.dueAllDay, task.notes);
+    } catch (e) {
+      error = String(e);
+    }
+  }
+
+  async function completeTask(id: number, done: boolean) {
+    try {
+      taskRows = await setTaskCompleted(id, done);
+    } catch (e) {
+      error = String(e);
+    }
+  }
 
   /** The `.ics` a user dropped on the window, or null for no import in
    *  progress (#67). Tauri delivers the drop as paths rather than as HTML5
@@ -1872,7 +1920,8 @@
        week, and a panel over the grid hides the thing the dates refer to. -->
   <div class="workspace">
     {#if tasksOpen}
-      <TasksSidebar onclose={() => (tasksOpen = false)} onchange={() => { void refreshAfterWrite(); }} />
+      <TasksSidebar onclose={() => (tasksOpen = false)}
+                    onchange={() => { void refreshTasks(); }} />
     {/if}
     <div class="view">
     {#if view === 'month'}
@@ -1919,7 +1968,9 @@
       {:else}
         <WeekGrid {week} {visibleStartMs} visibleDays={visibleCount}
                   onerror={(m) => (error = m)}
-                  {weather} {weatherStale} onweather={openWeather} {formPreview} {createColor} {revealNowRequest} bind:hourPx
+                  {weather} {weatherStale} onweather={openWeather}
+                  tasks={weekTasks} ontaskmove={moveTask} ontasktoggle={completeTask}
+                  {formPreview} {createColor} {revealNowRequest} bind:hourPx
                   keyboardCursor={visibleKeyboardCursor}
                   onpan={panView}
                   oncreate={newEventAt} oncreateallday={newAllDayEventOver}

--- a/ui/src/lib/WeekGrid.svelte
+++ b/ui/src/lib/WeekGrid.svelte
@@ -6,6 +6,7 @@
   import { formatTemp } from './temperature';
   import WeatherGlyph from './WeatherGlyph.svelte';
   import { dateKey, type DayWeather } from './weather';
+  import type { TaskChip } from './taskchips';
   import { gutterLabel, zoneAbbrev, zoneGutterLabel } from './timefmt';
   import { tick, untrack } from 'svelte';
   import { HOUR_PX_DEFAULT, hourPxAfterPinch, hourPxAfterWheel, scrollTopKeeping } from './zoom';
@@ -26,7 +27,7 @@
   import { cursorNamesEvent, type KeyboardCursor } from './keyboardnav';
   import { dateOf } from './eventform';
 
-  let { week, weather = null, weatherStale = false, onweather = null, formPreview = null, createColor = null, revealNowRequest = 0, keyboardCursor = null, onpan = null, hourPx = $bindable(HOUR_PX_DEFAULT), visibleStartMs = null, visibleDays = null, onerror = null, oncreate, oncreateallday, onedit, ondelete, oncopy, onmove, ondraftmove = null, onresponded }: {
+  let { week, weather = null, weatherStale = false, onweather = null, tasks = null, ontaskmove = null, ontasktoggle = null, formPreview = null, createColor = null, revealNowRequest = 0, keyboardCursor = null, onpan = null, hourPx = $bindable(HOUR_PX_DEFAULT), visibleStartMs = null, visibleDays = null, onerror = null, oncreate, oncreateallday, onedit, ondelete, oncopy, onmove, ondraftmove = null, onresponded }: {
     /** Padded since 2026-09-03: `visibleDays` from `visibleStartMs` are what
      *  is on screen, and the days either side are the track's to slide into
      *  under a finger (`weekwindow.ts`). Both null — a standalone mount, a
@@ -52,6 +53,16 @@
      *  (`weather.ts`'s `freshness`). The glyph fades and says so, so a
      *  stale sky is noticed without opening a card. */
     weatherStale?: boolean;
+    /** Tasks due in this week, by the ISO date they fall on (`weather.ts`'s
+     *  `dateKey`). Null or empty draws no row at all: a strip of chrome for
+     *  a week with nothing due is the cost Option B was warned about, and
+     *  it is avoidable. */
+    tasks?: Map<string, TaskChip[]> | null;
+    /** A task chip was dragged to another day: its id and that day's start.
+     *  The grid decides which column, never what a due date becomes — the
+     *  hour and the all-day flag are the caller's to keep. */
+    ontaskmove?: ((id: number, dayStartMs: number) => void) | null;
+    ontasktoggle?: ((id: number, done: boolean) => void) | null;
     /** The sky in a day header was clicked: that day's start and the
      *  glyph's own rect, for App to open the weather card over. Optional —
      *  a grid without it keeps the glyph as the label it always was. */
@@ -612,6 +623,76 @@
     drag && drag.moving && drag.id === event.id && drag.startMs === event.start_ms
       ? drag.landed
       : null;
+
+  /** Whether any visible day has a task due. The row exists only then. */
+  const anyTasks = $derived(
+    renderedDays.some((d) => (tasks?.get(dateKey(d.start_ms))?.length ?? 0) > 0),
+  );
+
+  /** A task chip being dragged across the row: which one, from where, and
+   *  how many columns the pointer has travelled. */
+  let taskDrag = $state<
+    { id: number; fromMs: number; originX: number; colWidth: number; cols: number; moving: boolean } | null
+  >(null);
+
+  /** The day a drag currently points at, or null when nothing is moving.
+   *  One derived answer rather than a function called per cell, so the
+   *  landing chip and the lit column cannot disagree about where it is. */
+  const taskDropMs = $derived.by(() => {
+    if (!taskDrag || !taskDrag.moving) return null;
+    const days = renderedDays.map((d) => d.start_ms);
+    const i = days.indexOf(taskDrag.fromMs);
+    if (i < 0) return null;
+    return days[Math.min(days.length - 1, Math.max(0, i + taskDrag.cols))];
+  });
+  /** Whether a chip is the one in flight, and so drawn under the pointer
+   *  rather than in the column it came from. */
+  const inFlight = (chip: TaskChip) => taskDrag?.moving === true && taskDrag.id === chip.id;
+
+  function startTaskDrag(chip: TaskChip, dayMs: number, e: PointerEvent) {
+    if (e.button !== 0 || !chip.canWrite || !ontaskmove) return;
+    const col = (e.currentTarget as HTMLElement).closest('.tcell');
+    if (!col) return;
+    taskDrag = {
+      id: chip.id,
+      fromMs: dayMs,
+      originX: e.clientX,
+      colWidth: col.getBoundingClientRect().width,
+      cols: 0,
+      moving: false,
+    };
+    window.addEventListener('pointermove', onTaskDragMove);
+    window.addEventListener('pointerup', onTaskDragEnd);
+    window.addEventListener('keydown', onTaskDragKey);
+  }
+
+  function onTaskDragMove(e: PointerEvent) {
+    if (!taskDrag) return;
+    const dx = e.clientX - taskDrag.originX;
+    if (!taskDrag.moving && !beganDrag(dx, 0)) return;
+    taskDrag.moving = true;
+    taskDrag.cols = colsMoved(dx, taskDrag.colWidth);
+  }
+
+  function endTaskDrag(commit: boolean) {
+    const d = taskDrag;
+    taskDrag = null;
+    window.removeEventListener('pointermove', onTaskDragMove);
+    window.removeEventListener('pointerup', onTaskDragEnd);
+    window.removeEventListener('keydown', onTaskDragKey);
+    if (!d || !d.moving || !commit || d.cols === 0) return;
+    const days = renderedDays.map((x) => x.start_ms);
+    const i = days.indexOf(d.fromMs);
+    if (i < 0) return;
+    const j = Math.min(days.length - 1, Math.max(0, i + d.cols));
+    if (days[j] !== d.fromMs) ontaskmove?.(d.id, days[j]);
+  }
+
+  const onTaskDragEnd = () => endTaskDrag(true);
+  /** Escape puts it back, the same escape the event drag honours. */
+  const onTaskDragKey = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') endTaskDrag(false);
+  };
 
   function startDrag(event: UiEvent, day: { start_ms: number; end_ms: number }, e: PointerEvent) {
     // Primary button only: a right-click opens a context menu and must not
@@ -1367,6 +1448,52 @@
      occurrence's `start_ms` is its own day (`commands::assemble_week` calls
      `to_ui` per expanded occurrence), which is exactly what
      `occurrenceStartMs` has to carry. -->
+<!-- Tasks get a row of their own rather than a place in the all-day band:
+     an event is a commitment at a time and a task is something to finish,
+     and a band holding both makes the busiest strip on the screen busier.
+     Drawn only when the visible week has something due, so a week with no
+     tasks carries no chrome for them. -->
+{#if anyTasks}
+  <div class="trow" class:dragging={taskDrag?.moving}>
+    <div class="tgutter">TASKS</div>
+    <div class="tcols" style="--cols:{renderedDays.length}">
+      {#each renderedDays as d (d.start_ms)}
+        <div class="tcell" class:drop={taskDropMs === d.start_ms && taskDropMs !== taskDrag?.fromMs}>
+          {#each tasks?.get(dateKey(d.start_ms)) ?? [] as chip (chip.id)}
+            {#if !inFlight(chip)}
+              <div class="tchip" class:over={chip.overdue} style:--cal={chip.color ?? 'var(--muted)'}>
+                <input
+                  type="checkbox"
+                  checked={false}
+                  disabled={!chip.canWrite}
+                  aria-label="Complete {chip.summary}"
+                  onchange={() => ontasktoggle?.(chip.id, true)}
+                />
+                <!-- The title is the grab handle: a button rather than the
+                     whole chip, so the checkbox beside it stays its own
+                     control instead of nesting inside one. -->
+                <button class="tt" disabled={!chip.canWrite}
+                        onpointerdown={(e) => startTaskDrag(chip, d.start_ms, e)}>{chip.summary}</button>
+              </div>
+            {/if}
+          {/each}
+          <!-- The chip in flight, drawn in the column it would land in. -->
+          {#if taskDropMs === d.start_ms && taskDrag}
+            {#each tasks?.get(dateKey(taskDrag.fromMs)) ?? [] as chip (chip.id)}
+              {#if inFlight(chip)}
+                <div class="tchip landing" class:over={chip.overdue}
+                     style:--cal={chip.color ?? 'var(--muted)'}>
+                  <span class="tt">{chip.summary}</span>
+                </div>
+              {/if}
+            {/each}
+          {/if}
+        </div>
+      {/each}
+    </div>
+  </div>
+{/if}
+
 <AllDayBand
   lanes={renderedLanes}
   events={week.all_day_events}
@@ -1610,6 +1737,38 @@
   /* Faded, not hidden: the number is still the best one there is, and the
      fade is what makes somebody click and find out it is two days old. */
   .wx.stale { opacity: .45; }
+
+  /* The tasks row. Quieter than the all-day band above it: a task is
+     something to finish rather than a commitment at a time, and the row
+     says so by being flatter — no fill of the calendar's colour, a tick
+     instead of a spine, and a checkbox as the first thing in it. */
+  .trow { display: flex; border-top: 1px solid var(--hairline);
+          border-bottom: 1px solid var(--hairline);
+          background: color-mix(in srgb, var(--text) 3%, transparent); }
+  .trow.dragging { cursor: grabbing; }
+  .tgutter { width: var(--gutter); flex: 0 0 var(--gutter); font-size: 9.5px;
+             color: var(--muted); letter-spacing: .06em; text-align: right;
+             padding: 7px 8px 0 0; }
+  .tcols { flex-grow: 1; display: grid; grid-template-columns: repeat(var(--cols), minmax(0, 1fr));
+           padding: 4px 0; min-width: 0; }
+  .tcell { min-width: 0; display: flex; flex-direction: column; gap: 2px; padding-right: 3px; }
+  .tcell.drop { background: color-mix(in srgb, var(--accent) 7%, transparent);
+                box-shadow: inset 1px 0 0 0 color-mix(in srgb, var(--accent) 40%, transparent),
+                            inset -1px 0 0 0 color-mix(in srgb, var(--accent) 40%, transparent); }
+  /* Not `.chip`: the all-day band already owns that name, and a spec
+     asking for one would find both. */
+  .tchip { display: flex; align-items: center; gap: 6px; min-width: 0;
+          font-size: 11.5px; font-weight: 500; padding: 2px 7px;
+          border-radius: var(--event-chip-radius, 4px);
+          background: color-mix(in srgb, var(--cal) 10%, var(--bg));
+          color: var(--text); }
+  .tchip.over { background: color-mix(in srgb, var(--error) 12%, var(--bg)); }
+  .tchip.landing { outline: 1px solid var(--accent); cursor: grabbing; }
+  .tchip input { width: 11px; height: 11px; flex: 0 0 11px; margin: 0; }
+  .tt { appearance: none; -webkit-appearance: none; font: inherit; border: 0; background: none;
+        color: inherit; padding: 0; text-align: left; min-width: 0; cursor: grab;
+        touch-action: none; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .tt:disabled { cursor: default; }
   @container (max-width: 104px) { .wx { display: none; } }
   .head b { font-size: 15px; color: var(--text);
             font-weight: 500; letter-spacing: -.02em; }

--- a/ui/src/lib/taskchips.ts
+++ b/ui/src/lib/taskchips.ts
@@ -1,0 +1,55 @@
+// A task as the week grid draws it, and how a week's worth are found.
+//
+// The grid takes chips rather than `Task`s so it never has to know what a
+// task list is, only what belongs on Thursday — the same bargain the
+// forecast makes with `weather.ts`.
+
+import { dateKey } from './weather';
+import type { Task } from './tasks';
+
+export type TaskChip = {
+  id: number;
+  summary: string;
+  color: string | null;
+  completed: boolean;
+  overdue: boolean;
+  canWrite: boolean;
+};
+
+/**
+ * The tasks the grid should draw, by the ISO date they belong on.
+ *
+ * Two rules, both about not lying:
+ *
+ * - An **overdue** task is drawn on today, not on the day it was due. Its
+ *   date has passed and the column for it may not even be on screen; a task
+ *   that quietly leaves the week when the week moves is one nobody does.
+ *   It is marked, so the day it lands on is not read as its due date.
+ * - A **completed** task is left out. The row is what still needs doing,
+ *   and the sidebar's Done section is where a finished one goes.
+ */
+export function taskChips(
+  tasks: Task[],
+  nowMs: number,
+  lists: { calendarId: number; color: string | null }[] = [],
+): Map<string, TaskChip[]> {
+  const today = dateKey(nowMs);
+  const out = new Map<string, TaskChip[]>();
+  for (const t of tasks) {
+    if (t.completed || t.dueMs === null) continue;
+    const overdue = dateKey(t.dueMs) < today;
+    const key = overdue ? today : dateKey(t.dueMs);
+    const chip: TaskChip = {
+      id: t.id,
+      summary: t.summary,
+      color: t.color ?? lists.find((l) => l.calendarId === t.calendarId)?.color ?? null,
+      completed: false,
+      overdue,
+      canWrite: t.canWrite,
+    };
+    const at = out.get(key);
+    if (at) at.push(chip);
+    else out.set(key, [chip]);
+  }
+  return out;
+}

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -5010,3 +5010,95 @@ test.describe('dropping a file on the calendar', () => {
     await expect(page.getByRole('dialog', { name: /^Import / })).toHaveCount(0);
   });
 });
+
+/**
+ * Tasks on the week, and dragging one to another day.
+ *
+ * The row exists only when the visible week has something due: a strip of
+ * chrome for a week with nothing in it is the cost this shape was warned
+ * about, and it is avoidable.
+ */
+test.describe('tasks on the grid', () => {
+  const openWeek = async (page: import('@playwright/test').Page) => {
+    await page.clock.setFixedTime(APP_NOW);
+    await page.goto(app());
+    await expect(page.locator('.ev').first()).toBeVisible();
+  };
+
+  test('due tasks appear in a row of their own, and overdue ones on today', async ({ page }) => {
+    await openWeek(page);
+    const row = page.locator('.trow');
+    await expect(row).toBeVisible();
+    await expect(row.getByText('Ship the release')).toBeVisible();
+    // The overdue one is drawn on today rather than off the week, and marked.
+    await expect(row.locator('.tchip.over')).toHaveCount(1);
+    await expect(row.locator('.tchip.over')).toContainText('Answer the issue');
+    // A completed task is not on the grid at all.
+    await expect(row.getByText('Old standup note')).toHaveCount(0);
+  });
+
+  test('dragging a task to another day moves its due date', async ({ page }) => {
+    await openWeek(page);
+    // The title is the grab handle; the checkbox beside it is not.
+    const title = page.locator('.trow .tchip .tt', { hasText: 'Ship the release' });
+    const from = (await title.boundingBox())!;
+    const cell = (await page.locator('.trow .tcell').first().boundingBox())!;
+    const y = from.y + from.height / 2;
+
+    await page.mouse.move(from.x + 4, y);
+    await page.mouse.down();
+    await page.mouse.move(from.x + 4 + cell.width * 2, y, { steps: 8 });
+    await page.mouse.up();
+
+    // Two columns on: the day moves, the all-day flag is kept.
+    await expect.poll(() => page.evaluate(() =>
+      (window as any).__harness.calls.filter((c: any) => c.cmd === 'update_task').pop()?.args,
+    )).toMatchObject({ summary: 'Ship the release', dueAllDay: true });
+    // `Date.UTC`, not `new Date(...)`: the suite fixes the browser to UTC
+    // (playwright.config.ts) while this expression runs in the runner's own
+    // zone, and the two disagree by the machine's offset.
+    const moved = await page.evaluate(() =>
+      (window as any).__harness.calls.filter((c: any) => c.cmd === 'update_task').pop()?.args.dueMs);
+    expect(moved).toBe(Date.UTC(2024, 0, 31));
+  });
+
+  /** Escape puts it back, the same escape an event drag honours. */
+  test('escape during a drag writes nothing', async ({ page }) => {
+    await openWeek(page);
+    const title = page.locator('.trow .tchip .tt', { hasText: 'Ship the release' });
+    const from = (await title.boundingBox())!;
+    const cell = (await page.locator('.trow .tcell').first().boundingBox())!;
+    const y = from.y + from.height / 2;
+
+    await page.mouse.move(from.x + 4, y);
+    await page.mouse.down();
+    await page.mouse.move(from.x + 4 + cell.width * 2, y, { steps: 8 });
+    await page.keyboard.press('Escape');
+    await page.mouse.up();
+
+    expect(await page.evaluate(() =>
+      (window as any).__harness.calls.filter((c: any) => c.cmd === 'update_task').length)).toBe(0);
+  });
+
+  test('the checkbox on a chip completes the task', async ({ page }) => {
+    await openWeek(page);
+    await page.locator('.trow').getByRole('checkbox', { name: 'Complete Ship the release' }).click();
+    await expect.poll(() => page.evaluate(() =>
+      (window as any).__harness.calls.filter((c: any) => c.cmd === 'set_task_completed').pop()?.args,
+    )).toMatchObject({ on: true });
+    // Once done it leaves the grid: the row is what still needs doing.
+    await expect(page.locator('.trow').getByText('Ship the release')).toHaveCount(0);
+  });
+
+  /** No chrome for a week with nothing due. */
+  test('a week with no due tasks has no row', async ({ page }) => {
+    await page.clock.setFixedTime(APP_NOW);
+    await page.goto(app());
+    await expect(page.locator('.ev').first()).toBeVisible();
+    await expect(page.locator('.trow')).toBeVisible();
+
+    // Forward a year: nothing is due there.
+    for (let i = 0; i < 5; i += 1) await page.keyboard.press('l');
+    await expect(page.locator('.trow')).toHaveCount(0);
+  });
+});

--- a/ui/tests/harness/tauri.ts
+++ b/ui/tests/harness/tauri.ts
@@ -1131,7 +1131,7 @@ export function installTauriStub(scenario: string): Harness {
       }
       case 'set_task_completed':
         taskRows = taskRows.map((t) =>
-          t.id === args.id ? { ...t, completed: args.completed as boolean } : t);
+          t.id === args.id ? { ...t, completed: args.on as boolean } : t);
         return taskRows;
       case 'update_task':
         taskRows = taskRows.map((t) => t.id === args.id ? {

--- a/ui/tests/taskchips.spec.ts
+++ b/ui/tests/taskchips.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+import { taskChips } from '../src/lib/taskchips';
+import type { Task } from '../src/lib/tasks';
+
+/**
+ * Which day a task is drawn on. Two rules, both about not lying, and both
+ * invisible from a rendered row: an overdue task moves to today rather than
+ * off the screen, and a finished one is not drawn at all.
+ */
+const task = (over: Partial<Task> = {}): Task => ({
+  id: 1, calendarId: 1, summary: 'x', notes: null, dueMs: null, dueAllDay: true,
+  completed: false, calendar: 'Work', color: '#2dd4bf', priority: 0, canWrite: true, ...over,
+});
+const NOW = new Date(2026, 8, 9, 10, 0).getTime(); // Wed 9 Sep 2026
+const on = (day: number, hour = 9) => new Date(2026, 8, day, hour, 0).getTime();
+
+test('a task is drawn on the day it is due', () => {
+  const map = taskChips([task({ id: 1, dueMs: on(11) })], NOW);
+  expect([...map.keys()]).toEqual(['2026-09-11']);
+  expect(map.get('2026-09-11')![0]).toMatchObject({ id: 1, overdue: false, summary: 'x' });
+});
+
+/** Its own day may not be on screen, and a task that leaves the week when
+ *  the week moves is one nobody does. It is marked, so the day it lands on
+ *  is not read as its due date. */
+test('an overdue task is drawn on today, and marked', () => {
+  const map = taskChips([task({ id: 2, dueMs: on(4) })], NOW);
+  expect([...map.keys()]).toEqual(['2026-09-09']);
+  expect(map.get('2026-09-09')![0].overdue).toBe(true);
+});
+
+test('a completed task and an undated one are not drawn at all', () => {
+  const map = taskChips([
+    task({ id: 3, dueMs: on(11), completed: true }),
+    task({ id: 4, dueMs: null }),
+    // Completed *and* overdue: still not drawn, and not piled onto today.
+    task({ id: 5, dueMs: on(4), completed: true }),
+  ], NOW);
+  expect(map.size).toBe(0);
+});
+
+test('several tasks on one day keep their order', () => {
+  const map = taskChips([
+    task({ id: 6, dueMs: on(11), summary: 'first' }),
+    task({ id: 7, dueMs: on(11, 14), summary: 'second' }),
+  ], NOW);
+  expect(map.get('2026-09-11')!.map((c) => c.summary)).toEqual(['first', 'second']);
+});
+
+/** A task's own colour wins; without one it takes its list's, and without
+ *  that the grid falls back rather than drawing nothing. */
+test('a chip takes its colour from the task, else from its list', () => {
+  const lists = [{ calendarId: 9, color: '#7aa2f7' }];
+  expect(taskChips([task({ dueMs: on(11) })], NOW, lists).get('2026-09-11')![0].color).toBe('#2dd4bf');
+  expect(taskChips([task({ dueMs: on(11), calendarId: 9, color: null })], NOW, lists)
+    .get('2026-09-11')![0].color).toBe('#7aa2f7');
+  expect(taskChips([task({ dueMs: on(11), calendarId: 1, color: null })], NOW, lists)
+    .get('2026-09-11')![0].color).toBe(null);
+});


### PR DESCRIPTION
The grid half of the tasks arc, on top of #72's update path.

**The row.** A task with a due date shows on that day, in a row of its own under the all-day band rather than in it: an event is a commitment at a time and a task is something to finish. The row exists only when the visible week has something due, so an empty week carries no chrome for it.

**Two rules, both about not lying.** An overdue task is drawn on today rather than on its own day, because that column may not be on screen and a task that leaves the week when the week moves is one nobody does; it is marked so the day it lands on is not read as its due date. A completed task is not drawn at all. Both are invisible from a rendered row, so they are tested as a table of inputs to outputs.

**The drag.** Moving a chip to another column moves the due date. The grid decides which column and nothing else — what the due date *becomes* is decided in App, the only side that knows whether the task had an hour worth keeping, so a task due at 18:00 stays due at 18:00 on its new day. Escape puts it back, like an event drag.

**Two collisions the suite caught**, both mine: the task chip's class name is already owned by the all-day band, and an existing spec found it immediately. Renamed.

**Tests.** Ten new: the chip mapping as a table, the row's presence and absence, the overdue marking, the drag, escape, and the checkbox. Mutations: overdue tasks left on their own day, and an escape that commits. Rust 908, UI 1964.

**Next and last in the arc:** the CLI, so agents can read and change tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GabzsFfyts4eNZMbTkhtkQ