### PR TITLE
feat(cli): omacal tasks — read what is due, add, tick off and edit

### DIFF
--- a/skills/omacal/SKILL.md
+++ b/skills/omacal/SKILL.md
@@ -24,6 +24,9 @@ omacal search quarterly review --json
 omacal calendars --json              # every calendar with ids
 omacal weather --json                # the app's forecast (v2.2+): place +
                                      # how it was decided, now, eight days
+omacal tasks --json                  # what still needs doing (v2.3+), with
+                                     # due dates, ids and which list
+omacal tasks --all --json            # including recently completed
 omacal commands --json               # machine-readable catalog of every
                                      # command and flag (v0.8.1+) — check
                                      # here before assuming a flag exists
@@ -53,6 +56,16 @@ user that a reschedule will move the meeting for the other people** — on
 `own-copy` it will not; tell them to ask the organizer instead.
 
 ## Writing (requires the app to be running; omacal v0.7+)
+
+```bash
+omacal tasks add "Renew the domain" --due 2026-09-11 --json
+omacal tasks add "Call the bank" --due 2026-09-11 --at 10:00 --list 3 --json
+omacal tasks done 41 --json          # and `reopen 41` to put it back
+omacal tasks edit 41 --due 2026-09-14 --json
+omacal tasks edit 41 --due none --json     # clears the date; `--at none` keeps
+                                           # the day and drops the hour
+```
+
 
 ```bash
 omacal events create --title "Standup" --date 2026-09-01 \
@@ -131,6 +144,13 @@ When showing the calendar to the user (not piping into a script):
   calendars --json` shows what is hidden.
 - Times are in the user's display zone; trust `start`/`end` for prose and
   `startMs`/`endMs` for arithmetic.
+- Tasks are VTODOs on an iCloud or CalDAV list; a Google-only account has
+  none, and `omacal tasks` printing nothing means that rather than a clear
+  plate. `due` is a bare date when the task has no hour and an instant when
+  it has one — do not invent an hour for one that has none. `overdue` is
+  already computed; say a task is late rather than working it out from the
+  date. Adding needs a list: omit `--list` and it lands on the first one,
+  which `omacal tasks` names in each row.
 - Weather can be stale: `fetched_at` is when the app last reached the
   forecast, and it keeps the last good answer when offline. Check it before
   answering — past about six hours say so ("the forecast is from yesterday

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -46,6 +46,10 @@ USAGE
                                            organizer, description
   omacal search <query> [--json]           titles, nearest to today first
   omacal calendars [--json]                every calendar, with ids
+  omacal tasks [--all] [--json]            what still needs doing, with ids
+  omacal tasks add \"title\" [--list ID] [--due YYYY-MM-DD] [--at HH:MM]
+  omacal tasks done ID | omacal tasks reopen ID
+  omacal tasks edit ID [--title T] [--due D|none] [--at HH:MM|none] [--notes N|none]
   omacal weather [--json]                  the app's forecast, and the place it is for
   omacal doctor [--json]                   diagnose this install
   omacal skill                             print the agent skill this binary carries
@@ -95,6 +99,10 @@ pub(crate) enum Command {
     Show { id: i64 },
     Search { query: String },
     Calendars,
+    /// What still needs doing, off the same rows the window draws. `all`
+    /// adds the recently completed, which the window keeps in its own
+    /// section rather than in the list.
+    Tasks { all: bool },
     /// The forecast the window shows, off the same cache — and where it is
     /// for, since that place may not be where the user is.
     Weather,
@@ -165,6 +173,18 @@ pub(crate) fn command_catalog() -> Vec<CommandInfo> {
         CommandInfo { name: "calendars", usage: "calendars", writes: false,
             description: "every calendar with ids and accounts",
             flags: &["--json"] },
+        CommandInfo { name: "tasks", usage: "tasks [--all]", writes: false,
+            description: "what still needs doing, with due dates and ids",
+            flags: &["--all", "--json"] },
+        CommandInfo { name: "tasks add", usage: "tasks add \"title\" [--list ID] [--due D] [--at HH:MM]", writes: true,
+            description: "add a task to a list",
+            flags: &["--list", "--due", "--at", "--json"] },
+        CommandInfo { name: "tasks done", usage: "tasks done|reopen ID", writes: true,
+            description: "tick a task off, or put it back",
+            flags: &["--json"] },
+        CommandInfo { name: "tasks edit", usage: "tasks edit ID [--title T] [--due D|none] [--at HH:MM|none] [--notes N|none]", writes: true,
+            description: "change a task's title, due date or note",
+            flags: &["--title", "--due", "--at", "--notes", "--json"] },
         CommandInfo { name: "weather", usage: "weather", writes: false,
             description: "the app's forecast: the place it is for and how that was decided, now, and eight days",
             flags: &["--json"] },
@@ -226,6 +246,16 @@ pub(crate) fn parse(argv: &[String]) -> Option<Result<Invocation, String>> {
             ))),
         },
         "calendars" => build(Command::Calendars),
