### PR TITLE
fix(tests): the task fixtures carry their type

### DIFF
--- a/ui/tests/fixtures.ts
+++ b/ui/tests/fixtures.ts
@@ -4,6 +4,7 @@ import type {
 } from '../src/lib/api';
 import type { AppStatus } from '../src/lib/status';
 import type { DayWeather, WeatherReport } from '../src/lib/weather';
+import type { Task } from '../src/lib/tasks';
 import type { Calendar } from '../src/lib/calendars';
 import type { Attendee, EventDetail } from '../src/lib/eventdetail';
 import type { Rect } from '../src/lib/position';
@@ -1992,7 +1993,7 @@ export const TASK_LISTS = [
   { calendarId: 1, name: 'Personal', color: '#5b8def' },
   { calendarId: 2, name: 'Work', color: '#2dd4bf' },
 ];
-export const TASKS = [
+export const TASKS: Task[] = [
   // Dated against `APP_NOW` (Mon 29 Jan 2024), so "By when" has an overdue
   // row, a today row and an undated one — the three groups that differ.
   { id: 11, calendarId: 1, summary: 'Buy milk', notes: null, dueMs: null, dueAllDay: true,


### PR DESCRIPTION
Main is red since #74 and this fixes it.

`TASKS` was an untyped array literal, so `notes` was inferred from whichever fixtures happened to be in it; the stub's `update_task` writes `string | null` there and the inferred type refused it. Typed as `Task[]`, which is what those rows are.

**How it got in.** The rebase of #74 brought #73's fixtures together with #74's stub for the first time. After rebasing I reran the test suite but not `npm run check` — the suite does not type-check, and that is the only step that would have caught this. I also merged on a watcher result rather than re-reading the checks. Both are mine.

`npm run check` clean, full UI suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GabzsFfyts4eNZMbTkhtkQ