### PR TITLE
feat(settings): choose time zones with a searchable combobox

### DIFF
--- a/ui/src/lib/SettingsModal.svelte
+++ b/ui/src/lib/SettingsModal.svelte
@@ -9,6 +9,7 @@
   } from './appearance';
   import { REMINDER_UNITS, reminderAmountOf, reminderMax, reminderUnitOf } from './reminders';
   import CalendarList from './CalendarList.svelte';
+  import TimezoneSelect from './TimezoneSelect.svelte';
   import { calendarColor, offerableCalendarId, writableCalendars, type Calendar } from './calendars';
   import { connectCaldav } from './tasks';
   import { listAccounts, signOut, type Account } from './accounts';
@@ -170,7 +171,7 @@
       listTimezones().then((z) => (timezones = z)).catch(() => {});
     }
   });
-  /** The zone box's text — '' is "System default". Seeded from the stored
+  /** The zone dropdown's selection — '' is "System default". Seeded from the stored
    *  setting once it arrives; a change to a *valid* value enables Apply. */
   let tzChoice = $state('');
   let tzSeeded = false;
@@ -186,15 +187,6 @@
   const tzValid = $derived(tzChoice === '' || timezones.includes(tzChoice));
   const tzChanged = $derived(
     settings !== null && tzValid && tzChoice !== (settings.displayTimezone ?? ''));
-  /** Substring search over the whole zone id, because typing a capital —
-   *  "sofia" — must find "Europe/Sofia"; a native 600-option select only
-   *  jumps on leading letters (reported live, minutes after it shipped).
-   *  Empty once the text IS a zone, so a picked value has no list under it. */
-  const tzMatches = $derived.by(() => {
-    const q = tzChoice.trim().toLowerCase();
-    if (q === '' || timezones.includes(tzChoice)) return [];
-    return timezones.filter((z) => z.toLowerCase().includes(q)).slice(0, 8);
-  });
   /** Applying restarts omacal — this is the one settings write with a
    *  deliberate confirmation step (the button), and the note is the last
    *  thing painted before the window goes. */
@@ -209,7 +201,7 @@
     }
   }
 
-  /** The second-zone box — the display zone's combo pattern over the same
+  /** The second-zone dropdown — the display zone's selection pattern over the same
    *  fetched list; '' is "Off". Its Apply carries no restart: nothing
    *  process-level captures this zone, so the settings that come back are
    *  already in force, and `onsettingschange` starts the second clock
@@ -225,11 +217,6 @@
   const z2Valid = $derived(z2Choice === '' || timezones.includes(z2Choice));
   const z2Changed = $derived(
     settings !== null && z2Valid && z2Choice !== (settings.secondTimezone ?? ''));
-  const z2Matches = $derived.by(() => {
-    const q = z2Choice.trim().toLowerCase();
-    if (q === '' || timezones.includes(z2Choice)) return [];
-    return timezones.filter((z) => z.toLowerCase().includes(q)).slice(0, 8);
-  });
   async function applySecondZone() {
     try {
       settings = await setSecondTimezone(z2Choice === '' ? null : z2Choice);
@@ -837,13 +824,8 @@
       <div class="row">
         <label class="lab" for="display-tz">Time zone</label>
         <div class="inline">
-          <input
-            id="display-tz"
-            type="text"
-            placeholder="System default"
-            disabled={!settings || tzRestarting}
-            bind:value={tzChoice}
-          />
+          <TimezoneSelect id="display-tz" label="Time zone" zones={timezones} bind:value={tzChoice}
+            disabled={!settings || tzRestarting} emptyLabel="System default" />
           <button
             type="button"
             disabled={!tzChanged || tzRestarting}
@@ -853,14 +835,7 @@
             <span class="rownote" data-testid="tz-note">Restarting…</span>
           {/if}
         </div>
-        {#if tzMatches.length > 0}
-          <div class="tzlist" role="listbox" aria-label="Matching time zones">
-            {#each tzMatches as z (z)}
-              <button type="button" role="option" aria-selected="false"
-                      onclick={() => (tzChoice = z)}>{z}</button>
-            {/each}
-          </div>
-        {/if}
+
       </div>
       <p class="hint">
         Every time OmaCal shows reads in this zone — the grid, reminders, the
@@ -871,32 +846,20 @@
       <div class="row">
         <label class="lab" for="second-tz">Second time zone</label>
         <div class="inline">
-          <input
-            id="second-tz"
-            type="text"
-            placeholder="Off"
-            disabled={!settings}
-            bind:value={z2Choice}
-          />
+          <TimezoneSelect id="second-tz" label="Second time zone" zones={timezones} bind:value={z2Choice}
+            disabled={!settings} emptyLabel="Off" />
           <button
             type="button"
             disabled={!z2Changed}
             onclick={applySecondZone}
           >Apply</button>
         </div>
-        {#if z2Matches.length > 0}
-          <div class="tzlist" role="listbox" aria-label="Matching second time zones">
-            {#each z2Matches as z (z)}
-              <button type="button" role="option" aria-selected="false"
-                      onclick={() => (z2Choice = z)}>{z}</button>
-            {/each}
-          </div>
-        {/if}
+
       </div>
       <p class="hint">
         A second clock beside the first — on the Week and Day hour ruler, and
         under the event form's times. Convenience only: events are still
-        created and edited in the time zone above. Clear the box to turn it
+        created and edited in the time zone above. Choose Off to turn it
         off; no restart either way.
       </p>
 
@@ -1518,7 +1481,6 @@
   input[type='number'] { width: 72px; }
   /* Wide enough for "Australia/Lord_Howe"; scoped to the inline rows so the
      CalDAV form below keeps its own column width. */