+        "tasks" => {
+            // A verb means a change, and changes go over the socket.
+            if let Some(parsed) = crate::cli_tasks::parse(&rest) {
+                return Some(parsed.map(|cmd| Invocation {
+                    command: Command::Write(Box::new(crate::cli_write::WriteCmd::Task(cmd))),
+                    json,
+                }));
+            }
+            build(Command::Tasks { all: rest.iter().any(|a| a.as_str() == "--all") })
+        }
         "weather" => build(Command::Weather),
         "doctor" => build(Command::Doctor),
         "agenda" => {
@@ -639,6 +669,63 @@ fn print_rows_human(rows: &[Row]) {
     }
 }
 
+/// One task, as an agent consumes it. `due` is RFC 3339 in the display
+/// zone when the task has a time, and a bare date when it does not — the
+/// distinction the app stores, kept rather than flattened.
+fn task_json(row: &omacal_store::TaskRow) -> serde_json::Value {
+    let t = &row.task;
+    serde_json::json!({
+        "id": t.id,
+        "summary": t.summary.clone().unwrap_or_default(),
+        "notes": t.description,
+        "due": t.due_utc.map(|ms| due_wire(ms, t.due_all_day)),
+        "dueMs": t.due_utc,
+        "dueAllDay": t.due_all_day,
+        "overdue": t.due_utc.is_some_and(|ms| ms < crate::now_ms()) && t.status != "completed",
+        "completed": t.status == "completed",
+        "list": row.calendar_summary,
+        "listId": t.calendar_id,
+        "canWrite": row.access_role != "reader",
+    })
+}
+
+/// A due date on the wire: a bare date when the task has no hour, and an
+/// instant when it has one.
+fn due_wire(ms: i64, all_day: bool) -> String {
+    let z = jiff::Timestamp::from_millisecond(ms)
+        .unwrap_or(jiff::Timestamp::UNIX_EPOCH)
+        .to_zoned(jiff::tz::TimeZone::system());
+    if all_day { z.date().to_string() } else { z.timestamp().to_string() }
+}
+
+/// The tasks as a person reads them: what is late first, then what is due,
+/// then what has no date — the order somebody actually works in.
+pub(crate) fn task_lines(rows: &[&omacal_store::TaskRow], now_ms: i64) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut sorted: Vec<&&omacal_store::TaskRow> = rows.iter().collect();
+    sorted.sort_by_key(|r| (r.task.due_utc.is_none(), r.task.due_utc.unwrap_or(i64::MAX)));
+    for r in sorted {
+        let t = &r.task;
+        let when = match t.due_utc {
+            None => "        ".to_string(),
+            Some(ms) => {
+                let overdue = ms < now_ms && t.status != "completed";
+                let d = due_wire(ms, t.due_all_day);
+                let d = d.split('T').next().unwrap_or(&d).to_string();
+                if overdue { format!("{d} !") } else { format!("{d}  ") }
+            }
+        };
+        let mark = if t.status == "completed" { "x" } else { " " };
+        out.push(format!(
+            "{:>5}  [{mark}] {when}  {}  ({})",
+            t.id,
+            t.summary.clone().unwrap_or_else(|| "(untitled)".into()),
+            r.calendar_summary,
+        ));
+    }
+    out
+}
+
 /// The forecast as a person reads it: the place first, with how it was
 /// decided, because that place may not be where they are; then now; then
 /// the days. Units follow the app's setting, rounded here once, the way
@@ -837,6 +924,24 @@ pub(crate) fn run(inv: Invocation) -> i32 {
                     unreachable!("handled above, before the database")
                 }
                 Command::Write(_) => unreachable!("taken by value above"),
