### PR TITLE
fix(accounts): allow cancelling an abandoned Google sign-in

### DIFF
--- a/crates/omacal-google/src/auth.rs
+++ b/crates/omacal-google/src/auth.rs
@@ -239,11 +239,14 @@ pub async fn refresh(
 use std::io::{BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
 use std::time::{Duration, Instant};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 pub struct Redirect {
     pub code: String,
     pub state: String,
 }
+
+pub const CANCELLED: &str = "Sign-in cancelled.";
 
 /// How long the loopback listener waits for the browser before giving up.
 ///
@@ -251,7 +254,7 @@ pub struct Redirect {
 /// a password; short enough that abandoning the flow is not permanent. An
 /// explicit *deny* comes back as `?error=` and returns immediately — this
 /// deadline is for the user who simply closes the tab, in which case nothing
-/// ever reaches us and only the clock can end the wait.
+/// ever reaches us. Explicit cancellation can end the wait sooner.
 pub const SIGN_IN_TIMEOUT: Duration = Duration::from_secs(180);
 
 /// A connection that opens but never sends a request line would hang the read
@@ -282,10 +285,11 @@ pub fn bind_loopback() -> anyhow::Result<(TcpListener, String)> {
 /// free the UI but abandon the thread inside `accept()`, which would then sit
 /// blocked for the life of the process; polling a non-blocking listener means
 /// the thread actually ends.
-fn accept_before(listener: &TcpListener, deadline: Duration) -> anyhow::Result<TcpStream> {
+fn accept_before(listener: &TcpListener, deadline: Duration, cancelled: &AtomicBool) -> anyhow::Result<TcpStream> {
     listener.set_nonblocking(true)?;
     let start = Instant::now();
     loop {
+        if cancelled.load(Ordering::Relaxed) { bail!(CANCELLED); }
         match listener.accept() {
             Ok((stream, _)) => {
                 // Back to blocking for the request line and the reply, with a
@@ -316,7 +320,12 @@ fn accept_before(listener: &TcpListener, deadline: Duration) -> anyhow::Result<T
 /// HTTP server for a single one-shot request would be more machinery than the
 /// problem deserves.
 pub fn wait_for_redirect(listener: TcpListener, deadline: Duration) -> anyhow::Result<Redirect> {
-    let mut stream = accept_before(&listener, deadline)?;
+    wait_for_redirect_cancellable(listener, deadline, &AtomicBool::new(false))
+}
+
+/// Ends the listener as well as the caller when consent is abandoned.
+pub fn wait_for_redirect_cancellable(listener: TcpListener, deadline: Duration, cancelled: &AtomicBool) -> anyhow::Result<Redirect> {
+    let mut stream = accept_before(&listener, deadline, cancelled)?;
     let mut line = String::new();
     BufReader::new(stream.try_clone()?).read_line(&mut line)?;
 
@@ -626,6 +635,32 @@ mod tests {
         let _ = reqwest::get(format!("http://127.0.0.1:{port}/?code=c&state=s")).await;
         assert!(handle.await.unwrap().is_ok());
         assert!(started.elapsed() < Duration::from_secs(5), "returned only after the deadline");
+    }
+
+    #[test]
+    fn cancelling_abandoned_consent_closes_listener_and_allows_a_fresh_attempt() {
+        let (listener, _) = bind_loopback().unwrap();
+        let address = listener.local_addr().unwrap();
+        let cancelled = std::sync::Arc::new(AtomicBool::new(false));
+        let worker_cancelled = cancelled.clone();
+        let worker = std::thread::spawn(move || {
+            match wait_for_redirect_cancellable(listener, Duration::from_millis(500), &worker_cancelled) {
+                Ok(_) => panic!("cancelled listener returned a code"),
+                Err(e) => e.to_string(),
+            }
+        });
+        std::thread::sleep(Duration::from_millis(60));
+        cancelled.store(true, Ordering::Relaxed);
+        assert_eq!(worker.join().unwrap(), CANCELLED);
+        assert!(TcpStream::connect(address).is_err(), "cancel must close the old listener");
+        let (fresh, _) = bind_loopback().unwrap();
+        let address = fresh.local_addr().unwrap();
+        let worker = std::thread::spawn(move || {
+            wait_for_redirect_cancellable(fresh, Duration::from_secs(2), &AtomicBool::new(false)).is_ok()
+        });
+        let mut browser = TcpStream::connect(address).unwrap();
+        browser.write_all(b"GET /?code=fresh&state=fresh HTTP/1.1\r\n\r\n").unwrap();
+        assert!(worker.join().unwrap(), "a new attempt must accept its own redirect");
     }
 
     #[test]

--- a/src-tauri/src/errors.rs
+++ b/src-tauri/src/errors.rs
@@ -69,6 +69,7 @@ const SAFE_EXACT: &[&str] = &[
     // here. Withheld, this failure is indistinguishable from an OAuth
     // problem — which is issue #1's diagnosis story in one line.
     crate::BROWSER_FAILED,
+    omacal_google::auth::CANCELLED,
     // crates/omacal-google/src/auth.rs:171 (the `TIMED_OUT` constant), raised
     // at auth.rs:206 with no interpolation and propagated to `sign_in_impl`
     // via a bare `?` with no `.context(..)` added along the way.
@@ -392,6 +393,7 @@ mod tests {
             // `tracing`, never into this string, and no `.context(..)` wraps
             // it on the way to `sign_in_impl`'s `map_err`.
             crate::BROWSER_FAILED,
+            omacal_google::auth::CANCELLED,
             // Checked against the doc-comment rule: a fixed literal raised by
             // `bail!(NOT_PRIVATE_HTTP)` in the caldav crate's transport guard,
             // interpolating nothing (the address it refused is deliberately

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -473,11 +473,29 @@ fn load_refresh_token(email: &str) -> anyhow::Result<String> {
     Ok(keyring::Entry::new(KEYRING_SERVICE, email)?.get_password()?)
 }
 
-/// Runs the full interactive sign-in: loopback listener, browser, code
-/// exchange, keyring write, then account and calendar bootstrap.
+/// One pending consent attempt across windows; cancellation stops its listener.
+#[derive(Default)]
+struct SignInAttempt(std::sync::Mutex<Option<std::sync::Arc<std::sync::atomic::AtomicBool>>>);
+
 #[tauri::command]
-async fn sign_in(state: tauri::State<'_, AppState>) -> Result<String, String> {
-    let email = sign_in_impl(&state.pool, state.demo).await?;
+fn cancel_sign_in(attempt: tauri::State<'_, SignInAttempt>) {
+    if let Some(cancelled) = attempt.0.lock().expect("sign-in lock poisoned").as_ref() {
+        cancelled.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+/// Runs interactive consent, code exchange, keyring write and account bootstrap.
+#[tauri::command]
+async fn sign_in(attempt: tauri::State<'_, SignInAttempt>, state: tauri::State<'_, AppState>) -> Result<String, String> {
+    let cancelled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    {
+        let mut active = attempt.0.lock().expect("sign-in lock poisoned");
+        if active.is_some() { return Err("Sign-in is already in progress.".into()); }
+        *active = Some(cancelled.clone());
+    }
+    let result = sign_in_impl(&state.pool, state.demo, cancelled).await;
+    *attempt.0.lock().expect("sign-in lock poisoned") = None;
+    let email = result?;
     forget_stale_credentials(
         &mut *state.tokens.lock().await,
         &mut state.reauth.lock().expect("reauth mark poisoned"),
@@ -514,10 +532,10 @@ pub(crate) const BROWSER_FAILED: &str =
 /// from a test. The demo gate is the first statement for the same reason it is
 /// in `sync_now`: everything below it reads the config file, the keyring and
 /// Google, and demo mode has no business touching any of the three.
-async fn sign_in_impl(pool: &SqlitePool, demo: bool) -> Result<String, String> {
+async fn sign_in_impl(pool: &SqlitePool, demo: bool, cancelled: std::sync::Arc<std::sync::atomic::AtomicBool>) -> Result<String, String> {
     demo_sync_guard(demo)?;
 
-    async fn inner(pool: &SqlitePool) -> anyhow::Result<String> {
+    async fn inner(pool: &SqlitePool, cancelled: std::sync::Arc<std::sync::atomic::AtomicBool>) -> anyhow::Result<String> {
         let cfg = load_config()?;
         let pkce = omacal_google::auth::generate_pkce();
         let (listener, redirect_uri) = omacal_google::auth::bind_loopback()?;
@@ -539,14 +557,19 @@ async fn sign_in_impl(pool: &SqlitePool, demo: bool) -> Result<String, String> {
         // Deadline on the listener, not on this future: a `tokio::time::timeout`
         // here would return while the blocking thread stayed parked in
         // `accept()` for the life of the process.
+        let listener_cancelled = cancelled.clone();
         let redirect = tokio::task::spawn_blocking(move || {
-            omacal_google::auth::wait_for_redirect(
+            omacal_google::auth::wait_for_redirect_cancellable(
                 listener,
                 omacal_google::auth::SIGN_IN_TIMEOUT,
+                &listener_cancelled,
             )
         })
         .await??;
 
+        if cancelled.load(std::sync::atomic::Ordering::Relaxed) {
+            anyhow::bail!(omacal_google::auth::CANCELLED);
+        }
         if redirect.state != csrf {
             anyhow::bail!("state mismatch — possible CSRF, sign-in aborted");
         }
@@ -596,7 +619,7 @@ async fn sign_in_impl(pool: &SqlitePool, demo: bool) -> Result<String, String> {
         Ok(email)
     }
 
-    inner(pool).await.map_err(|e| errors::user_facing(&e))
+    inner(pool, cancelled).await.map_err(|e| errors::user_facing(&e))
 }
 
 /// Records one calendar Google listed for an account.
@@ -1260,6 +1283,7 @@ pub fn run() {
 
     #[allow(unused_mut)]
     let mut builder = tauri::Builder::default()
+        .manage(SignInAttempt::default())
         // First, before every other plugin, per its own docs — a second
         // process must be turned away before anything else initialises.
         // Closing the window only hides omacal (see `tray`), so "start it
@@ -1589,6 +1613,7 @@ pub fn run() {
             get_status,
             take_open_date,
             sign_in,
+            cancel_sign_in,
             sync_now,
             update::open_latest_release,
             update::install_update,
@@ -1829,7 +1854,7 @@ mod tests {
     async fn sign_in_refuses_in_demo_mode_without_touching_config_keyring_or_google() {
         let pool = omacal_store::connect_memory().await.unwrap();
 
-        assert_eq!(sign_in_impl(&pool, true).await, Err(DEMO_SYNC_MESSAGE.to_string()));
+        assert_eq!(sign_in_impl(&pool, true, Default::default()).await, Err(DEMO_SYNC_MESSAGE.to_string()));
 
         // Had it run past the guard it would have inserted an account row (or
         // failed with a config/keyring error instead of the demo message).

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -8,7 +8,7 @@
     getWeek, getDay, getRange, getMonth, getYear, getBigYear, weekStart,
     type WeekPayload, type MonthPayload, type YearPayload, type BigYearPayload, type UiEvent,
   } from './lib/api';
-  import { getStatus, installUpdate, openLatestRelease, restartApp, signIn, syncNow, takeOpenDate, type AppStatus } from './lib/status';
+  import { cancelSignIn, getStatus, installUpdate, openLatestRelease, restartApp, signIn, syncNow, takeOpenDate, type AppStatus } from './lib/status';
   import { dateKey, freshness, getWeather, weatherByDate, type DayWeather, type WeatherReport } from './lib/weather';
   import WeatherPopover from './lib/WeatherPopover.svelte';
   import ImportPanel from './lib/ImportPanel.svelte';
@@ -172,6 +172,7 @@
   let status = $state<AppStatus | null>(null);
   let calendars = $state<Calendar[]>([]);
   let busy = $state(false);
+  let signingIn = $state(false);
   let error = $state<string | null>(null);
   // Opened right after every sign-in (Task 7) — see `handleSignIn` — so a
   // freshly imported set of calendars, all switched on by default, is never
@@ -969,9 +970,12 @@
   });
 
   async function handleSignIn() {
+    if (busy || signingIn) return;
+    signingIn = true;
     busy = true; error = null;
     try {
       await signIn();
+      signingIn = false;
       await refreshStatus();
       // A second account's calendars exist in the store the moment sign_in
       // returns, but nothing else here fetches them: handleSync refreshes
@@ -986,8 +990,13 @@
       pickerOpen = true;
       await handleSync();
     }
+    catch (e) { if (String(e) !== 'Sign-in cancelled.') error = String(e); }
+    finally { signingIn = false; busy = false; }
+  }
+
+  async function handleCancelSignIn() {
+    try { await cancelSignIn(); }
     catch (e) { error = String(e); }
-    finally { busy = false; }
   }
 
   async function handleSync() {
@@ -1894,6 +1903,8 @@
       // the switch change the headers now rather than within the hour.
       void refreshWeather();
     }}
+    {signingIn}
+    onCancelSignIn={handleCancelSignIn}
     onSignIn={handleSignIn}
     onWhatsNew={() => { void openLatestRelease(); }}
     onRestart={() => { void restartApp(); }}

--- a/ui/src/lib/Header.svelte
+++ b/ui/src/lib/Header.svelte
@@ -13,6 +13,7 @@
   let {
     status, anchorMs, weekStartMs, weekStartsToday = false, weekDays = 7,
     yearShown = new Date(anchorMs).getFullYear(),
+    signingIn = false, onCancelSignIn = () => {},
     busy, error, calendars, view, onpick,
     onsettingschange, onappearancechange,
     listMode, onToggleList,
@@ -41,6 +42,8 @@
      *  named the wrong year the moment either had stepped away from it. */
     yearShown?: number;
     busy: boolean;
+    signingIn?: boolean;
+    onCancelSignIn?: () => void;
     error: string | null;
     calendars: Calendar[];
     /** The view the switcher shows as current — `App`'s own `view` state,
@@ -420,6 +423,8 @@
     accounts={status?.accounts ?? []}
     version={status?.version ?? ''}
     {busy}
+    {signingIn}
+    {onCancelSignIn}
     onclose={() => (settingsOpen = false)}
     {calendars}
     {oncalendarchange}
@@ -437,6 +442,12 @@
      "Create it with client_id and client_secret" — is the part that used to
      fall off the end of a 320px ellipsised line and live only in a title
      attribute nobody hovers. -->
+{#if signingIn}
+  <p class="sign-in-status" role="status">
+    Waiting for Google sign-in. Closed the browser tab?
+    <button type="button" onclick={onCancelSignIn}>Cancel sign-in</button>
+  </p>
+{/if}
 {#if error}
   <p class="err">{error}</p>
 {/if}
@@ -603,6 +614,10 @@
 
   .tz { font-size: 11px; color: var(--muted); letter-spacing: .03em;
         white-space: nowrap; }
+  .sign-in-status { display: flex; align-items: center; gap: 12px; flex-wrap: wrap;
+    color: var(--text); font-size: 12.5px; margin: 0 0 12px; }
+  .sign-in-status button { font: inherit; color: var(--text); background: var(--surface);
+    border: 1px solid var(--hairline); border-radius: 6px; padding: 5px 12px; cursor: pointer; }
   .err { color: var(--error); font-size: 12.5px; line-height: 1.45; margin: 0 0 12px;
          padding: 7px 10px; border-radius: 6px;
          background: color-mix(in srgb, var(--error) 9%, transparent);

--- a/ui/src/lib/SettingsModal.svelte
+++ b/ui/src/lib/SettingsModal.svelte
@@ -32,6 +32,7 @@
     accounts,
     version = '',
     busy,
+    signingIn = false, onCancelSignIn = () => {},
     calendars,
     onclose,
     onSignIn,
@@ -48,6 +49,8 @@
      *  rather than claim "OmaCal " and nothing. */
     version?: string;
     busy: boolean;
+    signingIn?: boolean;
+    onCancelSignIn?: () => void;
     /** Every calendar the app knows about, handed straight to `CalendarList` —
      *  the same rows the header's popover shows, from the same component. */
     calendars: Calendar[];
@@ -1229,7 +1232,13 @@
       {#if (accountRows ?? accounts).length === 0}
         <p class="soon">No account is connected.</p>
       {/if}
-      <button type="button" onclick={onSignIn} disabled={busy}>Add account</button>
+      <div class="inline">
+        <button type="button" onclick={onSignIn} disabled={busy}>Add account</button>
+        {#if signingIn}
+          <button type="button" onclick={onCancelSignIn}>Cancel sign-in</button>
+        {/if}
+      </div>
+      {#if signingIn}<p class="hint" role="status">Waiting for Google sign-in in your browser.</p>{/if}
       <p class="hint">
         Signing out removes the account's local data (its calendars, events
         and tasks re-sync if you connect again). For Google, the app's access

--- a/ui/src/lib/status.ts
+++ b/ui/src/lib/status.ts
@@ -44,6 +44,7 @@ export type AppStatus = {
 
 export const getStatus = () => invoke<AppStatus>('get_status');
 export const signIn = () => invoke<string>('sign_in');
+export const cancelSignIn = () => invoke<void>('cancel_sign_in');
 export const syncNow = () => invoke<number>('sync_now');
 /** Opens the latest release's page in the system browser. No argument on
  *  purpose: the backend opens the URL *it* fetched, so the webview never

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -5102,3 +5102,29 @@ test.describe('tasks on the grid', () => {
     await expect(page.locator('.trow')).toHaveCount(0);
   });
 });
+
+test('abandoned Google sign-in can be cancelled and Add account retried', async ({ page }) => {
+  await page.goto(app('abandoned-sign-in'));
+  await page.getByRole('button', { name: 'Menu', exact: true }).click();
+  await page.getByRole('button', { name: 'Settings…', exact: true }).click();
+  let modal = page.getByRole('dialog', { name: 'Settings' });
+  await modal.getByRole('tab', { name: 'Accounts', exact: true }).click();
+  await modal.getByRole('button', { name: 'Add account', exact: true }).click();
+  await expect(page.getByRole('status').filter({ hasText: 'Waiting for Google' })).toBeVisible();
+  await page.getByRole('button', { name: 'Cancel sign-in', exact: true }).click();
+  await expect(page.getByRole('button', { name: 'Cancel sign-in', exact: true })).toHaveCount(0);
+  await expect(page.locator('.err').filter({ hasText: 'Sign-in cancelled.' })).toHaveCount(0);
+  await page.getByRole('button', { name: 'Menu', exact: true }).click();
+  await page.getByRole('button', { name: 'Settings…', exact: true }).click();
+  modal = page.getByRole('dialog', { name: 'Settings' });
+  await modal.getByRole('tab', { name: 'Accounts', exact: true }).click();
+  await expect(modal.getByRole('button', { name: 'Add account', exact: true })).toBeEnabled();
+  await modal.getByRole('button', { name: 'Add account', exact: true }).click();
+  await expect.poll(() => page.evaluate(() => window.__harness.calls.filter(c => c.cmd === 'sign_in').length)).toBe(2);
+  // Cancellation is also available after reopening Settings during consent.
+  await page.getByRole('button', { name: 'Menu', exact: true }).click();
+  await page.getByRole('button', { name: 'Settings…', exact: true }).click();
+  await page.getByRole('dialog', { name: 'Settings' }).getByRole('tab', { name: 'Accounts', exact: true }).click();
+  await page.getByRole('dialog', { name: 'Settings' }).getByRole('button', { name: 'Cancel sign-in', exact: true }).click();
+  await expect(page.getByRole('dialog', { name: 'Settings' }).getByRole('button', { name: 'Add account', exact: true })).toBeEnabled();
+});

--- a/ui/tests/harness/tauri.ts
+++ b/ui/tests/harness/tauri.ts
@@ -710,6 +710,7 @@ export function installTauriStub(scenario: string): Harness {
   // must reflect it too, not just `get_calendars`.
   let status = statusFor(scenario);
   let signedIn = false;
+  let cancelPendingSignIn: ((reason: string) => void) | undefined;
   /** Whether `take_open_date` has answered — the real command clears on
    *  read, and a stub that kept answering would hide a remount replaying
    *  the date, which is exactly the defect `take` semantics exist to stop. */
@@ -1083,7 +1084,14 @@ export function installTauriStub(scenario: string): Harness {
         // popover was showing is gone, and reading it back would fail on the
         // runs that succeeded.
         return null;
+      case 'cancel_sign_in':
+        cancelPendingSignIn?.('Sign-in cancelled.');
+        cancelPendingSignIn = undefined;
+        return null;
       case 'sign_in':
+        if (scenario === 'abandoned-sign-in') {
+          return new Promise((_resolve, reject) => { cancelPendingSignIn = reject; });
+        }
         // Tauri rejects a `Result<_, String>` with the bare string, so the
         // app sees exactly the sentence Rust produced.
         if (scenario === 'no-config') return Promise.reject(NO_CONFIG_ERROR);


### PR DESCRIPTION
Closing Google's consent tab used to leave Add account disabled. Add a Cancel sign-in action, release the pending callback, and let the user try again without restarting OmaCal.

Validated with workspace Rust tests, Clippy, UI type checks, and the cancel/retry regression in Chromium and WebKit.
