### PR TITLE
feat(settings): add a shared date format preference

### DIFF
--- a/src-tauri/src/invites.rs
+++ b/src-tauri/src/invites.rs
@@ -35,9 +35,10 @@ const MONTHS: [&str; 12] =
 /// and says only the hour, but an invitation may be for weeks away, so the
 /// day is the headline. Unknown zones fall back to UTC, the same policy as
 /// `notify::time_in_zone_with_format`.
-fn date_in_words(ms: i64, tz: &str) -> String {
+fn date_in_words(ms: i64, tz: &str, format: crate::settings::DateFormat) -> String {
     let ts = jiff::Timestamp::from_millisecond(ms).unwrap_or(jiff::Timestamp::UNIX_EPOCH);
     let z = ts.in_tz(tz).unwrap_or_else(|_| ts.in_tz("UTC").expect("UTC always resolves"));
+    if format != crate::settings::DateFormat::Locale { return format.display(z.date()); }
     let weekday = WEEKDAYS[z.weekday().to_monday_zero_offset() as usize];
     let month = MONTHS[z.month() as usize - 1];
     format!("{weekday}, {month} {}", z.day())
@@ -65,13 +66,14 @@ pub(crate) fn invite_notification_with_format(
     c: &InviteCandidate,
     display_tz: &str,
     time_format: crate::settings::TimeFormat,
+    date_format: crate::settings::DateFormat,
 ) -> Notification {
     let when = if c.is_all_day {
-        format!("{} · All day", date_in_words(c.start_utc, &c.calendar_timezone))
+        format!("{} · All day", date_in_words(c.start_utc, &c.calendar_timezone, date_format))
     } else {
         format!(
             "{} · {}",
-            date_in_words(c.start_utc, display_tz),
+            date_in_words(c.start_utc, display_tz, date_format),
             crate::notify::time_in_zone_with_format(c.start_utc, display_tz, time_format)
         )
     };
@@ -119,7 +121,7 @@ pub(crate) fn invite_notification_with_format(
 /// the stored preference.
 #[cfg(test)]
 pub(crate) fn invite_notification(c: &InviteCandidate, display_tz: &str) -> Notification {
-    invite_notification_with_format(c, display_tz, crate::settings::TimeFormat::H24)
+    invite_notification_with_format(c, display_tz, crate::settings::TimeFormat::H24, crate::settings::DateFormat::Locale)
 }
 
 /// One pass over the ledger: seed what predates the watch, announce what is
@@ -170,6 +172,7 @@ pub(crate) async fn run_pass(
             &c,
             display_tz,
             settings.time_format,
+            settings.date_format,
         )) {
             tracing::warn!(%e, event_id = c.event_id, "could not announce an invitation");
         }
@@ -781,6 +784,7 @@ mod tests {
             &candidate(),
             SOFIA,
             crate::settings::TimeFormat::H12,
+            crate::settings::DateFormat::Locale,
         );
         assert!(n.body.starts_with("Mon, Aug 10 · 1:00 PM · from ana@x.com"), "{}", n.body);
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1632,6 +1632,7 @@ pub fn run() {
             settings::set_default_event_duration,
             settings::set_appearance_preferences,
             settings::set_time_format,
+            settings::set_date_format,
             settings::set_temperature_unit,
             settings::set_week_start,
             settings::set_week_starts_today,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -122,6 +122,25 @@ impl TimeFormat {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DateFormat { Locale, Mdy, Dmy, Iso, LongMdy, LongDmy }
+impl DateFormat {
+    fn as_str(self) -> &'static str { match self {
+        Self::Locale => "locale", Self::Mdy => "mdy", Self::Dmy => "dmy",
+        Self::Iso => "iso", Self::LongMdy => "long-mdy", Self::LongDmy => "long-dmy",
+    } }
+    pub fn display(self, date: jiff::civil::Date) -> String {
+        match self {
+            Self::Mdy => date.strftime("%m/%d/%Y").to_string(),
+            Self::Dmy => date.strftime("%d/%m/%Y").to_string(),
+            Self::Iso => date.to_string(),
+            Self::LongDmy => format!("{} {} {}", date.day(), date.strftime("%b"), date.year()),
+            _ => format!("{} {}, {}", date.strftime("%b"), date.day(), date.year()),
+        }
+    }
+}
+
 /// Whether a temperature is drawn as `22°` or `72°` — Celsius or Fahrenheit.
 ///
 /// [`TimeFormat`]'s reason, twice over: the set is closed, so [`set_temperature_unit`]
@@ -494,6 +513,7 @@ pub struct AppSettings {
     /// 24-hour ruler has to convert in their head at exactly the moment the
     /// ruler exists to save them from it.
     pub time_format: TimeFormat,
+    pub date_format: DateFormat,
     /// The day a week begins on, honoured by the Week grid's own anchor, the
     /// month grid's leading blanks, the Year view's twelve small grids, and
     /// Big Year's 392-day ribbon. When `week_starts_today` is on, this still
@@ -670,6 +690,7 @@ pub(crate) async fn read_settings_with(pool: &SqlitePool, baseline: u8) -> AppSe
         // takes and for the same reason: absent, garbage, and a value written
         // by some future version all land on the format the app has always
         // drawn, rather than on the one nobody asked for.
+        date_format: read(pool, "date_format").await.and_then(|v| serde_json::from_value(serde_json::Value::String(v)).ok()).unwrap_or(DateFormat::Locale),
         time_format: read(pool, TIME_FORMAT_KEY)
             .await
             .map(|v| if v == "12h" { TimeFormat::H12 } else { TimeFormat::H24 })
@@ -1273,6 +1294,14 @@ pub async fn set_hour_height(
     Ok(read_settings(&state.pool).await)
 }
 
+#[tauri::command]
+pub async fn set_date_format(app: tauri::AppHandle, state: tauri::State<'_, AppState>, format: DateFormat) -> Result<AppSettings, String> {
+    write(&state.pool, "date_format", format.as_str()).await.map_err(|e| crate::errors::user_facing(&e))?;
+    crate::upcoming::refresh(&state.pool, state.demo).await;
+    crate::tray::refresh(&app);
+    Ok(read_settings(&state.pool).await)
+}
+
 /// Stores the clock format. Like [`set_list_mode`] nothing is refused, and
 /// here the *type* is the reason rather than the triviality of a boolean:
 /// [`TimeFormat`] has no third variant for a caller to send.
@@ -1839,6 +1868,20 @@ mod tests {
 
         write(&p, TIME_FORMAT_KEY, TimeFormat::H24.as_str()).await.unwrap();
         assert_eq!(read_settings(&p).await.time_format, TimeFormat::H24);
+    }
+
+    #[tokio::test]
+    async fn date_formats_round_trip_and_render_unambiguous_dates() {
+        let p = pool().await;
+        let date: jiff::civil::Date = "2026-09-07".parse().unwrap();
+        for (format, expected) in [(DateFormat::Mdy, "09/07/2026"), (DateFormat::Dmy, "07/09/2026"),
+            (DateFormat::Iso, "2026-09-07"), (DateFormat::LongMdy, "Sep 7, 2026"), (DateFormat::LongDmy, "7 Sep 2026")] {
+            write(&p, "date_format", format.as_str()).await.unwrap();
+            assert_eq!(read_settings(&p).await.date_format, format);
+            assert_eq!(format.display(date), expected);
+        }
+        write(&p, "date_format", "garbage").await.unwrap();
+        assert_eq!(read_settings(&p).await.date_format, DateFormat::Locale);
     }
 
     /// All three round-trip, and an unrecognised row reads as Monday — the

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -1,5 +1,8 @@
 <!-- ui/src/App.svelte -->
 <script lang="ts">
+  import { formatDate } from './lib/datefmt';
+  import { dateFormat } from './lib/date.svelte';
+  import { setDateFormat } from './lib/date.svelte';
   import { listen } from '@tauri-apps/api/event';
   import { tick, untrack } from 'svelte';
   import { applyPalette, setPalette, type Palette } from './lib/theme';
@@ -454,7 +457,7 @@
 
   const keyboardStatus = $derived.by(() => {
     if (!keyboardActive || !listable(view) || keyboardDays.length === 0) return '';
-    const day = new Date(keyboardCursor.dayStartMs).toLocaleDateString(undefined, {
+    const day = formatDate(new Date(keyboardCursor.dayStartMs).getTime(), dateFormat(), {
       weekday: 'long', month: 'long', day: 'numeric',
     });
     const event = eventAtCursor(keyboardDays, keyboardCursor);
@@ -707,6 +710,7 @@
         defaultCalendarId = s.defaultCalendarId;
         defaultEventDurationMinutes = s.defaultEventDurationMinutes;
         setClockFormat(s.timeFormat);
+      setDateFormat(s.dateFormat);
         setSecondZone(s.secondTimezone);
         setTemperatureUnit(s.temperatureUnit);
         if (appearanceChoices === appearanceBefore) applyAppearance(s);
@@ -1885,6 +1889,7 @@
       defaultCalendarId = s.defaultCalendarId;
       defaultEventDurationMinutes = s.defaultEventDurationMinutes;
       setClockFormat(s.timeFormat);
+      setDateFormat(s.dateFormat);
       setSecondZone(s.secondTimezone);
       setTemperatureUnit(s.temperatureUnit);
       weekViewChoices += 1;

--- a/ui/src/lib/EventForm.svelte
+++ b/ui/src/lib/EventForm.svelte
@@ -1,5 +1,6 @@
 <!-- ui/src/lib/EventForm.svelte -->
 <script lang="ts">
+  import { dateFormat } from './date.svelte';
   import { onMount } from 'svelte';
   import { clockFormat } from './clock.svelte';
   import { secondZone } from './secondzone.svelte';
@@ -295,7 +296,7 @@
    *  on offer (greyed) so they can see what they are replacing, and picking it
    *  back is impossible — which is the point. */
   const isCustom = $derived(initial.repeat === CUSTOM_REPEAT);
-  const customWords = $derived(ruleInWords(initial.recurrence));
+  const customWords = $derived(ruleInWords(initial.recurrence, dateFormat()));
   /** How many people Save could mail — see `mailableGuests`. Derived from the
    *  working copy as well as `initial`, unlike everything else in this block:
    *  the answer changes as the user edits the list, which is the whole point.

--- a/ui/src/lib/EventPopover.svelte
+++ b/ui/src/lib/EventPopover.svelte
@@ -1,5 +1,7 @@
 <!-- ui/src/lib/EventPopover.svelte -->
 <script lang="ts">
+  import { formatDate } from './datefmt';
+  import { dateFormat } from './date.svelte';
   import { meetingUrl } from './location';
   import { openConference } from './api';
   import { clockFormat } from './clock.svelte';
@@ -89,7 +91,7 @@
   /** The day an **instant** falls on, read in the browser's zone — right for a
    *  timed event, whose start genuinely is an instant and whose reader is
    *  whoever is looking at the screen. */
-  const dayOfInstant = (ms: number) => new Date(ms).toLocaleDateString([], DAY_FORMAT);
+  const dayOfInstant = (ms: number) => formatDate(new Date(ms).getTime(), dateFormat(), DAY_FORMAT);
 
   /** The day a `yyyy-mm-dd` names, read in **no** zone.
    *
@@ -105,7 +107,7 @@
    *  for a trip the form beside it opened on `2026-08-10`. */
   const dayOfDate = (date: string) => {
     const [y, m, d] = date.split('-').map(Number);
-    return new Date(Date.UTC(y, m - 1, d)).toLocaleDateString([], { ...DAY_FORMAT, timeZone: 'UTC' });
+    return formatDate(new Date(Date.UTC(y, m - 1, d)).getTime(), dateFormat(), { ...DAY_FORMAT, timeZone: 'UTC' });
   };
 
   /**

--- a/ui/src/lib/Filmstrip.svelte
+++ b/ui/src/lib/Filmstrip.svelte
@@ -1,5 +1,7 @@
 <!-- ui/src/lib/Filmstrip.svelte -->
 <script lang="ts">
+  import { formatDate } from './datefmt';
+  import { dateFormat } from './date.svelte';
   import { clockFormat } from './clock.svelte';
   import { formatClock } from './timefmt';
   import { openConference, type UiEvent } from './api';
@@ -45,7 +47,7 @@
    *  the day the same way. No year: a list is one period long, and a year
    *  repeated down forty rows is noise. */
   const dateLabel = (ms: number) =>
-    new Date(ms).toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
+    formatDate(new Date(ms).getTime(), dateFormat(), { weekday: 'short', month: 'short', day: 'numeric' });
 
   /** `getBoundingClientRect()` for the reason `EventBlock` and `AllDayBand` both
    *  use it: the popover places itself against the viewport, and a row's own

--- a/ui/src/lib/InviteTray.svelte
+++ b/ui/src/lib/InviteTray.svelte
@@ -1,5 +1,7 @@
 <!-- ui/src/lib/InviteTray.svelte -->
 <script lang="ts">
+  import { formatDate } from './datefmt';
+  import { dateFormat } from './date.svelte';
   import { respondToEvent } from './eventdetail';
   import { clockFormat } from './clock.svelte';
   import { formatClock } from './timefmt';
@@ -41,14 +43,14 @@
   const hhmm = (ms: number) => formatClock(ms, clockFormat());
 
   const day = (ms: number) =>
-    new Date(ms).toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
+    formatDate(new Date(ms).getTime(), dateFormat(), { weekday: 'short', month: 'short', day: 'numeric' });
 
   /** `yyyy-mm-dd` (a calendar-zone day) rendered as "Mon, Aug 17". Built
    *  from parts, never from `Date.parse` — a bare ISO date parses as UTC
    *  midnight and shifts a day for any browser east of Greenwich. */
   function dateWords(d: string): string {
     const [y, m, dd] = d.split('-').map(Number);
-    return new Date(y, m - 1, dd).toLocaleDateString(undefined, {
+    return formatDate(new Date(y, m - 1, dd).getTime(), dateFormat(), {
       weekday: 'short', month: 'short', day: 'numeric',
     });
   }

--- a/ui/src/lib/QuickEventModal.svelte
+++ b/ui/src/lib/QuickEventModal.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { dateFormat } from './date.svelte';
+  import { clockFormat } from './clock.svelte';
   import { onMount } from 'svelte';
   import type { Calendar } from './calendars';
   import { escapeCloses } from './dismiss.svelte';
@@ -33,7 +35,7 @@
   const parsed = $derived(parseQuickEvent(line, {
     nowMs, anchorDayMs, calendarId, defaultDurationMinutes, calendars,
   }));
-  const rows = $derived(quickPreviewRows(parsed, calendars));
+  const rows = $derived(quickPreviewRows(parsed, calendars, dateFormat(), clockFormat()));
   const guests = $derived(parsed.value.guests.length);
 
   onMount(() => fieldEl?.focus());

--- a/ui/src/lib/SearchOverlay.svelte
+++ b/ui/src/lib/SearchOverlay.svelte
@@ -1,5 +1,7 @@
 <!-- ui/src/lib/SearchOverlay.svelte -->
 <script lang="ts">
+  import { formatDate } from './datefmt';
+  import { dateFormat } from './date.svelte';
   import { onMount } from 'svelte';
   import { escapeCloses } from './dismiss.svelte';
   import { searchEvents, type Hit } from './search';
@@ -69,7 +71,7 @@
 
   /** The day a result sits on, for the line under its title. */
   const when = (ms: number) =>
-    new Date(ms).toLocaleDateString(undefined, {
+    formatDate(new Date(ms).getTime(), dateFormat(), {
       weekday: 'short', day: 'numeric', month: 'short', year: 'numeric',
     });
 </script>

--- a/ui/src/lib/SettingsModal.svelte
+++ b/ui/src/lib/SettingsModal.svelte
@@ -1,5 +1,7 @@
 <!-- ui/src/lib/SettingsModal.svelte -->
 <script lang="ts">
+  import { DATE_FORMATS, type DateFormat } from './datefmt';
+  import { setDateFormatPreference } from './settings';
   import { onMount } from 'svelte';
   import { invoke } from '@tauri-apps/api/core';
 
@@ -265,6 +267,11 @@
     } catch (e) {
       note = { text: String(e), kind: 'error' };
     }
+  }
+
+  async function saveDateFormat(format: DateFormat) {
+    try { settings = await setDateFormatPreference(format); onsettingschange?.(settings); }
+    catch (e) { note = { text: String(e), kind: 'error' }; }
   }
 
   async function saveTimeFormat(format: TimeFormat) {
@@ -807,6 +814,14 @@
         Used when a new event has a start time but no end time selected yet.
         Dragging a range still uses the range you chose.
       </p>
+
+      <div class="row">
+        <label class="lab" for="date-format">Show dates as</label>
+        <div class="inline"><select id="date-format" disabled={!settings} value={settings?.dateFormat ?? 'locale'} onchange={(e) => saveDateFormat(e.currentTarget.value as DateFormat)}>
+          {#each DATE_FORMATS as f}<option value={f.value}>{f.label}</option>{/each}
+        </select></div>
+      </div>
+      <p class="hint">Used for displayed dates throughout OmaCal. Native date pickers follow your system’s format.</p>
 
       <div class="row">
         <label class="lab" for="time-format">Show times as</label>

--- a/ui/src/lib/TasksSidebar.svelte
+++ b/ui/src/lib/TasksSidebar.svelte
@@ -1,5 +1,6 @@
 <!-- ui/src/lib/TasksSidebar.svelte -->
 <script lang="ts">
+  import { dateFormat } from './date.svelte';
   import { clockFormat } from './clock.svelte';
   import {
     createTask, deleteTask, listTasks, setTaskCompleted, taskLists, updateTask,
@@ -272,7 +273,7 @@
               <button class="title" onclick={() => edit(t)} disabled={!t.canWrite}>{t.summary}</button>
               {#if t.dueMs !== null}
                 <span class="due" class:overdue={isOverdue(t, nowMs)}>
-                  {dueLabel(t, nowMs, clockFormat())}
+                  {dueLabel(t, nowMs, clockFormat(), dateFormat())}
                 </span>
               {/if}
               {#if t.canWrite}

--- a/ui/src/lib/WeatherPopover.svelte
+++ b/ui/src/lib/WeatherPopover.svelte
@@ -1,5 +1,7 @@
 <!-- ui/src/lib/WeatherPopover.svelte -->
 <script lang="ts">
+  import { formatDate } from './datefmt';
+  import { dateFormat } from './date.svelte';
   import { onMount } from 'svelte';
   import { escapeCloses } from './dismiss.svelte';
   import { placePopover, type Rect } from './position';
@@ -26,7 +28,7 @@
   const unit = $derived(temperatureUnit());
   const now = $derived(today ? (report.current ?? null) : null);
   const dayLabel = $derived(
-    new Date(`${day.date}T12:00:00`).toLocaleDateString(undefined, {
+    formatDate(new Date(`${day.date}T12:00:00`).getTime(), dateFormat(), {
       weekday: 'long', day: 'numeric', month: 'long',
     }),
   );

--- a/ui/src/lib/date.svelte.ts
+++ b/ui/src/lib/date.svelte.ts
@@ -1,0 +1,4 @@
+import type { DateFormat } from './datefmt';
+const state = $state<{ format: DateFormat }>({ format: 'locale' });
+export const dateFormat = () => state.format;
+export const setDateFormat = (format: DateFormat) => { state.format = format ?? 'locale'; };

--- a/ui/src/lib/datefmt.ts
+++ b/ui/src/lib/datefmt.ts
@@ -1,0 +1,22 @@
+export type DateFormat = 'locale' | 'mdy' | 'dmy' | 'iso' | 'long-mdy' | 'long-dmy';
+export const DATE_FORMATS: { value: DateFormat; label: string }[] = [
+  { value: 'locale', label: 'System default' },
+  { value: 'long-mdy', label: 'Sep 7, 2026' },
+  { value: 'long-dmy', label: '7 Sep 2026' },
+  { value: 'mdy', label: '09/07/2026' },
+  { value: 'dmy', label: '07/09/2026' },
+  { value: 'iso', label: '2026-09-07' },
+];
+
+// Date-only values must pass UTC explicitly; instants use the display zone.
+export function formatDate(ms: number, format: DateFormat = 'locale', options: Intl.DateTimeFormatOptions = {}): string {
+  if (format === 'locale') return new Intl.DateTimeFormat(undefined, Object.keys(options).length ? options : { year: 'numeric', month: 'short', day: 'numeric' }).format(ms);
+  const parts = new Intl.DateTimeFormat('en-US', { timeZone: options.timeZone, year: 'numeric', month: '2-digit', day: '2-digit' }).formatToParts(ms);
+  const part = (name: string) => parts.find(p => p.type === name)!.value;
+  const [y, m, d] = [part('year'), part('month'), part('day')];
+  if (format === 'iso') return `${y}-${m}-${d}`;
+  if (format === 'mdy') return `${m}/${d}/${y}`;
+  if (format === 'dmy') return `${d}/${m}/${y}`;
+  const month = new Intl.DateTimeFormat('en-US', { timeZone: options.timeZone, month: 'short' }).format(ms);
+  return format === 'long-dmy' ? `${Number(d)} ${month} ${y}` : `${month} ${Number(d)}, ${y}`;
+}

--- a/ui/src/lib/eventform.ts
+++ b/ui/src/lib/eventform.ts
@@ -1,3 +1,4 @@
+import { formatDate, type DateFormat } from './datefmt';
 // The event form's own value type, and the pure functions either side of it:
 // what a form value is made of, how one is built from an `EventDetail`, and
 // how one becomes the `EventInput` the Rust write commands take.
@@ -1510,7 +1511,7 @@ function dayInWords(token: string): string | null {
 
 /** `20261231` or `20261231T235959Z` → `Dec 31, 2026`. `null` when it is
  *  neither — an UNTIL this cannot read must not become a wrong date. */
-function untilInWords(value: string): string | null {
+function untilInWords(value: string, dateFormat: DateFormat): string | null {
   const m = /^(\d{4})(\d{2})(\d{2})(T\d{6}Z?)?$/.exec(value.trim());
   if (!m) return null;
   const [y, mo, d] = [Number(m[1]), Number(m[2]), Number(m[3])];
@@ -1523,7 +1524,7 @@ function untilInWords(value: string): string | null {
   if (at.getUTCFullYear() !== y || at.getUTCMonth() !== mo - 1 || at.getUTCDate() !== d) {
     return null;
   }
-  return at.toLocaleDateString(undefined, {
+  return formatDate(at.getTime(), dateFormat, {
     year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC',
   });
 }
@@ -1536,7 +1537,7 @@ const listInWords = (items: string[]): string =>
 /** The body of one RRULE (no `RRULE:` prefix) in English, or `null` the
  *  moment it meets a part it does not model, an unreadable value, or no
  *  `FREQ` at all — never a partial description. */
-function rruleBodyInWords(body: string): string | null {
+function rruleBodyInWords(body: string, dateFormat: DateFormat): string | null {
   const parts = new Map<string, string>();
   for (const part of body.split(';')) {
     if (part.trim() === '') continue;
@@ -1571,7 +1572,7 @@ function rruleBodyInWords(body: string): string | null {
 
   const until = parts.get('UNTIL');
   if (until !== undefined) {
-    const when = untilInWords(until);
+    const when = untilInWords(until, dateFormat);
     if (!when) return null;
     words += `, until ${when}`;
   }
@@ -1614,7 +1615,7 @@ function datesListed(line: string): { kind: 'EXDATE' | 'RDATE'; count: number } 
  * Exactly one `RRULE` line, every other line a countable `EXDATE`/`RDATE`,
  * or the whole blob shows verbatim.
  */
-export function ruleInWords(rule: string | null): string {
+export function ruleInWords(rule: string | null, dateFormat: DateFormat = 'locale'): string {
   if (!rule) return '';
   const raw = rule.trim();
   if (raw === '') return '';
@@ -1634,7 +1635,7 @@ export function ruleInWords(rule: string | null): string {
     const line = lines[0];
     if (line.length > MAX_RULE_LENGTH) return verbatim;
     const body = /^rrule:/i.test(line) ? line.slice('RRULE:'.length) : line;
-    return rruleBodyInWords(body) ?? verbatim;
+    return rruleBodyInWords(body, dateFormat) ?? verbatim;
   }
 
   // A multi-line blob: the rule, plus the deletions/additions that made it
@@ -1660,7 +1661,7 @@ export function ruleInWords(rule: string | null): string {
   // Dates with no rule to hang them on: nothing to describe them against.
   if (ruleBody === null) return verbatim;
 
-  let words = rruleBodyInWords(ruleBody);
+  let words = rruleBodyInWords(ruleBody, dateFormat);
   if (words === null) return verbatim;
   if (added > 0) words += `, plus ${added} added date${added === 1 ? '' : 's'}`;
   if (except > 0) words += `, except ${except} date${except === 1 ? '' : 's'}`;

--- a/ui/src/lib/quickevent.ts
+++ b/ui/src/lib/quickevent.ts
@@ -1,3 +1,5 @@
+import { formatDate, type DateFormat } from './datefmt';
+import { formatClock, type TimeFormat } from './timefmt';
 import type { Calendar } from './calendars';
 import {
   WEEKDAY_OPTIONS, blankValue, blankValueAt, dateOf, normalizedWeeklyDays,
@@ -832,16 +834,18 @@ export function parseQuickEvent(source: string, context: QuickEventContext): Qui
 export function quickPreviewRows(
   result: QuickEventResult,
   calendars: Calendar[],
+  dateFormat: DateFormat = 'locale',
+  timeFormat?: TimeFormat,
 ): Array<{ label: string; value: string }> {
   const v = result.value;
   const start = new Date(`${v.date}T${v.start}:00`);
   const end = new Date(`${v.endDate}T${v.end}:00`);
-  const date = start.toLocaleDateString(undefined, {
+  const date = formatDate(start.getTime(), dateFormat, {
     weekday: 'short', month: 'short', day: 'numeric', year: 'numeric',
   });
   const time = v.isAllDay
     ? 'All day'
-    : `${start.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}–${end.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}`;
+    : timeFormat ? `${formatClock(start.getTime(), timeFormat)}–${formatClock(end.getTime(), timeFormat)}` : `${start.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}–${end.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}`;
   const rows = [
     { label: 'Title', value: v.title || '(no title)' },
     { label: 'When', value: `${date} · ${time}` },
@@ -856,7 +860,7 @@ export function quickPreviewRows(
     rows.push({ label: 'Repeats', value: repeat });
     if (v.repeatEnd.kind === 'on') {
       const [year, month, day] = v.repeatEnd.date.split('-').map(Number);
-      const shown = new Date(Date.UTC(year, month - 1, day)).toLocaleDateString(undefined, {
+      const shown = formatDate(Date.UTC(year, month - 1, day), dateFormat, {
         month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC',
       });
       rows.push({ label: 'Ends', value: `On ${shown}` });

--- a/ui/src/lib/settings.ts
+++ b/ui/src/lib/settings.ts
@@ -1,3 +1,4 @@
+import type { DateFormat } from './datefmt';
 import { invoke } from '@tauri-apps/api/core';
 
 import type { TemperatureUnit } from './temperature';
@@ -108,6 +109,7 @@ export type AppSettings = {
    *  the `clock.svelte.ts` rune rather than as a prop — six components print a
    *  time and none of them owns the preference. */
   timeFormat: TimeFormat;
+  dateFormat: DateFormat;
   /** The day a week begins on. Read by the grids through the
    *  `weekstartstore.svelte.ts` rune, for the same reason `timeFormat` is. */
   weekStart: WeekStartDay;
@@ -312,3 +314,5 @@ export const setAppearancePreferences = (
  *  that is what `sync_loop` compares against a clock. */
 export const minutesOf = (ms: number): number => Math.round(ms / 60_000);
 export const msOfMinutes = (min: number): number => Math.round(min * 60_000);
+
+export const setDateFormatPreference = (format: DateFormat) => invoke<AppSettings>('set_date_format', { format });

--- a/ui/src/lib/taskdates.ts
+++ b/ui/src/lib/taskdates.ts
@@ -1,3 +1,4 @@
+import { formatDate, type DateFormat } from './datefmt';
 // When a task is due, in the words the sidebar uses — and which group it
 // falls in. Pure, and separate from the panel, for `eventform.ts`'s reason:
 // this is a table of inputs to outputs and wants testing as one. A spec that
@@ -60,7 +61,7 @@ export function whenOf(task: Task, nowMs: number): When {
  *  the reason every other time in the window does: the setting is the
  *  user's answer and a task reading 6:00 PM beside a grid reading 18:00
  *  would be the app disagreeing with itself. */
-export function dueLabel(task: Task, nowMs: number, format: TimeFormat = '24h'): string {
+export function dueLabel(task: Task, nowMs: number, format: TimeFormat = '24h', dateFormat: DateFormat = 'locale'): string {
   if (task.dueMs === null) return '';
   const away = daysAway(task.dueMs, nowMs);
   const time = task.dueAllDay ? '' : formatClock(task.dueMs, format);
@@ -71,7 +72,7 @@ export function dueLabel(task: Task, nowMs: number, format: TimeFormat = '24h'):
   // and a column of dates wants one order. The weekday name is still the
   // locale's.
   const due = new Date(task.dueMs);
-  const day = `${due.toLocaleDateString(undefined, { weekday: 'short' })} ${due.getDate()}`;
+  const day = dateFormat !== 'locale' ? formatDate(task.dueMs, dateFormat) : `${due.toLocaleDateString(undefined, { weekday: 'short' })} ${due.getDate()}`;
   return time ? `${day} ${time}` : day;
 }
 

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -1869,7 +1869,7 @@ test.describe('App', () => {
     await expect(quick.getByText('Weekly · Mon, Wed, Fri', { exact: true })).toBeVisible();
     // The app fixture freezes time on Monday 29 Jan; Monday belongs to MWF,
     // so the first occurrence is today rather than needlessly skipping ahead.
-    await expect(quick.getByText(/Mon, Jan 29, 2024.*9:00 AM/)).toBeVisible();
+    await expect(quick.getByText(/Mon, Jan 29, 2024.*09:00/)).toBeVisible();
 
     await quick.getByRole('button', { name: 'Continue editing' }).click();
     const form = newForm(page);
@@ -5101,4 +5101,19 @@ test.describe('tasks on the grid', () => {
     for (let i = 0; i < 5; i += 1) await page.keyboard.press('l');
     await expect(page.locator('.trow')).toHaveCount(0);
   });
+});
+
+test('date preference repaints event dates and survives a reload', async ({ page }) => {
+  await page.clock.setFixedTime(APP_NOW);
+  await page.goto(app());
+  await page.getByRole('button', { name: 'Menu' }).click();
+  await page.getByRole('button', { name: 'Settings…' }).click();
+  const modal = page.getByRole('dialog', { name: 'Settings' });
+  await modal.locator('#date-format').selectOption('dmy');
+  await page.keyboard.press('Escape');
+  await page.locator('.col .ev').first().click();
+  await expect(page.locator('.pop .when')).toContainText(/\d{2}\/\d{2}\/2024/);
+  await page.reload();
+  await page.locator('.col .ev').first().click();
+  await expect(page.locator('.pop .when')).toContainText(/\d{2}\/\d{2}\/2024/);
 });

--- a/ui/tests/datefmt.spec.ts
+++ b/ui/tests/datefmt.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+import { formatDate, type DateFormat } from '../src/lib/datefmt';
+test('date preferences preserve date-only values and respect display-zone boundaries', () => {
+  const ms = Date.UTC(2026, 8, 7);
+  for (const [format, expected] of Object.entries({ mdy: '09/07/2026', dmy: '07/09/2026', iso: '2026-09-07', 'long-mdy': 'Sep 7, 2026', 'long-dmy': '7 Sep 2026' })) {
+    expect(formatDate(ms, format as DateFormat, { timeZone: 'UTC' })).toBe(expected);
+  }
+  expect(formatDate(ms, 'iso', { timeZone: 'America/Chicago' })).toBe('2026-09-06');
+  expect(formatDate(Date.UTC(2028, 1, 29), 'dmy', { timeZone: 'UTC' })).toBe('29/02/2028');
+});
+

--- a/ui/tests/harness/tauri.ts
+++ b/ui/tests/harness/tauri.ts
@@ -575,6 +575,7 @@ type StubSettings = {
   eventCornerStyle: EventCornerStyle;
   transparentWindow: boolean;
   timeFormat: TimeFormat;
+  dateFormat: import('../../src/lib/datefmt').DateFormat;
   weekStart: WeekStartDay;
   weekStartsToday: boolean;
   weekViewDays: WeekViewDays;
@@ -623,6 +624,7 @@ const DEFAULT_SETTINGS: StubSettings = {
   // The clock the app has always drawn, so every existing spec and every
   // committed screenshot golden goes on describing the same pixels.
   timeFormat: '24h',
+  dateFormat: 'locale',
   // The week omacal has always drawn, so every golden holds.
   weekStart: 'monday',
   weekStartsToday: false,
@@ -943,6 +945,9 @@ export function installTauriStub(scenario: string): Harness {
       case 'set_week_view_days':
         settings = saveSettings({ ...settings, weekViewDays: args.days as WeekViewDays });
         return { ...settings };
+      case 'set_date_format':
+        settings = saveSettings({ ...settings, dateFormat: args.format as import('../../src/lib/datefmt').DateFormat });
+        return settings;
       case 'set_time_format':
         settings = saveSettings({ ...settings, timeFormat: args.format as TimeFormat });
         return { ...settings };


### PR DESCRIPTION
Add a date format preference and use it for displayed dates across the calendar, event details, search, tasks, and invitations. Native date pickers continue to follow the system format.

Validated with workspace Rust tests, Clippy, UI type checks, and date formatting/persistence tests in Chromium and WebKit.

<img src="https://raw.githubusercontent.com/jondkinney/omacal/1ffe3e426e98bd0c5ce9e726b862655284b67150/screenshots/dates.png" alt="Date format preference; synthetic calendar data" width="480">