-  .inline input[type='text'] { width: 220px; }
   input:focus, select:focus { outline: 1px solid var(--accent); outline-offset: -1px; }
 
   .caldot { width: 10px; height: 10px; border-radius: 3px; flex: none; }
@@ -1526,13 +1488,6 @@
   /* The zone search results: plain rows under the box, in the flow rather
      than floating — the modal scrolls, and a floating list inside a
      scrolling body clips. Eight rows at most (the derivation caps it). */
-  .tzlist { display: flex; flex-direction: column; gap: 1px; margin-top: 2px;
-            border: 1px solid var(--hairline); border-radius: 6px; padding: 3px;
-            max-width: 320px; }
-  .tzlist button { font: inherit; font-size: 12px; color: var(--text); cursor: pointer;
-                   background: none; border: 0; border-radius: 4px;
-                   padding: 4px 8px; text-align: left; }
-  .tzlist button:hover { background: color-mix(in srgb, var(--text) 7%, transparent); }
 
   .check { display: flex; align-items: center; gap: 7px; font-size: 12.5px; cursor: pointer; }
 

--- a/ui/src/lib/TimezoneSelect.svelte
+++ b/ui/src/lib/TimezoneSelect.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+  import { onMount, tick } from 'svelte';
+  import { matchingTimezones } from './timezone-search';
+  let { id, label, zones, value = $bindable(''), disabled = false, emptyLabel }: {
+    id: string; label: string; zones: string[]; value?: string; disabled?: boolean; emptyLabel: string;
+  } = $props();
+  let open = $state(false);
+  let draft = $state('');
+  let query = $state('');
+  let active = $state(0);
+  let input: HTMLInputElement;
+  let left = $state(0), top = $state(0), width = $state(300), maxHeight = $state(220);
+  const options = $derived([
+    ...(!query || emptyLabel.toLowerCase().includes(query.toLowerCase()) ? [''] : []),
+    ...matchingTimezones(zones, query),
+  ]);
+  $effect(() => { if (!open) draft = value || emptyLabel; });
+  function portal(node: HTMLElement) {
+    document.body.appendChild(node);
+    return { destroy() { node.remove(); } };
+  }
+  function position() {
+    if (!input || !open) return;
+    const rect = input.getBoundingClientRect();
+    left = rect.left; width = rect.width;
+    const below = window.innerHeight - rect.bottom - 12;
+    maxHeight = Math.min(220, Math.max(below, rect.top - 12));
+    top = below >= Math.min(220, options.length * 30 + 8) ? rect.bottom + 4 : Math.max(8, rect.top - maxHeight - 4);
+  }
+  async function begin() {
+    if (disabled) return;
+    open = true; query = ''; active = Math.max(0, options.indexOf(value));
+    input.scrollIntoView({ block: 'nearest' });
+    position();
+    await tick(); document.getElementById(`${id}-option-${active}`)?.scrollIntoView({ block: 'nearest' });
+  }
+  function close() { open = false; query = ''; draft = value || emptyLabel; }
+  function choose(zone: string) { value = zone; close(); }
+  async function keydown(e: KeyboardEvent) {
+    if (e.key === 'Escape' && open) { e.preventDefault(); e.stopPropagation(); close(); return; }
+    if (e.key === 'Tab') { close(); return; }
+    if (e.key === 'Enter' && open) {
+      e.preventDefault(); if (options[active] !== undefined) choose(options[active]); return;
+    }
+    if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
+    e.preventDefault();
+    if (!open) begin();
+    else active = Math.max(0, Math.min(options.length - 1, active + (e.key === 'ArrowDown' ? 1 : -1)));
+    await tick(); document.getElementById(`${id}-option-${active}`)?.scrollIntoView({ block: 'nearest' });
+  }
+  onMount(() => {
+    window.addEventListener('scroll', position, true);
+    window.addEventListener('resize', position);
+    return () => { window.removeEventListener('scroll', position, true); window.removeEventListener('resize', position); };
+  });
+</script>
+
+<div class="zone-picker">
+  <input bind:this={input} {id} aria-label={label} {disabled} role="combobox"
+    aria-autocomplete="list" aria-expanded={open && !disabled} aria-controls="{id}-options"
+    aria-activedescendant={open && options[active] !== undefined ? `${id}-option-${active}` : undefined}
+    autocomplete="off" spellcheck="false" value={draft}
+    onfocus={() => { begin(); input.select(); }}
+    onclick={() => { if (!open) begin(); }}
+    oninput={(e) => { draft = e.currentTarget.value; query = draft; open = true; active = 0; position(); }}
+    onblur={close} onkeydown={keydown} />
+  <button class="arrow" type="button" tabindex="-1" {disabled} aria-label="Show {label.toLowerCase()} options"
+    onpointerdown={(e) => e.preventDefault()}
+    onclick={() => { const wasOpen = open; input.focus(); if (wasOpen) close(); else begin(); }}>▾</button>
+  {#if open && !disabled}
+    <div use:portal class="options" id="{id}-options" role="listbox" aria-label="{label} options"
+      style:left="{left}px" style:top="{top}px" style:width="{width}px" style:max-height="{maxHeight}px">
+      {#each options as zone, i (zone)}
+        <button type="button" role="option" id="{id}-option-{i}" aria-selected={value === zone}
+          class:active={active === i} tabindex="-1" onpointerdown={(e) => e.preventDefault()}
+          onmouseenter={() => (active = i)} onclick={() => choose(zone)}>{zone || emptyLabel}</button>
+      {:else}<div class="empty" role="status">No matching time zones</div>{/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .zone-picker { width: 300px; max-width: 100%; min-width: 0; flex: 1; position: relative; }
+  input { width: 100%; box-sizing: border-box; font: inherit; font-size: 13px; color: var(--text);
+    background-color: color-mix(in srgb, var(--text) 5%, transparent);
+    border: 1px solid var(--hairline); border-radius: 5px; padding: 4px 26px 4px 6px; }
+  input:focus { outline: 1px solid var(--accent); outline-offset: -1px; }
+  button { font: inherit; font-size: 12px; color: var(--text); cursor: pointer; border: 0; }
+  .arrow { position: absolute; right: 1px; top: 1px; bottom: 1px; width: 24px; background: transparent; color: var(--muted); }
+  input:disabled, button:disabled { opacity: .5; cursor: default; }
+  .options { position: fixed; z-index: 1000; overflow-y: auto; box-sizing: border-box;
+    padding: 4px; border: 1px solid var(--hairline); border-radius: 5px; background: var(--surface, #25262b);
+    box-shadow: 0 4px 16px #0004; }
+  .options button { display: block; width: 100%; text-align: left; padding: 7px 8px;
+    border-radius: 3px; background: transparent; }
+  .options button.active { background: color-mix(in srgb, var(--accent) 25%, transparent); }
+  .empty { padding: 8px; color: var(--muted); font-size: 12px; }
+</style>

--- a/ui/src/lib/timezone-search.ts
+++ b/ui/src/lib/timezone-search.ts
@@ -1,0 +1,30 @@
+/** Prefer city/name matches, then abbreviations and small spelling mistakes. */
+export function matchingTimezones(zones: string[], query: string): string[] {
+  const normalize = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, '');
+  const q = normalize(query).slice(0, 100);
+  if (!q) return zones;
+  function score(zone: string): number {
+    const city = normalize(zone.split('/').slice(-1)[0] ?? zone);
+    const full = normalize(zone);
+    if (city === q || full === q) return 0;
+    if (city.startsWith(q)) return 1;
+    if (city.includes(q)) return 2;
+    if (full.includes(q)) return 3;
+    let i = 0;
+    for (const ch of full) if (ch === q[i]) i++;
+    if (i === q.length) return 4 + (full.length - q.length) / 100;
+    if (q.length < 4) return Infinity;
+    // Levenshtein distance allows a mistyped letter; limit to two edits.
+    let prev = Array.from({ length: q.length + 1 }, (_, n) => n);
+    for (let j = 0; j < city.length; j++) {
+      const next = [j + 1];
+      for (let k = 0; k < q.length; k++)
+        next.push(Math.min(next[k] + 1, prev[k + 1] + 1, prev[k] + (city[j] === q[k] ? 0 : 1)));
+      prev = next;
+    }
+    return prev[q.length] <= 2 ? 6 + prev[q.length] : Infinity;
+  }
+  return zones.map(zone => ({ zone, rank: score(zone) }))
+    .filter(x => Number.isFinite(x.rank)).sort((a, b) => a.rank - b.rank || a.zone.localeCompare(b.zone))
+    .map(x => x.zone);
+}

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -1628,17 +1628,15 @@ test.describe('Header', () => {
     // Defaults to the system zone; Apply is dead until something changes —
     // a restart button that is live with nothing to apply invites misclicks.
     const box = modal.getByLabel('Time zone', { exact: true });
-    await expect(box).toHaveValue('');
+    await expect(box).toHaveValue('System default');
     const apply = modal.getByRole('button', { name: 'Apply & restart' });
     await expect(apply).toBeDisabled();
 
-    // Searching by the CAPITAL, lower-case, finds the zone — the native
-    // select this replaced only jumped on leading letters, so "sofia"
-    // found nothing (reported live, minutes after it shipped). A half-typed
-    // name is not applyable; picking the match is.
-    await box.fill('sofia');
+    // Search within the dropdown choices by city; searching itself does not
+    // change the selection or enable Apply.
+    await box.fill('sofa');
     await expect(apply).toBeDisabled();
-    await modal.getByRole('option', { name: 'Europe/Sofia' }).click();
+    await page.getByRole('option', { name: 'Europe/Sofia', exact: true }).click();
     await expect(box).toHaveValue('Europe/Sofia');
     await expect(apply).toBeEnabled();
     await apply.click();
@@ -1655,7 +1653,8 @@ test.describe('Header', () => {
     await page.keyboard.press('Escape');
     const again = await openSettings(page);
     await expect(again.getByLabel('Time zone', { exact: true })).toHaveValue('Europe/Sofia');
-    await again.getByLabel('Time zone', { exact: true }).fill('');
+    await again.getByLabel('Time zone', { exact: true }).fill('System');
+    await page.getByRole('listbox', { name: 'Time zone options', exact: true }).getByRole('option', { name: 'System default', exact: true }).click();
     await again.getByRole('button', { name: 'Apply & restart' }).click();
     const second = await page.evaluate(() =>
       (window as any).__harness.calls.filter((c: { cmd: string }) => c.cmd === 'set_display_timezone').pop()?.args);
@@ -1669,14 +1668,14 @@ test.describe('Header', () => {
     // Same combo pattern as the display zone above it, same substring
     // search — and the same dead-until-valid Apply, though this one costs
     // no restart and says so by not being labelled with one.
-    const box = modal.getByLabel('Second time zone');
-    await expect(box).toHaveValue('');
+    const box = modal.getByLabel('Second time zone', { exact: true });
+    await expect(box).toHaveValue('Off');
     const apply = modal.getByRole('button', { name: 'Apply', exact: true });
     await expect(apply).toBeDisabled();
 
-    await box.fill('kolkata');
+    await box.fill('kolkta');
     await expect(apply).toBeDisabled();
-    await modal.getByRole('option', { name: 'Asia/Kolkata' }).click();
+    await box.press('Enter');
     await expect(apply).toBeEnabled();
     await apply.click();
 
@@ -1691,12 +1690,39 @@ test.describe('Header', () => {
     // backend's vocabulary for off, exactly as the display zone clears.
     await page.keyboard.press('Escape');
     const again = await openSettings(page);
-    await expect(again.getByLabel('Second time zone')).toHaveValue('Asia/Kolkata');
-    await again.getByLabel('Second time zone').fill('');
+    await expect(again.getByLabel('Second time zone', { exact: true })).toHaveValue('Asia/Kolkata');
+    await again.getByLabel('Second time zone', { exact: true }).fill('Off');
+    await page.getByRole('option', { name: 'Off', exact: true }).click();
     await again.getByRole('button', { name: 'Apply', exact: true }).click();
     const second = await page.evaluate(() =>
       (window as any).__harness.calls.filter((c: { cmd: string }) => c.cmd === 'set_second_timezone').pop()?.args);
     expect(second).toEqual({ tz: null });
+  });
+
+  test('time-zone combobox cancels invalid text and supports keyboard navigation', async ({ page }) => {
+    await page.goto(show('Header', 'connected'));
+    const modal = await openSettings(page);
+    const box = modal.getByRole('combobox', { name: 'Second time zone', exact: true });
+    await box.fill('zzzzzzzz');
+    await expect(page.getByRole('status')).toContainText('No matching time zones');
+    await box.press('Enter');
+    await expect(modal.getByRole('button', { name: 'Apply', exact: true })).toBeDisabled();
+    await box.press('Escape');
+    await expect(modal).toBeVisible();
+    await expect(box).toHaveValue('Off');
+    await box.fill('kolktta');
+    await expect(page.getByRole('option', { name: 'Asia/Kolkata', exact: true })).toBeVisible();
+    await box.press('Enter');
+    await expect(box).toHaveValue('Asia/Kolkata');
+    await box.press('ArrowDown');
+    await expect(box).toHaveAttribute('aria-expanded', 'true');
+    await box.press('ArrowUp');
+    await box.press('Enter');
+    await expect(box).not.toHaveValue('Asia/Kolkata');
+    await box.fill('invalid');
+    await box.press('Tab');
+    await expect(box).not.toHaveValue('invalid');
+    await expect(box).toHaveAttribute('aria-expanded', 'false');
   });
 
   test('the floor is stated before anybody trips over it', async ({ page }) => {

--- a/ui/tests/timezone-search.spec.ts
+++ b/ui/tests/timezone-search.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+import { matchingTimezones } from '../src/lib/timezone-search';
+
+test('time-zone fuzzy search ranks cities and tolerates abbreviations and typos', () => {
+  const zones = ['America/New_York', 'America/Chicago', 'Europe/Sofia', 'Asia/Kolkata', 'America/North_Dakota/New_Salem'];
+  expect(matchingTimezones(zones, 'new york')[0]).toBe('America/New_York');
+  expect(matchingTimezones(zones, 'ny')[0]).toBe('America/New_York');
+  expect(matchingTimezones(zones, 'chicgo')[0]).toBe('America/Chicago');
+  expect(matchingTimezones(zones, 'chciago')[0]).toBe('America/Chicago');
+  expect(matchingTimezones(zones, 'kolktta')[0]).toBe('Asia/Kolkata');
+  expect(matchingTimezones(zones, 'zzzzzz')).toEqual([]);
+  expect(matchingTimezones(zones, '')).toEqual(zones);
+});


### PR DESCRIPTION
Replace the time-zone text fields and separate search action with one typeahead control. Both zone settings support fuzzy matching and keyboard selection; cancelling an edit restores the saved value. The results stay visible outside the scrolling settings pane.

Validated with UI type checks and zone search/selection tests in Chromium and WebKit.

<img src="https://raw.githubusercontent.com/jondkinney/omacal/1ffe3e426e98bd0c5ce9e726b862655284b67150/screenshots/zones.png" alt="Fuzzy time-zone search; synthetic calendar data" width="480">
