### PR TITLE
feat(calendars): use provider names and allow local display labels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5560,6 +5560,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/crates/omacal-google/src/client.rs
+++ b/crates/omacal-google/src/client.rs
@@ -83,6 +83,15 @@ impl CalendarClient {
         Ok(resp.items)
     }
 
+    pub async fn calendar_title(&self, id: &str) -> anyhow::Result<String> {
+        #[derive(Deserialize)]
+        struct Title { summary: String }
+        let title = self.http.get(format!("{}/calendars/{}", self.base_url, urlencoding_path(id)))
+            .bearer_auth(&self.access_token).timeout(std::time::Duration::from_secs(10))
+            .send().await?.error_for_status()?.json::<Title>().await?;
+        Ok(title.summary)
+    }
+
     /// One page of events.
     ///
     /// `singleEvents=false` is deliberate (spec §5): we store recurring masters

--- a/crates/omacal-google/src/model.rs
+++ b/crates/omacal-google/src/model.rs
@@ -6,6 +6,8 @@ pub struct Calendar {
     pub id: String,
     #[serde(default)]
     pub summary: String,
+    /// The name this user chose in Google Calendar, when different from the owner’s.
+    pub summary_override: Option<String>,
     pub background_color: Option<String>,
     pub time_zone: Option<String>,
     #[serde(default)]
@@ -19,6 +21,13 @@ pub struct Calendar {
     /// set, which is a real answer rather than a missing one.
     #[serde(default)]
     pub default_reminders: Vec<Reminder>,
+}
+
+impl Calendar {
+    pub fn display_name(&self) -> &str {
+        self.summary_override.as_deref().filter(|s| !s.trim().is_empty())
+            .unwrap_or(&self.summary)
+    }
 }
 
 /// One reminder. `method` is Google's own vocabulary — `popup` or `email` —

--- a/crates/omacal-store/migrations/0013_calendar_label.sql
+++ b/crates/omacal-store/migrations/0013_calendar_label.sql
@@ -1,0 +1,2 @@
+-- Local display names survive provider syncs; NULL follows the provider.
+ALTER TABLE calendars ADD COLUMN label_override TEXT;

--- a/crates/omacal-store/src/calendars.rs
+++ b/crates/omacal-store/src/calendars.rs
@@ -7,6 +7,8 @@ pub struct CalendarRow {
     pub account_id: i64,
     pub account_email: String,
     pub summary: String,
+    pub provider_summary: String,
+    pub label_override: Option<String>,
     /// **The colour to draw this calendar in** — its override if it has one,
     /// and Google's own otherwise, resolved by the same `COALESCE` the event
     /// read uses. Every consumer that only wants to *draw* something reads
@@ -45,13 +47,14 @@ pub struct CalendarRow {
 /// stable ordering so the popover does not reshuffle between renders.
 pub async fn list_calendars(pool: &SqlitePool) -> anyhow::Result<Vec<CalendarRow>> {
     let rows = sqlx::query(
-        "SELECT c.id, c.account_id, a.email AS account_email, c.summary,
+        "SELECT c.id, c.account_id, a.email AS account_email, COALESCE(c.label_override, c.summary) AS summary,
+                c.summary AS provider_summary, c.label_override,
                 COALESCE(c.color_override, c.color_hex) AS color_hex,
                 c.color_override,
                 c.selected, c.sync_enabled, c.is_primary, c.access_role, a.provider
          FROM calendars c
          JOIN accounts a ON a.id = c.account_id
-         ORDER BY a.email, c.is_primary DESC, c.summary COLLATE NOCASE",
+         ORDER BY a.email, c.is_primary DESC, COALESCE(c.label_override, c.summary) COLLATE NOCASE",
     )
     .fetch_all(pool)
     .await?;
@@ -63,6 +66,8 @@ pub async fn list_calendars(pool: &SqlitePool) -> anyhow::Result<Vec<CalendarRow
             account_id: r.get("account_id"),
             account_email: r.get("account_email"),
             summary: r.get("summary"),
+            provider_summary: r.get("provider_summary"),
+            label_override: r.get("label_override"),
             color_hex: r.get("color_hex"),
             color_override: r.get("color_override"),
             selected: r.get::<i64, _>("selected") != 0,
@@ -134,6 +139,17 @@ pub async fn set_color_override(
         .bind(hex)
         .execute(pool)
         .await?;
+    Ok(())
+}
+
+/// Local display label; blank restores the provider's current name.
+pub async fn set_label_override(pool: &SqlitePool, id: i64, label: Option<&str>) -> anyhow::Result<()> {
+    let label = label.map(str::trim).filter(|s| !s.is_empty());
+    anyhow::ensure!(label.is_none_or(|s| s.chars().count() <= 200 && !s.chars().any(char::is_control)),
+        "calendar label must be at most 200 characters without control characters");
+    let result = sqlx::query("UPDATE calendars SET label_override = ?2 WHERE id = ?1")
+        .bind(id).bind(label).execute(pool).await?;
+    anyhow::ensure!(result.rows_affected() == 1, "calendar not found");
     Ok(())
 }
 
@@ -217,6 +233,29 @@ mod tests {
         let pool = connect_memory().await.unwrap();
         seed(&pool).await;
         pool
+    }
+
+    #[tokio::test]
+    async fn local_label_survives_provider_rename_and_resets() {
+        let pool = seeded().await;
+        let before = list_calendars(&pool).await.unwrap();
+        let id = before[0].id;
+        set_label_override(&pool, id, Some("  Jon Kinney  ")).await.unwrap();
+        sqlx::query("UPDATE calendars SET summary = 'Provider renamed' WHERE id = ?")
+            .bind(id).execute(&pool).await.unwrap();
+        let rows = list_calendars(&pool).await.unwrap();
+        let cal = rows.iter().find(|c| c.id == id).unwrap();
+        assert_eq!(cal.summary, "Jon Kinney");
+        assert_eq!(cal.provider_summary, "Provider renamed");
+        assert_eq!(cal.label_override.as_deref(), Some("Jon Kinney"));
+        assert_eq!(rows.iter().find(|c| c.id == before[1].id).unwrap().summary, before[1].summary);
+        assert!(set_label_override(&pool, id, Some(&"x".repeat(201))).await.is_err());
+        assert!(set_label_override(&pool, id, Some("bad\nlabel")).await.is_err());
+        set_label_override(&pool, id, Some("  ")).await.unwrap();
+        let rows = list_calendars(&pool).await.unwrap();
+        let cal = rows.iter().find(|c| c.id == id).unwrap();
+        assert_eq!(cal.summary, "Provider renamed");
+        assert_eq!(cal.label_override, None);
     }
 
     fn ev(cal: i64, gid: &str) -> StoredEvent {

--- a/crates/omacal-store/src/lib.rs
+++ b/crates/omacal-store/src/lib.rs
@@ -10,7 +10,7 @@ pub mod invites;
 pub mod reminders;
 pub mod tasks;
 pub use calendars::{
-    calendar_for_write, delete_account, list_calendars, set_color_override, set_selected,
+    calendar_for_write, delete_account, list_calendars, set_color_override, set_label_override, set_selected,
     set_sync_enabled, CalendarRow,
 };
 pub use changes::{

--- a/crates/omacal-store/src/tasks.rs
+++ b/crates/omacal-store/src/tasks.rs
@@ -140,7 +140,7 @@ pub async fn delete_tasks_not_in(
 /// completion, newest first.
 pub async fn tasks_for_ui(pool: &SqlitePool, done_since_ms: i64) -> anyhow::Result<Vec<TaskRow>> {
     let sql = format!(
-        "SELECT {COLS}, c.summary AS cal_summary,
+        "SELECT {COLS}, COALESCE(c.label_override, c.summary) AS cal_summary,
                 COALESCE(c.color_override, c.color_hex) AS cal_color,
                 c.access_role AS cal_role
          FROM tasks t

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,7 +47,7 @@ tracing-subscriber = "0.3.23"
 sqlx = { version = "0.8.6", features = ["runtime-tokio", "sqlite"] }
 # `net` + `io-util` joined for the CLI write socket (ipc.rs): a Unix
 # listener and buffered line reads, nothing more.
-tokio = { version = "1.53.1", features = ["rt-multi-thread", "macros", "time", "net", "io-util"] }
+tokio = { version = "1.53.1", features = ["rt-multi-thread", "macros", "time", "net", "io-util", "process"] }
 anyhow.workspace = true
 thiserror.workspace = true
 # The *file watcher* for live theme reload. Not `notify-rust`, which is the

--- a/src-tauri/src/calendars.rs
+++ b/src-tauri/src/calendars.rs
@@ -51,3 +51,16 @@ pub async fn set_calendar_sync(
         .await
         .map_err(|e| crate::errors::user_facing(&e))
 }
+
+#[tauri::command]
+pub async fn set_calendar_label(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+    id: i64,
+    label: Option<String>,
+) -> Result<(), String> {
+    omacal_store::set_label_override(&state.pool, id, label.as_deref())
+        .await.map_err(|e| crate::errors::user_facing(&e))?;
+    crate::settings::refresh_menu_surfaces(&app, &state).await;
+    Ok(())
+}

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -501,7 +501,7 @@ pub(crate) async fn detail_by_id(pool: &SqlitePool, id: i64) -> anyhow::Result<O
         return Ok(None);
     };
     let (cal_name, account_email, cal_gid): (String, String, String) = sqlx::query_as(
-        "SELECT c.summary, a.email, c.google_id FROM calendars c
+        "SELECT COALESCE(c.label_override, c.summary), a.email, c.google_id FROM calendars c
          JOIN accounts a ON a.id = c.account_id WHERE c.id = ?1",
     )
     .bind(ev.calendar_id)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1631,6 +1631,7 @@ pub fn run() {
             calendars::set_calendar_selected,
             calendars::set_calendar_sync,
             calendars::set_calendar_color,
+            calendars::set_calendar_label,
             search::search_events,
             events::known_guests,
             settings::get_settings,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -637,7 +637,7 @@ async fn upsert_calendar(
     )
     .bind(account_id)
     .bind(&c.id)
-    .bind(&c.summary)
+    .bind(c.display_name())
     .bind(&c.background_color)
     .bind(c.time_zone.as_deref().unwrap_or("UTC"))
     .bind(&c.access_role)
@@ -828,6 +828,12 @@ where
 
         let client = omacal_google::CalendarClient::new(api_base, &access_token);
 
+        // Names can change without reconnecting an account. Update only known
+        // calendars: this must not import or re-enable calendars during sync.
+        if let Err(e) = refresh_calendar_names(pool, *account_id, &client).await {
+            tracing::warn!(%e, "could not refresh calendar names; keeping cached names");
+        }
+
         let cals = match calendars_to_sync(pool, *account_id).await {
             Ok(c) => c,
             Err(e) => {
@@ -853,6 +859,30 @@ where
     }
 
     (total, failed, dead)
+}
+
+async fn refresh_calendar_names(
+    pool: &SqlitePool, account_id: i64, client: &omacal_google::CalendarClient,
+) -> anyhow::Result<()> {
+    let calendars = client.list_calendars().await?;
+    let mut names = Vec::new();
+    for c in calendars {
+        let mut name = c.display_name().to_string();
+        if name == c.id && c.primary && c.summary_override.as_deref().is_none_or(|s| s.trim().is_empty()) {
+            if let Ok(title) = client.calendar_title(&c.id).await {
+                if !title.trim().is_empty() { name = title; }
+            }
+        }
+        names.push((c.id, name));
+    }
+    let mut tx = pool.begin().await?;
+    for (id, name) in names {
+        sqlx::query("UPDATE calendars SET summary = ?3 WHERE account_id = ?1 AND google_id = ?2")
+            .bind(account_id).bind(id).bind(name)
+            .execute(&mut *tx).await?;
+    }
+    tx.commit().await?;
+    Ok(())
 }
 
 /// The accounts a sync should even attempt: everyone not marked as needing
@@ -2187,10 +2217,65 @@ mod tests {
         assert!(!shown.contains("someone@example.com"), "{shown}");
     }
 
+    #[tokio::test]
+    async fn calendar_display_labels_survive_sign_in_and_refresh_during_sync() {
+        let pool = omacal_store::connect_memory().await.unwrap();
+        let account = seed_account(&pool, "sub-label", "owner@x").await;
+        let other = seed_account(&pool, "sub-other", "other@x").await;
+        let mut cal: omacal_google::model::Calendar = serde_json::from_value(
+            serde_json::json!({"id":"owner@x", "summary":"owner@x", "summaryOverride":"Work"})
+        ).unwrap();
+        upsert_calendar(&pool, account, &cal).await.unwrap();
+        assert_eq!(omacal_store::list_calendars(&pool).await.unwrap()[0].summary, "Work");
+        cal.summary_override = None;
+        upsert_calendar(&pool, other, &cal).await.unwrap();
+        sqlx::query("UPDATE calendars SET selected = 0, sync_enabled = 0 WHERE account_id = ?1")
+            .bind(account).execute(&pool).await.unwrap();
+        let server = MockServer::start().await;
+        Mock::given(method("GET")).and(path("/users/me/calendarList"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"items":[
+                {"id":"owner@x", "summary":"owner@x", "summaryOverride":"Studio"},
+                {"id":"unknown", "summary":"Do not import"}
+            ]}))).mount(&server).await;
+        sync_accounts(&pool, &[(account, "owner@x".into())], &server.uri(), 0, 1,
+            |_| async { Ok("test-token".into()) }).await;
+        let cals = omacal_store::list_calendars(&pool).await.unwrap();
+        assert_eq!(cals.len(), 2);
+        let updated = cals.iter().find(|c| c.account_id == account).unwrap();
+        assert_eq!(updated.summary, "Studio");
+        assert!(!updated.selected && !updated.sync_enabled);
+        assert_eq!(cals.iter().find(|c| c.account_id == other).unwrap().summary, "owner@x");
+        for blank in [None, Some("".into()), Some("  ".into())] {
+            cal.summary_override = blank;
+            upsert_calendar(&pool, account, &cal).await.unwrap();
+            assert_eq!(omacal_store::list_calendars(&pool).await.unwrap().iter()
+                .find(|c| c.account_id == account).unwrap().summary, "owner@x");
+        }
+    }
+
+    #[tokio::test]
+    async fn primary_calendar_email_uses_the_calendar_resource_title() {
+        let pool = omacal_store::connect_memory().await.unwrap();
+        let account = seed_account(&pool, "title-sub", "owner@x").await;
+        let cal = google_calendar("owner@x");
+        upsert_calendar(&pool, account, &cal).await.unwrap();
+        let server = MockServer::start().await;
+        Mock::given(method("GET")).and(path("/users/me/calendarList"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"items":[
+                {"id":"owner@x", "summary":"owner@x", "primary":true}
+            ]}))).mount(&server).await;
+        Mock::given(method("GET")).and(path("/calendars/owner%40x"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"summary":"Jon Kinney"})))
+            .expect(1).mount(&server).await;
+        refresh_calendar_names(&pool, account, &omacal_google::CalendarClient::new(server.uri(), "test")).await.unwrap();
+        assert_eq!(omacal_store::list_calendars(&pool).await.unwrap()[0].summary, "Jon Kinney");
+    }
+
     fn google_calendar(id: &str) -> omacal_google::model::Calendar {
         omacal_google::model::Calendar {
             id: id.to_string(),
             summary: "Work".into(),
+            summary_override: None,
             background_color: Some("#5b8def".into()),
             time_zone: Some("Europe/Sofia".into()),
             access_role: "owner".into(),

--- a/src-tauri/src/restart.rs
+++ b/src-tauri/src/restart.rs
@@ -220,8 +220,7 @@ pub(crate) fn stop_webkit_helpers() {
     // below is for).
     let deadline = std::time::Instant::now() + std::time::Duration::from_millis(1500);
     loop {
-        reap(&first);
-        if first.iter().all(|&pid| !alive(pid)) || std::time::Instant::now() >= deadline {
+        if reap(&first) || std::time::Instant::now() >= deadline {
             break;
         }
         std::thread::sleep(std::time::Duration::from_millis(20));
@@ -234,10 +233,15 @@ pub(crate) fn stop_webkit_helpers() {
             libc::kill(pid as libc::pid_t, libc::SIGKILL);
         }
     }
+    // The live-process sweep excludes zombies. Keep the original children
+    // in the reap set too: one may have exited as the first deadline elapsed.
+    let mut pending = first.clone();
+    pending.extend(left.iter().copied());
+    pending.sort_unstable();
+    pending.dedup();
     let deadline = std::time::Instant::now() + std::time::Duration::from_millis(300);
     loop {
-        reap(&left);
-        if left.iter().all(|&pid| !alive(pid)) || std::time::Instant::now() >= deadline {
+        if reap(&pending) || std::time::Instant::now() >= deadline {
             break;
         }
         std::thread::sleep(std::time::Duration::from_millis(10));
@@ -245,23 +249,21 @@ pub(crate) fn stop_webkit_helpers() {
     tracing::info!(stopped = first.len(), killed = left.len(), "webkit helpers stopped before the restart");
 }
 
-/// Whether `pid` is still a running process: present in `/proc` and not a
-/// zombie. A reaped process has no entry at all.
-fn alive(pid: u32) -> bool {
-    std::fs::read_to_string(format!("/proc/{pid}/stat"))
-        .ok()
-        .and_then(|stat| parse_stat(&stat))
-        .is_some_and(|(_, _, state, _)| state != 'Z' && state != 'X')
-}
-
-/// Collects whichever of `pids` have exited, without blocking on the rest.
-fn reap(pids: &[u32]) {
+/// Collects exited children and reports whether every child has been reaped.
+/// A child can exit just after WNOHANG returns zero. Checking its liveness
+/// separately would then see a zombie and stop waiting before collecting it.
+fn reap(pids: &[u32]) -> bool {
+    let mut done = true;
     for &pid in pids {
         let mut status = 0;
-        unsafe {
-            libc::waitpid(pid as libc::pid_t, &mut status, libc::WNOHANG);
-        }
+        let result = unsafe {
+            libc::waitpid(pid as libc::pid_t, &mut status, libc::WNOHANG)
+        };
+        // Another owner (e.g. WebKit) may already have collected this child.
+        done &= result == pid as libc::pid_t
+            || (result == -1 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ECHILD));
     }
+    done
 }
 
 #[cfg(test)]

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1258,6 +1258,27 @@ pub async fn set_show_date(
     Ok(read_settings(&state.pool).await)
 }
 
+pub(crate) async fn refresh_menu_surfaces(app: &tauri::AppHandle, state: &AppState) {
+    use tauri::Emitter;
+    crate::upcoming::refresh(&state.pool, state.demo).await;
+    crate::tray::refresh(app);
+    let _ = app.emit("menubar-changed", ());
+    #[cfg(target_os = "linux")]
+    if !state.demo && std::path::Path::new("/usr/share/omarchy/shell/shell.qml").is_file() {
+        // Fixed IPC arguments, no output retained, and no orphaned process
+        // if the shell is unavailable. The widget keeps its polling fallback.
+        if let Ok(mut child) = tokio::process::Command::new("/usr/bin/qs")
+            .args(["ipc", "-n", "-p", "/usr/share/omarchy/shell", "call", "--", "omacal.upcoming", "refresh"])
+            .stdin(std::process::Stdio::null()).stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null()).kill_on_drop(true).spawn() {
+            if tokio::time::timeout(std::time::Duration::from_secs(2), child.wait()).await.is_err() {
+                let _ = child.kill().await;
+            }
+        }
+    }
+}
+
+
 /// Stores the hour height, clamped rather than refused: the value comes off
 /// a gesture, and the honest answer to "a little past the end" is the end,
 /// not an error surfacing under somebody's fingers mid-pinch.

--- a/src-tauri/src/tasks.rs
+++ b/src-tauri/src/tasks.rs
@@ -396,11 +396,11 @@ pub(crate) async fn writable_task_lists(
     pool: &sqlx::SqlitePool,
 ) -> anyhow::Result<Vec<TaskListVm>> {
     let rows: Vec<(i64, String, Option<String>)> = sqlx::query_as(
-        "SELECT c.id, c.summary, COALESCE(c.color_override, c.color_hex)
+        "SELECT c.id, COALESCE(c.label_override, c.summary), COALESCE(c.color_override, c.color_hex)
          FROM calendars c JOIN accounts a ON a.id = c.account_id
          WHERE a.provider = 'caldav' AND c.supports_tasks = 1
            AND c.selected = 1 AND c.access_role != 'reader'
-         ORDER BY c.summary COLLATE NOCASE",
+         ORDER BY COALESCE(c.label_override, c.summary) COLLATE NOCASE",
     )
     .fetch_all(pool)
     .await?;

--- a/ui/src/lib/CalendarList.svelte
+++ b/ui/src/lib/CalendarList.svelte
@@ -2,7 +2,7 @@
 <script lang="ts">
   import { tick } from 'svelte';
   import {
-    byAccount, setCalendarColor, setCalendarSelected, setCalendarSync, type Calendar,
+    byAccount, setCalendarLabel, setCalendarColor, setCalendarSelected, setCalendarSync, type Calendar,
   } from './calendars';
   import { CALENDAR_COLOURS } from './theme';
 
@@ -28,6 +28,22 @@
    *  ambiguous about which one just settled; naming the calendar makes it
    *  unambiguous even when read mid-race. */
   let message = $state<{ text: string; kind: 'info' | 'error' } | null>(null);
+
+  let editingLabel = $state<number | null>(null);
+  let labelDraft = $state('');
+  async function saveLabel(c: Calendar, reset = false) {
+    markBusy(c.id, true);
+    message = null;
+    try {
+      await setCalendarLabel(c.id, reset ? null : labelDraft.trim() || null);
+      editingLabel = null;
+      onchange();
+    } catch (err) {
+      message = { text: `${c.summary} · ${String(err)}`, kind: 'error' };
+    } finally {
+      markBusy(c.id, false);
+    }
+  }
 
   const groups = $derived(byAccount(calendars));
 
@@ -158,6 +174,8 @@
           <span class="dot" aria-hidden="true" style="background:{c.color_hex ?? 'var(--accent)'}"></span>
           <span class="name" title={c.summary}>{c.summary}</span>
         </label>
+        <button class="label-button" type="button" disabled={busy.has(c.id)} aria-label="Label for {c.summary}"
+          onclick={() => { editingLabel = c.id; labelDraft = c.label_override ?? c.summary; }}>Label…</button>
         <!-- The colour control. On the row, so it appears in both hosts — the
              header's popover and the settings tab — from one place. -->
         <button
@@ -177,6 +195,18 @@
           onclick={(e) => toggleSync(c, e)}
         >{c.sync_enabled ? 'Remove' : 'Add'}</button>
       </div>
+      {#if editingLabel === c.id}
+        <form class="label-editor" onsubmit={(e) => { e.preventDefault(); saveLabel(c); }}>
+          <label for="calendar-label-{c.id}">Calendar label</label>
+          <input id="calendar-label-{c.id}" bind:value={labelDraft} maxlength="200" disabled={busy.has(c.id)} />
+          <div>
+            <button type="submit" disabled={busy.has(c.id)}>Save label</button>
+            <button type="button" disabled={busy.has(c.id) || !c.label_override} onclick={() => saveLabel(c, true)}>Use provider name</button>
+            <button type="button" onclick={() => (editingLabel = null)}>Cancel</button>
+          </div>
+          <p class="hint">Only in OmaCal. Provider name: {c.provider_summary ?? c.summary}</p>
+        </form>
+      {/if}
       {#if picking === c.id}
         <!-- A curated set, from `theme.ts` — no free picker. omacal draws on
              both a light and a dark Omarchy theme, and a colour chosen against
@@ -215,6 +245,14 @@
 </div>
 
 <style>
+  .label-editor { display: grid; gap: 8px; margin: 8px 0 16px; }
+  .label-button, .label-editor button { font: inherit; font-size: 11px; color: var(--muted); cursor: pointer;
+    background: color-mix(in srgb, var(--text) 6%, transparent); border: 0; border-radius: 5px; padding: 4px 8px; }
+  .label-button:disabled, .label-editor button:disabled { opacity: .5; cursor: default; }
+  .label-editor input { font: inherit; font-size: 13px; color: var(--text);
+    background-color: color-mix(in srgb, var(--text) 5%, transparent);
+    border: 1px solid var(--hairline); border-radius: 5px; padding: 4px 6px; width: 100%; box-sizing: border-box; }
+  .label-editor div { display: flex; gap: 8px; flex-wrap: wrap; }
   /* No box of its own — no background, no border, no padding. Each host frames
      it: the popover puts it in a floating panel, the settings tab in a column
      that is already inside one. A component that carried its own surface would

--- a/ui/src/lib/calendars.ts
+++ b/ui/src/lib/calendars.ts
@@ -5,6 +5,8 @@ export type Calendar = {
   account_id: number;
   account_email: string;
   summary: string;
+  provider_summary?: string;
+  label_override?: string | null;
   /** **The colour to draw this calendar in** — its override if it has one, and
    *  Google's own otherwise, resolved in SQL. Anything that only wants to draw
    *  reads this and needs to know nothing about overrides. */
@@ -98,3 +100,6 @@ export function byAccount(cals: Calendar[]): Array<[string, Calendar[]]> {
   }
   return [...groups.entries()];
 }
+
+export const setCalendarLabel = (id: number, label: string | null): Promise<void> =>
+  invoke<void>('set_calendar_label', { id, label });

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -2041,6 +2041,17 @@ test.describe('CalendarPopover', () => {
     await expect(page.getByRole('button', { name: 'Amber' })).toBeVisible();
   });
 
+  test('a calendar label saves locally', async ({ page }) => {
+    await page.goto(show('colours'));
+    await page.getByRole('button', { name: /Calendars/ }).click();
+    await page.getByRole('button', { name: 'Label for Work', exact: true }).click();
+    await page.getByLabel('Calendar label', { exact: true }).fill('Jon Kinney');
+    await page.getByRole('button', { name: 'Save label', exact: true }).click();
+    await expect(page.getByLabel('Calendar label', { exact: true })).toHaveCount(0);
+    const calls = await page.evaluate(() => window.__harness.calls.filter(c => c.cmd === 'set_calendar_label'));
+    expect(calls.map(c => c.args)).toEqual([{ id: 1, label: 'Jon Kinney' }]);
+  });
+
   test('choosing a colour asks for it, locally', async ({ page }) => {
     await page.goto(show('colours'));
     await openColours(page, 'Work');

--- a/ui/tests/harness/tauri.ts
+++ b/ui/tests/harness/tauri.ts
@@ -978,6 +978,8 @@ export function installTauriStub(scenario: string): Harness {
         settings = saveSettings({ ...settings, fallbackReminderMinutes: minutes });
         return { ...settings };
       }
+      case 'set_calendar_label':
+        return calendarResult(cmd, undefined);
       case 'set_calendar_color':
         return calendarResult(cmd, undefined);
       case 'set_calendar_selected':


### PR DESCRIPTION
Use Google's calendar display name and refresh existing names during sync. Also let each calendar have a local label, with a reset to the provider's name. The resolved name is used wherever OmaCal displays that calendar; changing the label doesn't rename it at Google or CalDAV.

Validated with workspace Rust tests, Clippy, UI type checks, and calendar component tests in Chromium and WebKit.

CI also exposed a race in the existing Linux restart cleanup. A separate fix commit waits for helper processes to be reaped; the workspace suite, Clippy, and 100 repeated cleanup tests pass locally.

<img src="https://raw.githubusercontent.com/jondkinney/omacal/1ffe3e426e98bd0c5ce9e726b862655284b67150/screenshots/labels.png" alt="Calendar label editor; synthetic calendar data" width="480">