+                Command::Tasks { all } => {
+                    let since = if *all { crate::now_ms() - 7 * 24 * 3_600_000 } else { crate::now_ms() };
+                    let rows = omacal_store::tasks_for_ui(&pool, since).await?;
+                    let open: Vec<_> = rows
+                        .iter()
+                        .filter(|r| *all || r.task.status != "completed")
+                        .collect();
+                    if inv.json {
+                        print_json(&open.iter().map(|r| task_json(r)).collect::<Vec<_>>());
+                    } else if open.is_empty() {
+                        println!("Nothing to do.");
+                    } else {
+                        for line in task_lines(&open, crate::now_ms()) {
+                            println!("{line}");
+                        }
+                    }
+                    Ok(EXIT_OK)
+                }
                 Command::Weather => {
                     // The window's own cache, gated the way the window is:
                     // off in Settings answers empty, and so does a fresh
@@ -1242,8 +1347,8 @@ mod tests {
         let names: Vec<&str> = catalog.iter().map(|c| c.name).collect();
         for required in [
             "agenda", "events list", "events show", "events create", "events update",
-            "events delete", "events respond", "search", "calendars", "weather", "doctor",
-            "skill", "commands", "cli-help",
+            "events delete", "events respond", "search", "calendars", "tasks", "tasks add",
+            "tasks done", "tasks edit", "weather", "doctor", "skill", "commands", "cli-help",
         ] {
             assert_eq!(
                 names.iter().filter(|n| **n == required).count(),
@@ -1251,13 +1356,14 @@ mod tests {
                 "{required} appears exactly once"
             );
         }
-        assert_eq!(names.len(), 14, "nothing in the catalog the parser does not answer");
+        assert_eq!(names.len(), 18, "nothing in the catalog the parser does not answer");
         let writers: Vec<&str> =
             catalog.iter().filter(|c| c.writes).map(|c| c.name).collect();
         assert_eq!(
             writers,
-            ["events create", "events update", "events delete", "events respond"],
-            "exactly the four socket verbs write"
+            ["events create", "events update", "events delete", "events respond",
+             "tasks add", "tasks done", "tasks edit"],
+            "exactly the socket verbs write"
         );
         assert!(serde_json::to_string(&catalog).is_ok());
 
@@ -1265,6 +1371,23 @@ mod tests {
             parse(&argv("commands --json")),
             Some(Ok(Invocation { command: Command::Commands, json: true }))
         );
+
+        // The read and the three write verbs, as the catalog promises them.
+        assert_eq!(
+            parse(&argv("tasks")),
+            Some(Ok(Invocation { command: Command::Tasks { all: false }, json: false }))
+        );
+        assert_eq!(
+            parse(&argv("tasks --all --json")),
+            Some(Ok(Invocation { command: Command::Tasks { all: true }, json: true }))
+        );
+        for verb in ["add Thing", "done 4", "reopen 4", "edit 4 --title T"] {
+            let parsed = parse(&argv(&format!("tasks {verb}")));
+            assert!(
+                matches!(parsed, Some(Ok(Invocation { command: Command::Write(_), .. }))),
+                "tasks {verb} is a write",
+            );
+        }
     }
 
     /// The forecast a person reads leads with the place and how it was

--- a/src-tauri/src/cli_tasks.rs
+++ b/src-tauri/src/cli_tasks.rs
@@ -1,0 +1,382 @@
+//! `omacal tasks` — the task half of the CLI.
+//!
+//! Same division as the events side: the **list is a read**, straight off
+//! the synced database with no app running, and every **change goes over
+//! the socket** into the app's own write path, so a task the CLI creates
+//! passes exactly the guards a task the window creates does.
+//!
+//! The verbs are deliberately fewer than the window's. An agent's job here
+//! is to answer "what do I still have to do" and to put something on the
+//! list; the shapes a person wants a pointer and a calendar for — moving a
+//! task between lists, priorities, recurrence — are not offered rather than
+//! half-offered.
+
+use crate::cli::{fail, EXIT_USAGE};
+
+/// One change to a task, as the CLI parses it.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum TaskCmd {
+    Add {
+        summary: String,
+        /// Absent means the first list a task can be created on.
+        list: Option<i64>,
+        due: Option<String>,
+        at: Option<String>,
+    },
+    /// `done` and `reopen` are one verb with a flag on the wire; two words
+    /// here because "mark it not-done" is not a thing anyone types.
+    Complete { id: i64, done: bool },
+    Edit {
+        id: i64,
+        title: Option<String>,
+        /// `Some(None)` is `--due none`: the date goes. Absent leaves it.
+        due: Option<Option<String>>,
+        at: Option<Option<String>>,
+        notes: Option<Option<String>>,
+    },
+}
+
+/// `--due 2026-09-11` and `--at 18:00` into the instant they name, in the
+/// machine's own zone, plus whether it is a whole day.
+///
+/// A time with no date is refused rather than assumed onto today: the
+/// difference between "due at six" and "due today at six" is a day, and
+/// guessing it is the kind of help nobody asked for.
+pub(crate) fn due_at(
+    due: Option<&str>,
+    at: Option<&str>,
+    tz: &jiff::tz::TimeZone,
+) -> Result<(Option<i64>, bool), String> {
+    let Some(date) = due else {
+        return match at {
+            Some(_) => Err("--at needs --due: a time with no day is not a due date".into()),
+            None => Ok((None, true)),
+        };
+    };
+    let date: jiff::civil::Date = date
+        .parse()
+        .map_err(|_| format!("--due takes YYYY-MM-DD, not \"{date}\""))?;
+    let Some(time) = at else {
+        let ms = date
+            .to_datetime(jiff::civil::time(0, 0, 0, 0))
+            .to_zoned(tz.clone())
+            .map_err(|e| e.to_string())?
+            .timestamp()
+            .as_millisecond();
+        return Ok((Some(ms), true));
+    };
+    let time: jiff::civil::Time = time
+        .parse()
+        .map_err(|_| format!("--at takes HH:MM, not \"{time}\""))?;
+    let ms = date
+        .to_datetime(time)
+        .to_zoned(tz.clone())
+        .map_err(|e| e.to_string())?
+        .timestamp()
+        .as_millisecond();
+    Ok((Some(ms), false))
+}
+
+/// `omacal tasks add|done|reopen|edit …`, or `None` for the bare read.
+pub(crate) fn parse(rest: &[&String]) -> Option<Result<TaskCmd, String>> {
+    // The verb is the first word that is not a flag: `tasks --all --json`
+    // is the read, and only `tasks add …` and friends are changes.
+    let i = rest.iter().position(|a| !a.starts_with("--"))?;
+    let verb = rest[i].as_str();
+    let args = &rest[i + 1..];
+
+    let take = |name: &str| -> Result<Option<String>, String> {
+        let mut it = args.iter();
+        while let Some(a) = it.next() {
+            if a.as_str() == name {
+                return match it.next() {
+                    Some(v) if !v.starts_with("--") => Ok(Some((*v).clone())),
+                    _ => Err(format!("{name} needs a value")),
+                };
+            }
+        }
+        Ok(None)
+    };
+    /// `--flag none` clears; absent leaves alone; a value sets.
+    fn clearable(v: Option<String>) -> Option<Option<String>> {
+        v.map(|s| if s.eq_ignore_ascii_case("none") { None } else { Some(s) })
+    }
+    let positional = || -> Option<String> {
+        args.iter().find(|a| !a.starts_with("--")).map(|s| (*s).clone())
+    };
+    let id_of = |what: &str| -> Result<i64, String> {
+        positional()
+            .and_then(|v| v.parse::<i64>().ok())
+            .ok_or_else(|| format!("usage: omacal tasks {what} ID — `omacal tasks` prints ids"))
+    };
+
+    Some((|| {
+        match verb {
+            "add" => {
+                let summary = positional()
+                    .ok_or_else(|| "usage: omacal tasks add \"a title\" [--list ID] [--due YYYY-MM-DD] [--at HH:MM]".to_string())?;
+                let list = match take("--list")? {
+                    None => None,
+                    Some(v) => Some(v.parse::<i64>().map_err(|_| "--list takes a list id — `omacal tasks` prints them".to_string())?),
+                };
+                Ok(TaskCmd::Add { summary, list, due: take("--due")?, at: take("--at")? })
+            }
+            "done" => Ok(TaskCmd::Complete { id: id_of("done")?, done: true }),
+            "reopen" => Ok(TaskCmd::Complete { id: id_of("reopen")?, done: false }),
+            "edit" => {
+                let id = id_of("edit")?;
+                let cmd = TaskCmd::Edit {
+                    id,
+                    title: take("--title")?,
+                    due: clearable(take("--due")?),
+                    at: clearable(take("--at")?),
+                    notes: clearable(take("--notes")?),
+                };
+                let TaskCmd::Edit { title, due, at, notes, .. } = &cmd else { unreachable!() };
+                if title.is_none() && due.is_none() && at.is_none() && notes.is_none() {
+                    return Err(
+                        "omacal tasks edit ID needs something to change: --title, --due, --at or --notes \
+                         (--due none clears the date)"
+                            .into(),
+                    );
+                }
+                Ok(cmd)
+            }
+            other => Err(format!(
+                "usage: omacal tasks [add|done|reopen|edit] — not \"{other}\""
+            )),
+        }
+    })())
+}
+
+/// Runs one task change: fills in whatever the edit did not say from the
+/// task as it stands, then hands the whole state to the app.
+///
+/// Reading the current task first is what lets `edit` take one field at a
+/// time while the app's own command takes the complete state — the CLI is
+/// the layer that knows what "leave the rest alone" means, and it says so
+/// by naming every field.
+pub(crate) async fn execute(pool: &sqlx::SqlitePool, cmd: &TaskCmd, json: bool) -> i32 {
+    let tz = jiff::tz::TimeZone::system();
+    let refuse = |m: &str| fail(json, "usage", m, EXIT_USAGE);
+
+    let (request, done_word) = match cmd {
+        TaskCmd::Add { summary, list, due, at } => {
+            if summary.trim().is_empty() {
+                return refuse("a task needs a title");
+            }
+            let (due_ms, all_day) = match due_at(due.as_deref(), at.as_deref(), &tz) {
+                Ok(v) => v,
+                Err(m) => return refuse(&m),
+            };
+            (
+                serde_json::json!({
+                    "kind": "tasks-create",
+                    "calendarId": list,
+                    "summary": summary,
+                    "dueMs": due_ms,
+                    "dueAllDay": all_day,
+                }),
+                "Added",
+            )
+        }
+        TaskCmd::Complete { id, done } => (
+            serde_json::json!({ "kind": "tasks-complete", "id": id, "done": done }),
+            if *done { "Completed" } else { "Reopened" },
+        ),
+        TaskCmd::Edit { id, title, due, at, notes } => {
+            let task = match omacal_store::task_by_id(pool, *id).await {
+                Ok(Some(t)) => t,
+                Ok(None) => return refuse("no task with that id — `omacal tasks` prints them"),
+                Err(e) => return fail(json, "read_failed", &e.to_string(), crate::cli::EXIT_ERROR),
+            };
+
+            let summary = title.clone().unwrap_or_else(|| task.summary.clone().unwrap_or_default());
+            if summary.trim().is_empty() {
+                return refuse("a task needs a title");
+            }
+            let notes = match notes {
+                Some(n) => n.clone(),
+                None => task.description.clone(),
+            };
+
+            // The date and the time are one answer, so an edit naming only
+            // one takes the other from the task as it stands.
+            let (due_ms, all_day) = match resolve_edit_due(&task, due, at, &tz) {
+                Ok(v) => v,
+                Err(m) => return refuse(&m),
+            };
+            (
+                serde_json::json!({
+                    "kind": "tasks-update",
+                    "id": id,
+                    "summary": summary,
+                    "dueMs": due_ms,
+                    "dueAllDay": all_day,
+                    "notes": notes,
+                }),
+                "Saved",
+            )
+        }
+    };
+
+    crate::cli_write::send(&request, json, done_word)
+}
+
+/// The due date an `edit` means, given what it named and what the task
+/// already had.
+///
+/// `--due none` clears the date, and clears any time with it: a time on no
+/// day is not a due date. `--at none` keeps the day and drops the hour,
+/// which is how a task goes from "by six" back to "some time that day".
+pub(crate) fn resolve_edit_due(
+    task: &omacal_store::StoredTask,
+    due: &Option<Option<String>>,
+    at: &Option<Option<String>>,
+    tz: &jiff::tz::TimeZone,
+) -> Result<(Option<i64>, bool), String> {
+    if matches!(due, Some(None)) {
+        return Ok((None, true));
+    }
+    let current = task.due_utc.map(|ms| {
+        let z = jiff::Timestamp::from_millisecond(ms)
+            .unwrap_or(jiff::Timestamp::UNIX_EPOCH)
+            .to_zoned(tz.clone());
+        (z.date().to_string(), format!("{:02}:{:02}", z.hour(), z.minute()))
+    });
+
+    let date = match due {
+        Some(Some(d)) => Some(d.clone()),
+        _ => current.as_ref().map(|(d, _)| d.clone()),
+    };
+    let Some(date) = date else {
+        // Nothing said a day and the task has none: `--at` alone cannot
+        // invent one.
+        return match at {
+            Some(Some(_)) => Err("--at needs --due: a time with no day is not a due date".into()),
+            _ => Ok((None, true)),
+        };
+    };
+    let time = match at {
+        Some(None) => None,
+        Some(Some(t)) => Some(t.clone()),
+        None => {
+            if task.due_all_day { None } else { current.map(|(_, t)| t) }
+        }
+    };
+    due_at(Some(&date), time.as_deref(), tz)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn argv(s: &str) -> Vec<String> {
+        s.split_whitespace().map(String::from).collect()
+    }
+    fn p(s: &str) -> Result<TaskCmd, String> {
+        let owned = argv(s);
+        let refs: Vec<&String> = owned.iter().collect();
+        parse(&refs).expect("a verb")
+    }
+
+    #[test]
+    fn the_verbs_parse_and_the_mistakes_are_named() {
+        assert_eq!(
+            p("add Renew --due 2026-09-11 --at 18:00"),
+            Ok(TaskCmd::Add {
+                summary: "Renew".into(),
+                list: None,
+                due: Some("2026-09-11".into()),
+                at: Some("18:00".into()),
+            })
+        );
+        assert_eq!(p("done 41"), Ok(TaskCmd::Complete { id: 41, done: true }));
+        assert_eq!(p("reopen 41"), Ok(TaskCmd::Complete { id: 41, done: false }));
+
+        // `none` clears; a value sets; an absent flag leaves alone.
+        assert_eq!(
+            p("edit 41 --due none --notes hello"),
+            Ok(TaskCmd::Edit {
+                id: 41,
+                title: None,
+                due: Some(None),
+                at: None,
+                notes: Some(Some("hello".into())),
+            })
+        );
+
+        assert!(p("add").is_err(), "a title is not optional");
+        assert!(p("done").is_err(), "an id is not optional");
+        assert!(p("edit 41").is_err(), "an edit that changes nothing is a usage error");
+        assert!(p("wobble").unwrap_err().contains("add|done|reopen|edit"));
+        // Flags are not verbs: `tasks --all --json` is the read.
+        let flags = argv("--all --json");
+        let refs: Vec<&String> = flags.iter().collect();
+        assert!(parse(&refs).is_none(), "no verb means the read");
+        assert!(p("add Thing --list nine").is_err());
+    }
+
+    /// A day alone is a whole day; a day and a time is an instant; a time
+    /// with no day is refused rather than assumed onto today.
+    #[test]
+    fn a_due_date_needs_its_day() {
+        let tz = jiff::tz::TimeZone::get("Asia/Kolkata").unwrap();
+        let (ms, all_day) = due_at(Some("2026-09-11"), None, &tz).unwrap();
+        assert!(all_day);
+        // Midnight in Kolkata, not in UTC.
+        assert_eq!(ms, Some("2026-09-10T18:30:00Z".parse::<jiff::Timestamp>().unwrap().as_millisecond()));
+
+        let (ms, all_day) = due_at(Some("2026-09-11"), Some("18:00"), &tz).unwrap();
+        assert!(!all_day);
+        assert_eq!(ms, Some("2026-09-11T12:30:00Z".parse::<jiff::Timestamp>().unwrap().as_millisecond()));
+
+        assert_eq!(due_at(None, None, &tz).unwrap(), (None, true));
+        assert!(due_at(None, Some("18:00"), &tz).unwrap_err().contains("--at needs --due"));
+        assert!(due_at(Some("11/09/2026"), None, &tz).unwrap_err().contains("YYYY-MM-DD"));
+        assert!(due_at(Some("2026-09-11"), Some("six"), &tz).unwrap_err().contains("HH:MM"));
+    }
+
+    fn stored(due_utc: Option<i64>, all_day: bool) -> omacal_store::StoredTask {
+        omacal_store::StoredTask {
+            id: 1, calendar_id: 1, uid: "u".into(), etag: None, caldav_href: None,
+            summary: Some("t".into()), description: None, due_utc, due_tz: None,
+            due_all_day: all_day, status: "needs-action".into(), completed_utc: None,
+            priority: 0, raw_ics: None, updated_at: 0,
+        }
+    }
+
+    /// An edit naming one half of the date takes the other from the task,
+    /// and the two clears mean different things.
+    #[test]
+    fn an_edit_fills_the_half_it_was_not_given() {
+        let tz = jiff::tz::TimeZone::get("Asia/Kolkata").unwrap();
+        let at_six = "2026-09-11T12:30:00Z".parse::<jiff::Timestamp>().unwrap().as_millisecond();
+        let timed = stored(Some(at_six), false);
+
+        // A new day keeps the hour the task already had.
+        let (ms, all_day) =
+            resolve_edit_due(&timed, &Some(Some("2026-09-12".into())), &None, &tz).unwrap();
+        assert!(!all_day);
+        assert_eq!(ms, Some("2026-09-12T12:30:00Z".parse::<jiff::Timestamp>().unwrap().as_millisecond()));
+
+        // `--at none` keeps the day and drops the hour.
+        let (_, all_day) = resolve_edit_due(&timed, &None, &Some(None), &tz).unwrap();
+        assert!(all_day);
+
+        // `--due none` clears both.
+        assert_eq!(resolve_edit_due(&timed, &Some(None), &None, &tz).unwrap(), (None, true));
+
+        // An all-day task given a time becomes timed on its own day.
+        let day = stored(Some("2026-09-10T18:30:00Z".parse::<jiff::Timestamp>().unwrap().as_millisecond()), true);
+        let (ms, all_day) = resolve_edit_due(&day, &None, &Some(Some("09:15".into())), &tz).unwrap();
+        assert!(!all_day);
+        assert_eq!(ms, Some("2026-09-11T03:45:00Z".parse::<jiff::Timestamp>().unwrap().as_millisecond()));
+
+        // A task with no date, given only a time, is refused.
+        let none = stored(None, true);
+        assert!(resolve_edit_due(&none, &None, &Some(Some("09:15".into())), &tz)
+            .unwrap_err()
+            .contains("--at needs --due"));
+    }
+}

--- a/src-tauri/src/cli_write.rs
+++ b/src-tauri/src/cli_write.rs
@@ -35,6 +35,8 @@ const REPLY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 #[derive(Debug, PartialEq)]
 pub(crate) enum WriteCmd {
     Create(CreateArgs),
+    /// The task verbs, parsed and executed by `cli_tasks`.
+    Task(crate::cli_tasks::TaskCmd),
     Update(UpdateArgs),
     Delete(DeleteArgs),
     Respond(RespondArgs),
@@ -581,12 +583,17 @@ async fn target(pool: &SqlitePool, id: i64) -> Result<Target, String> {
 /// so a request that reaches the app is one the app can only judge on its
 /// own guards.
 pub(crate) async fn execute(pool: &SqlitePool, cmd: &WriteCmd, json: bool) -> i32 {
+    if let WriteCmd::Task(task) = cmd {
+        return crate::cli_tasks::execute(pool, task, json).await;
+    }
     let tz = jiff::tz::TimeZone::system();
     let tz_name = tz.iana_name().unwrap_or("UTC").to_string();
 
     let refuse = |m: &str| fail(json, "usage", m, EXIT_USAGE);
 
     let (request, done_word) = match cmd {
+        // Taken above; the compiler wants it named all the same.
+        WriteCmd::Task(_) => unreachable!("handled at the top of execute"),
         WriteCmd::Create(args) => {
             let notify = match notify_for(!args.guests.is_empty(), args.notify.as_deref()) {
                 Ok(n) => n,
@@ -706,7 +713,16 @@ pub(crate) async fn execute(pool: &SqlitePool, cmd: &WriteCmd, json: bool) -> i3
         }
     };
 
-    match call(&request) {
+    send(&request, json, done_word)
+}
+
+/// Sends one request to the running app and reports what came back.
+///
+/// Shared with `cli_tasks`: the socket, the three failure shapes and the
+/// "the write's fate is unknown" wording are the same contract whichever
+/// verb asked, and two copies of it would be two chances to drift.
+pub(crate) fn send(request: &serde_json::Value, json: bool, done_word: &str) -> i32 {
+    match call(request) {
         Ok(envelope) => finish(json, envelope, done_word),
         Err(CallError::NotRunning) => fail(
             json,

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -69,6 +69,37 @@ pub(crate) enum Request {
     Delete { id: i64, scope: String, occurrence_start_ms: i64 },
     #[serde(rename = "events-respond")]
     Respond { id: i64, response: String, scope: String, occurrence_start_ms: i64 },
+    /// The task verbs. Fewer than the event ones on purpose: an agent's job
+    /// here is what still needs doing and what to add to the list.
+    #[serde(rename = "tasks-create")]
+    TaskCreate {
+        /// Absent means the first list a task can be created on.
+        #[serde(default)]
+        calendar_id: Option<i64>,
+        summary: String,
+        #[serde(default)]
+        due_ms: Option<i64>,
+        #[serde(default = "yes")]
+        due_all_day: bool,
+    },
+    #[serde(rename = "tasks-complete")]
+    TaskComplete { id: i64, done: bool },
+    #[serde(rename = "tasks-update")]
+    TaskUpdate {
+        id: i64,
+        summary: String,
+        #[serde(default)]
+        due_ms: Option<i64>,
+        due_all_day: bool,
+        #[serde(default)]
+        notes: Option<String>,
+    },
+}
+
+/// A due date with no time is a whole day, which is what a request that
+/// does not mention it means.
+fn yes() -> bool {
+    true
 }
 
 /// One request line to a [`Request`], or the usage message to refuse it
@@ -173,6 +204,38 @@ pub(crate) async fn dispatch(state: &AppState, req: Request) -> serde_json::Valu
             .await
             {
                 Ok(detail) => ok_env(serde_json::json!(detail)),
+                Err(m) => fail_env("refused", &m),
+            }
+        }
+        Request::TaskCreate { calendar_id, summary, due_ms, due_all_day } => {
+            let calendar_id = match calendar_id {
+                Some(id) => id,
+                None => match crate::tasks::first_writable_list(&state.pool).await {
+                    Some(id) => id,
+                    None => {
+                        return fail_env(
+                            "refused",
+                            "no task list to add to — task lists arrive with an iCloud or CalDAV account",
+                        );
+                    }
+                },
+            };
+            match crate::tasks::create_body(state, calendar_id, &summary, due_ms, due_all_day).await {
+                Ok(tasks) => ok_env(serde_json::json!(tasks)),
+                Err(m) => fail_env("refused", &m),
+            }
+        }
+        Request::TaskComplete { id, done } => {
+            match crate::tasks::complete_body(state, id, done).await {
+                Ok(tasks) => ok_env(serde_json::json!(tasks)),
+                Err(m) => fail_env("refused", &m),
+            }
+        }
+        Request::TaskUpdate { id, summary, due_ms, due_all_day, notes } => {
+            match crate::tasks::update_body(state, id, &summary, due_ms, due_all_day, notes.as_deref())
+                .await
+            {
+                Ok(tasks) => ok_env(serde_json::json!(tasks)),
                 Err(m) => fail_env("refused", &m),
             }
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod browser;
 mod caldav_account;
 mod cli;
 mod cli_skill;
+mod cli_tasks;
 mod cli_write;
 mod caldav_write;
 mod calendars;

--- a/src-tauri/src/tasks.rs
+++ b/src-tauri/src/tasks.rs
@@ -227,6 +227,60 @@ pub(crate) fn due_for(
     Ok(Some(omacal_caldav::TodoDue::Date(ts.to_zoned(tz).date())))
 }
 
+/// The list a task lands on when nobody said: the first one a task can be
+/// created on, which is what `task_lists` already means.
+pub(crate) async fn first_writable_list(pool: &sqlx::SqlitePool) -> Option<i64> {
+    writable_task_lists(pool).await.ok()?.first().map(|l| l.calendar_id)
+}
+
+/// The socket's three task verbs, sharing the window's own write path —
+/// one code path, the same guards, as the events side does.
+pub(crate) async fn create_body(
+    state: &AppState,
+    calendar_id: i64,
+    summary: &str,
+    due_ms: Option<i64>,
+    due_all_day: bool,
+) -> Result<Vec<TaskVm>, String> {
+    crate::demo_sync_guard(state.demo)?;
+    create_impl(state, calendar_id, summary, due_ms, due_all_day)
+        .await
+        .map_err(|e| crate::errors::user_facing(&e))?;
+    Ok(list_body(state).await)
+}
+
+pub(crate) async fn complete_body(state: &AppState, id: i64, done: bool) -> Result<Vec<TaskVm>, String> {
+    crate::demo_sync_guard(state.demo)?;
+    set_completed_impl(state, id, done)
+        .await
+        .map_err(|e| crate::errors::user_facing(&e))?;
+    Ok(list_body(state).await)
+}
+
+pub(crate) async fn update_body(
+    state: &AppState,
+    id: i64,
+    summary: &str,
+    due_ms: Option<i64>,
+    due_all_day: bool,
+    notes: Option<&str>,
+) -> Result<Vec<TaskVm>, String> {
+    crate::demo_sync_guard(state.demo)?;
+    update_impl(state, id, summary, due_ms, due_all_day, notes)
+        .await
+        .map_err(|e| crate::errors::user_facing(&e))?;
+    Ok(list_body(state).await)
+}
+
+/// `list_tasks` without the Tauri wrapper, for the socket.
+pub(crate) async fn list_body(state: &AppState) -> Vec<TaskVm> {
+    let since = crate::now_ms() - DONE_WINDOW_MS;
+    omacal_store::tasks_for_ui(&state.pool, since)
+        .await
+        .map(|rows| rows.iter().map(|r| to_vm(r, state.demo)).collect())
+        .unwrap_or_default()
+}
+
 pub(crate) const TASK_NEEDS_A_TITLE: &str = "a task needs a title";
 pub(crate) const TASK_GONE: &str = "that task is no longer here";
 
@@ -238,7 +292,7 @@ pub async fn create_task(
     due_ms: Option<i64>,
 ) -> Result<Vec<TaskVm>, String> {
     crate::demo_sync_guard(state.demo)?;
-    create_impl(&state, calendar_id, &summary, due_ms).await.map_err(|e| e.to_string())?;
+    create_impl(&state, calendar_id, &summary, due_ms, true).await.map_err(|e| e.to_string())?;
     list_tasks(state).await
 }
 
@@ -247,6 +301,7 @@ async fn create_impl(
     calendar_id: i64,
     summary: &str,
     due_ms: Option<i64>,
+    all_day: bool,
 ) -> anyhow::Result<()> {
     let summary = summary.trim();
     if summary.is_empty() {
@@ -260,13 +315,16 @@ async fn create_impl(
 
     let uid = uuid::Uuid::new_v4().to_string();
     let now = jiff::Timestamp::from_millisecond(crate::now_ms())?;
-    // Quick-add dues are dates, not instants: "by Friday", not "by 16:23:07".
-    let due_time = due_ms
-        .and_then(|ms| jiff::Timestamp::from_millisecond(ms).ok())
-        .and_then(|ts| {
-            let tz = jiff::tz::TimeZone::get(&cal_tz).ok()?;
-            Some(omacal_caldav::IcsTime::Date(ts.to_zoned(tz).date()))
-        });
+    // The window's quick-add says dates, not instants: "by Friday", not
+    // "by 16:23:07". The CLI can say an hour, and then it means one.
+    let due_time = due_ms.and_then(|ms| jiff::Timestamp::from_millisecond(ms).ok()).map(|ts| {
+        if all_day {
+            let tz = jiff::tz::TimeZone::get(&cal_tz).unwrap_or(jiff::tz::TimeZone::UTC);
+            omacal_caldav::IcsTime::Date(ts.to_zoned(tz).date())
+        } else {
+            omacal_caldav::IcsTime::Utc(ts)
+        }
+    });
     let ics = omacal_caldav::new_todo_ics(&uid, summary, due_time.as_ref().map(|t| (t, cal_tz.as_str())), now);
 
     let href = format!("{}/{uid}.ics", collection_url.trim_end_matches('/'));
@@ -330,8 +388,13 @@ pub struct TaskListVm {
     pub color: Option<String>,
 }
 
-#[tauri::command]
-pub async fn task_lists(state: tauri::State<'_, AppState>) -> Result<Vec<TaskListVm>, String> {
+/// The task-capable, writable lists, in the order the picker offers them.
+/// One query, two callers: the window's command and the socket's "no list
+/// was named" default, so the CLI can never land a task somewhere the
+/// window would not offer.
+pub(crate) async fn writable_task_lists(
+    pool: &sqlx::SqlitePool,
+) -> anyhow::Result<Vec<TaskListVm>> {
     let rows: Vec<(i64, String, Option<String>)> = sqlx::query_as(
         "SELECT c.id, c.summary, COALESCE(c.color_override, c.color_hex)
          FROM calendars c JOIN accounts a ON a.id = c.account_id
@@ -339,13 +402,19 @@ pub async fn task_lists(state: tauri::State<'_, AppState>) -> Result<Vec<TaskLis
            AND c.selected = 1 AND c.access_role != 'reader'
          ORDER BY c.summary COLLATE NOCASE",
     )
-    .fetch_all(&state.pool)
-    .await
-    .map_err(|e| crate::errors::user_facing(&anyhow::Error::from(e)))?;
+    .fetch_all(pool)
+    .await?;
     Ok(rows
         .into_iter()
         .map(|(calendar_id, name, color)| TaskListVm { calendar_id, name, color })
         .collect())
+}
+
+#[tauri::command]
+pub async fn task_lists(state: tauri::State<'_, AppState>) -> Result<Vec<TaskListVm>, String> {
+    writable_task_lists(&state.pool)
+        .await
+        .map_err(|e| crate::errors::user_facing(&e))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The last piece of the tasks arc. Agents could read and write the calendar and could not see a single task.

```
omacal tasks [--all] [--json]
omacal tasks add "title" [--list ID] [--due YYYY-MM-DD] [--at HH:MM]
omacal tasks done ID | omacal tasks reopen ID
omacal tasks edit ID [--title T] [--due D|none] [--at HH:MM|none] [--notes N|none]
```

Same division as the events side: the list is a read straight off the synced database with no app running, and every change goes over the socket into the app's own write path, so a task the CLI creates passes exactly the guards a task the window creates does. Fewer verbs than the window on purpose — moving a task between lists, priorities and recurrence are not offered rather than half-offered.

**Three refusals, each a guess not made.** A time with no day is turned down rather than assumed onto today. An edit that changes nothing is a usage error with the flags named. `--due none` clears the date; `--at none` keeps the day and drops the hour, which are different answers.

`edit` takes one field at a time while the app's command takes the whole state: the CLI reads the task first and fills in what the edit did not say, since this is the layer that knows what "leave the rest alone" means.

**The skill** says tasks are VTODOs on an iCloud or CalDAV list, so an empty result on a Google-only account reads as "no lists here" rather than a clear plate; that `due` is a bare date when there is no hour, so an hour is never invented; and that `overdue` is already computed.

Tried against a real database: the empty case refuses correctly, and the usage lists the verbs. Rust 911, UI unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GabzsFfyts4eNZMbTkhtkQ