### PR TITLE
refactor(settings): organize preferences and give the dialog room to breathe

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -517,6 +517,7 @@ pub struct AppSettings {
     /// ruler exists to save them from it.
     pub time_format: TimeFormat,
     pub date_format: DateFormat,
+    pub desktop: String,
     /// The day a week begins on, honoured by the Week grid's own anchor, the
     /// month grid's leading blanks, the Year view's twelve small grids, and
     /// Big Year's 392-day ribbon. When `week_starts_today` is on, this still
@@ -706,6 +707,7 @@ pub(crate) async fn read_settings_with(pool: &SqlitePool, baseline: u8) -> AppSe
         // by some future version all land on the format the app has always
         // drawn, rather than on the one nobody asked for.
         date_format: read(pool, "date_format").await.and_then(|v| serde_json::from_value(serde_json::Value::String(v)).ok()).unwrap_or(DateFormat::Locale),
+        desktop: if cfg!(target_os = "macos") { "macos" } else if crate::theme::omarchy_theme_dir().is_some() { "omarchy" } else { "linux" }.into(),
         time_format: read(pool, TIME_FORMAT_KEY)
             .await
             .map(|v| if v == "12h" { TimeFormat::H12 } else { TimeFormat::H24 })

--- a/ui/src/lib/CalendarList.svelte
+++ b/ui/src/lib/CalendarList.svelte
@@ -8,9 +8,11 @@
 
   let {
     calendars,
+    spacious = false,
     onchange,
   }: {
     calendars: Calendar[];
+    spacious?: boolean;
     onchange: () => void;
   } = $props();
 
@@ -159,7 +161,7 @@
   two belong. A mutation is what told the difference; see
   `two calendars with the same name in one account both render`.
 -->
-<div class="list">
+<div class="list" class:spacious>
   {#each groups as [email, cals]}
     <div class="acct">{email}</div>
     {#each cals as c (c.id)}
@@ -257,6 +259,8 @@
      it: the popover puts it in a floating panel, the settings tab in a column
      that is already inside one. A component that carried its own surface would
      draw a panel inside a panel in the second. */
+  .spacious .acct { padding: 24px 6px 10px; }
+  .spacious .acct:first-child { padding-top: 0; }
   .list { display: flex; flex-direction: column; min-width: 0; }
 
   .acct { font-size: 10.5px; color: var(--muted); letter-spacing: .05em;

--- a/ui/src/lib/Header.svelte
+++ b/ui/src/lib/Header.svelte
@@ -403,11 +403,11 @@
             <!-- Demo mode's seeded account never went through OAuth, so a sync
                  would only fail; offering the button at all would be a control
                  that exists solely to produce an error. Same reasoning covers
-                 Add account: sign_in refuses server-side in demo mode
+                 Add Google account: sign_in refuses server-side in demo mode
                  (demo_sync_guard) regardless of whether an account is already
                  connected. -->
             <button onclick={() => fromMenu(onSync)} disabled={busy}>Sync now</button>
-            <button onclick={() => fromMenu(onSignIn)} disabled={busy}>Add account</button>
+            <button onclick={() => fromMenu(onSignIn)} disabled={busy}>Add Google account</button>
           {/if}
           <button onclick={openTasks}>Tasks…</button>
           <button onclick={openSettings}>Settings…</button>

--- a/ui/src/lib/SettingsModal.svelte
+++ b/ui/src/lib/SettingsModal.svelte
@@ -813,7 +813,7 @@
         Dragging a range still uses the range you chose.
       </p>
 
-      <div class="row">
+      <div class="row section-start">
         <label class="lab" for="date-format">Show dates as</label>
         <div class="inline"><select id="date-format" disabled={!settings} value={settings?.dateFormat ?? 'locale'} onchange={(e) => saveDateFormat(e.currentTarget.value as DateFormat)}>
           {#each DATE_FORMATS as f}<option value={f.value}>{f.label}</option>{/each}
@@ -1527,7 +1527,7 @@
 
   .check { display: flex; align-items: center; gap: 7px; font-size: 12.5px; cursor: pointer; }
 
-  .account-row { display: flex; align-items: center; gap: 12px; padding: 12px 0; }
+  .account-row { display: flex; align-items: center; gap: 12px; padding: 6px 0; }
   .acct-email { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
   .acct-prov { color: var(--muted); font-size: 11px; letter-spacing: 0.04em;
     text-transform: uppercase; }
@@ -1537,7 +1537,7 @@
   .caldav.empty { display: none; }
   .provider-row { display: flex; flex-wrap: wrap; gap: 8px; }
   .caldav-form { display: flex; flex-direction: column; gap: 6px; }
-  .caldav-form input { font: inherit; font-size: 12.5px; color: var(--text);
+  .caldav-form input { box-sizing: border-box; width: 100%; min-width: 0; font: inherit; font-size: 12.5px; color: var(--text);
     background: var(--bg); border: 1px solid var(--hairline); border-radius: 5px;
     padding: 5px 8px; }
   .caldav-form input:focus-visible { outline: 1px solid var(--accent); outline-offset: -1px; }

--- a/ui/src/lib/SettingsModal.svelte
+++ b/ui/src/lib/SettingsModal.svelte
@@ -611,27 +611,29 @@
     }
   }
 
-  /**
-   * The four tabs of spec §3 in the order it lists them, with Appearance
-   * added second (issue #36): General had grown a theme, a window frame and
-   * a week-view control — all about how the calendar looks rather than what
-   * it does — and a reader hunting for "light theme" was reading past sync
-   * intervals to find it. General keeps the behaviour: syncing, defaults,
-   * clocks, the tray, login. Appearance keeps the look.
-   *
-   * The transparency sliders and the corner shape sit there for the same
-   * reason, and beside each other on purpose: both sliders are live previews
-   * and belong next to the event shape they change.
-   *
-   * The shell predates its contents; a tab that is present and blank says
-   * "not yet" more honestly than a tab that is missing, which says "never".
-   */
-  const TABS = ['General', 'Appearance', 'Calendars', 'Accounts', 'Notifications'] as const;
+  // Group controls by what they affect. Menu-bar controls live together;
+  // calendar appearance stays separate from provider/account management.
+  const TABS = ['General', 'Appearance', 'Menu bar', 'Calendars', 'Accounts', 'Notifications'] as const;
   type Tab = (typeof TABS)[number];
 
   let tab = $state<Tab>('General');
 
   let panelEl: HTMLDivElement | undefined = $state();
+  let preferredHeight = $state<number | null>(null);
+  $effect(() => {
+    const panel = panelEl;
+    if (!panel) return;
+    // Every pane has the final dialog width, even while hidden/inert. Measure
+    // natural contents so switching tabs cannot change the dialog's height.
+    const measure = () => {
+      const heights = Array.from(panel.querySelectorAll<HTMLElement>('.pane-content'), el => el.getBoundingClientRect().height);
+      preferredHeight = Math.ceil(Math.max(0, ...heights) + (panel.querySelector('.tabs')?.getBoundingClientRect().height ?? 0) + (panel.querySelector('.version')?.getBoundingClientRect().height ?? 0) + 2);
+    };
+    const observer = new ResizeObserver(measure);
+    panel.querySelectorAll('.pane-content, .tabs, .version').forEach(el => observer.observe(el));
+    measure();
+    return () => observer.disconnect();
+  });
 
   onMount(() => {
     // The first tab, not the panel and not a close button. `role="dialog"` plus
@@ -681,6 +683,7 @@
 
 <div
   class="modal"
+  style:height={preferredHeight === null ? '80vh' : `${preferredHeight}px`}
   bind:this={panelEl}
   role="dialog"
   aria-modal="true"
@@ -699,8 +702,11 @@
     {/each}
   </div>
 
-  <div class="body" role="tabpanel" aria-label={tab}>
-    {#if tab === 'General'}
+  <div class="panes">
+  {#each TABS as pane}
+  <div class="body" class:inactive={pane !== tab} role="tabpanel" aria-label={pane} aria-hidden={pane !== tab} inert={pane !== tab}>
+  <div class="pane-content">
+    {#if pane === 'General'}
       <div class="row">
         <label class="lab" for="sync-interval">Sync every</label>
         <div class="inline">
@@ -741,7 +747,7 @@
         finite, and a desktop app has no business polling faster.
       </p>
 
-      <div class="row">
+      <div class="row section-start">
         <label class="lab" for="default-cal">New events land on</label>
         <div class="inline">
           <span class="caldot" aria-hidden="true" style="background:{defaultCalColor}"></span>
@@ -841,7 +847,7 @@
         the side of Day and Week.
       </p>
 
-      <div class="row">
+      <div class="row section-start">
         <label class="lab" for="display-tz">Time zone</label>
         <div class="inline">
           <TimezoneSelect id="display-tz" label="Time zone" zones={timezones} bind:value={tzChoice}
@@ -884,21 +890,6 @@
       <label class="check">
         <input
           type="checkbox"
-          checked={settings?.trayIcon ?? true}
-          disabled={!settings}
-          onchange={(e) => toggleTrayIcon(e.currentTarget.checked)}
-        />
-        Show the tray icon
-      </label>
-      <p class="hint">
-        The tray is where Quit lives — only turn this off when something else
-        covers it, like the Omarchy bar widget, which can quit and sync the
-        app itself.
-      </p>
-
-      <label class="check">
-        <input
-          type="checkbox"
           checked={settings?.quitOnClose ?? false}
           disabled={!settings}
           onchange={(e) => toggleQuitOnClose(e.currentTarget.checked)}
@@ -934,51 +925,7 @@
         notifications arrive only once you have opened it yourself.
       </p>
 
-      <label class="check">
-        <input
-          type="checkbox"
-          checked={settings?.weatherEnabled ?? true}
-          disabled={!settings}
-          onchange={(e) => toggleWeather(e.currentTarget.checked)}
-        />
-        Weather in the day headers
-      </label>
-      <p class="hint">
-        A small forecast icon and the day's high, from Open-Meteo — the same
-        keyless service the Omarchy bar widget reads. The location comes from
-        that widget's setting when there is one, otherwise from your IP
-        address; turning this off ends the only network traffic OmaCal makes
-        beyond your calendar providers.
-      </p>
-
-      {#if settings?.weatherEnabled}
-        <div class="row">
-          <label class="lab" for="temperature-unit">Show temperature as</label>
-          <div class="inline">
-            <select
-              id="temperature-unit"
-              disabled={!settings}
-              value={settings?.temperatureUnit ?? 'celsius'}
-              onchange={(e) =>
-                saveTemperatureUnit(
-                  (e.currentTarget as HTMLSelectElement).value as TemperatureUnit,
-                )}
-            >
-              <!-- Each option prints a temperature rather than naming the
-                   scale, `time-format`'s reason: "Celsius" is a word you have
-                   to translate and `22°C` is the thing itself. -->
-              <option value="celsius">22°C</option>
-              <option value="fahrenheit">72°F</option>
-            </select>
-          </div>
-        </div>
-        <p class="hint">
-          The day headers stay a bare number, same as always — this only
-          decides which scale it's read in.
-        </p>
-      {/if}
-
-    {:else if tab === 'Appearance'}
+    {:else if pane === 'Appearance'}
       <div class="row">
         <label class="lab" for="appearance">Theme</label>
         <div class="inline">
@@ -996,10 +943,9 @@
         </div>
       </div>
       <p class="hint">
-        OmaCal wears your Omarchy theme, and follows it as you switch. On any
-        other desktop there is no theme to follow, which is what Light and Dark
-        are for — they replace the whole palette, your theme's accent included,
-        and take effect without a restart.
+        {#if settings?.desktop === 'omarchy'}Automatic follows your Omarchy theme as you switch.
+        {:else}Choose Light or Dark for your preferred appearance.{/if}
+        Light and Dark replace the whole palette, including the accent, without a restart.
       </p>
 
       <!-- Only where there is a choice: on macOS the backend reports none,
@@ -1106,9 +1052,8 @@
         </div>
         <p class="hint">
           0% is opaque; 50% is as clear as the canvas goes, in 0.1% steps.
-          Inactive applies when another window has focus. Omarchy blends
-          every window a little on its own, so there the app starts at 4% to
-          match, and the compositor's share stays on top.
+          Inactive applies when another window has focus.
+          {#if settings?.desktop === 'omarchy'}Omarchy blends every window a little on its own, so OmaCal starts at 4% to match, and the compositor's share stays on top.{/if}
         </p>
       </section>
       {/if}
@@ -1167,11 +1112,64 @@
         </fieldset>
       </section>
 
-      <!-- What the app's face says, here rather than beside "Show the tray
-           icon" in General: that switch is about whether the app has a tray
-           at all, which is where Quit lives and therefore behaviour; this is
-           about what it looks like once it does. One switch for two
-           surfaces, because they are one idea (2026-09-04). -->
+      <label class="check section-start">
+        <input
+          type="checkbox"
+          checked={settings?.weatherEnabled ?? true}
+          disabled={!settings}
+          onchange={(e) => toggleWeather(e.currentTarget.checked)}
+        />
+        Weather in the day headers
+      </label>
+      <p class="hint">
+        A small forecast icon and the day's high, from Open-Meteo.
+        {#if settings?.desktop === 'omarchy'}The location uses your Omarchy weather widget setting when available, otherwise your IP address.
+        {:else}The location comes from your IP address.{/if}
+        Turning this off stops forecast requests.
+      </p>
+
+      {#if settings?.weatherEnabled}
+        <div class="row">
+          <label class="lab" for="temperature-unit">Show temperature as</label>
+          <div class="inline">
+            <select
+              id="temperature-unit"
+              disabled={!settings}
+              value={settings?.temperatureUnit ?? 'celsius'}
+              onchange={(e) =>
+                saveTemperatureUnit(
+                  (e.currentTarget as HTMLSelectElement).value as TemperatureUnit,
+                )}
+            >
+              <!-- Each option prints a temperature rather than naming the
+                   scale, `time-format`'s reason: "Celsius" is a word you have
+                   to translate and `22°C` is the thing itself. -->
+              <option value="celsius">22°C</option>
+              <option value="fahrenheit">72°F</option>
+            </select>
+          </div>
+        </div>
+        <p class="hint">
+          The day headers stay a bare number, same as always — this only
+          decides which scale it's read in.
+        </p>
+      {/if}
+
+    {:else if pane === 'Menu bar'}
+      <label class="check section-start">
+        <input
+          type="checkbox"
+          checked={settings?.trayIcon ?? true}
+          disabled={!settings}
+          onchange={(e) => toggleTrayIcon(e.currentTarget.checked)}
+        />
+        Show the tray icon
+      </label>
+      <p class="hint">
+        The tray provides Quit and Sync. Keep another way to access these
+        actions available when hiding it.
+      </p>
+
       <label class="check">
         <input
           type="checkbox"
@@ -1184,11 +1182,11 @@
       <p class="hint">
         The tray icon becomes the date, the way a calendar's icon does — a
         tray draws icons and nothing else, so this replaces the mark rather
-        than sitting beside it. The Omarchy bar widget shows the date too,
-        beside its own mark, where there is room for both. The number wears
-        the mark's colour and follows the clock without a restart.
+        than sitting beside it.
+        {#if settings?.desktop === 'omarchy'}The Omarchy bar widget also shows the date beside its mark.{/if}
+        The number follows the clock without a restart.
       </p>
-    {:else if tab === 'Calendars'}
+    {:else if pane === 'Calendars'}
       <!-- **The same rows the header's popover shows, from the same
            component.** Extracted rather than reimplemented, which is what
            makes "rehomed, not rewritten" checkable: `CalendarPopover`'s own
@@ -1199,12 +1197,12 @@
            row is a component with its own file rather than markup written out
            twice in two hosts. -->
       {#if calendars.length > 0}
-        <div class="cals"><CalendarList {calendars} onchange={oncalendarchange} /></div>
+        <div class="cals"><CalendarList {calendars} spacious onchange={oncalendarchange} /></div>
       {:else}
         <p class="soon">No calendars yet. Connect an account first.</p>
       {/if}
 
-    {:else if tab === 'Accounts'}
+    {:else if pane === 'Accounts'}
       <ul class="accounts">
         {#each accountRows ?? accounts.map((email, i) => ({ id: -1 - i, email, provider: 'google' })) as row (row.id)}
           <li class="account-row">
@@ -1231,8 +1229,10 @@
       {#if (accountRows ?? accounts).length === 0}
         <p class="soon">No account is connected.</p>
       {/if}
-      <div class="inline">
-        <button type="button" onclick={onSignIn} disabled={busy}>Add account</button>
+      <div class="provider-row">
+        <button type="button" onclick={onSignIn} disabled={busy}>Add Google account</button>
+        <button type="button" onclick={() => openCaldavForm('icloud')} disabled={busy || caldavBusy}>Add iCloud account</button>
+        <button type="button" onclick={() => openCaldavForm('caldav')} disabled={busy || caldavBusy}>Add CalDAV account</button>
         {#if signingIn}
           <button type="button" onclick={onCancelSignIn}>Cancel sign-in</button>
         {/if}
@@ -1247,17 +1247,8 @@
 
       <!-- CalDAV: the auth story with no OAuth in it. One form serves both —
            "iCloud" only fixes the server address and words the fields. -->
-      <div class="caldav" role="group" aria-label="Connect a CalDAV account">
-        {#if caldavForm === null}
-          <div class="provider-row">
-            <button type="button" onclick={() => openCaldavForm('icloud')} disabled={busy}>
-              Add iCloud account
-            </button>
-            <button type="button" onclick={() => openCaldavForm('caldav')} disabled={busy}>
-              Add CalDAV account
-            </button>
-          </div>
-        {:else}
+      <div class="caldav" class:empty={caldavForm === null} role="group" aria-label="Connect a CalDAV account">
+        {#if caldavForm !== null}
           <form
             class="caldav-form"
             onsubmit={(e) => {
@@ -1393,7 +1384,7 @@
               aria-label="Remove fallback reminder"
               disabled={!settings}
               onclick={() => settings && saveFallback(settings.fallbackReminderMinutes.filter((_, j) => j !== i))}
-            >⊗</button>
+            >×</button>
           </div>
         {/each}
         {#if (settings?.fallbackReminderMinutes.length ?? 5) < 5}
@@ -1411,21 +1402,22 @@
       </div>
     {/if}
 
-    {#if note}
+    {#if note && pane === tab}
       <p class="note" class:err={note.kind === 'error'} data-testid="settings-note">{note.text}</p>
     {/if}
 
-    {#if version}
-      <p class="version" data-testid="app-version">OmaCal {version}</p>
-    {/if}
   </div>
+  </div>
+  {/each}
+  </div>
+  {#if version}<p class="version" data-testid="app-version">OmaCal {version}</p>{/if}
 </div>
 
 <style>
   .appearance-section { align-self: stretch; display: flex; flex-direction: column;
-                        gap: 10px; padding: 2px 0 10px; }
+                        gap: 14px; padding: 8px 0 16px; margin-top: 16px; }
   .appearance-section + .appearance-section {
-    border-top: 1px solid var(--hairline); padding-top: 14px;
+    border-top: 1px solid var(--hairline); padding-top: 24px;
   }
   .appearance-section h2 { margin: 0; font-size: 13px; font-weight: 600;
                            color: var(--text); }
@@ -1458,9 +1450,9 @@
 
   /* A colophon, not a control: the quietest text in the modal, at the very
      bottom, on every tab — where "what version am I on?" goes looking. */
-  .version { margin: 14px 0 0; font-size: 11.5px; color: var(--muted);
-             text-align: right; }
-  .fallback { display: flex; flex-direction: column; gap: 4px; align-items: flex-start; }
+  .version { flex: none; margin: 0; padding: 16px 24px 20px; font-size: 11.5px; color: var(--muted);
+             text-align: left; }
+  .fallback { display: flex; flex-direction: column; gap: 20px; margin-top: 0; align-items: flex-start; }
   .frow { display: flex; align-items: center; gap: 5px; font-size: 13px; }
   .frow input[type='number'] { width: 56px; }
   .unremind { font: inherit; font-size: 14px; color: var(--muted); cursor: pointer;
@@ -1476,17 +1468,17 @@
   /* Centred rather than anchored — see the comment above the markup. `fixed`
      plus a translate keeps it centred without knowing its own size, which is
      what lets the body grow as the tabs are filled in. */
-  .modal { position: fixed; z-index: 61; top: 50%; left: 50%;
+  .modal { box-sizing: border-box; position: fixed; z-index: 61; top: 50%; left: 50%;
            transform: translate(-50%, -50%);
-           width: 480px; max-width: calc(100vw - 32px);
-           height: 420px; max-height: calc(100vh - 64px);
+           width: 650px; max-width: calc(100vw - 32px);
+           max-height: min(80vh, calc(100vh - 64px));
            display: flex; flex-direction: column;
            background: var(--surface); border: 1px solid var(--hairline);
            border-radius: 10px; box-shadow: 0 12px 40px rgba(0, 0, 0, .5);
            font-size: 13px; color: var(--text); overflow: hidden; }
   .modal:focus { outline: none; }
 
-  .tabs { display: flex; gap: 2px; padding: 8px 8px 0;
+  .tabs { display: flex; flex-wrap: wrap; gap: 2px; padding: 8px 8px 0;
           border-bottom: 1px solid var(--hairline); flex: none; }
   .tabs button { font: inherit; font-size: 12.5px; color: var(--muted); cursor: pointer;
                  background: none; border: 0; border-radius: 6px 6px 0 0;
@@ -1495,18 +1487,23 @@
                     background: color-mix(in srgb, var(--text) 7%, transparent); }
   .tabs button:focus-visible { outline: 1px solid var(--accent); outline-offset: -1px; }
 
-  .body { flex: 1; overflow-y: auto; padding: 14px;
-          display: flex; flex-direction: column; gap: 8px; align-items: flex-start; }
+  .panes { flex: 1; min-height: 0; position: relative; }
+  .body { position: absolute; inset: 0; overflow-y: auto; }
+  .body.inactive { visibility: hidden; pointer-events: none; }
+  .pane-content { padding: 24px; display: flex; flex-direction: column; gap: 12px; align-items: flex-start; }
+  .pane-content > * { flex-shrink: 0; }
   .soon { font-size: 12px; color: var(--muted); margin: 0; }
 
-  .row { display: flex; flex-direction: column; gap: 4px; }
+  .row { display: flex; flex-direction: column; gap: 8px; }
+  .pane-content > .hint + .row, .pane-content > .hint + .check { margin-top: 8px; }
+  .pane-content > .section-start, .pane-content > .hint + .section-start { margin-top: 24px; }
+  .pane-content > .row, .pane-content > .check, .pane-content > .hint, .appearance-section { flex-shrink: 0; }
   .lab { font-size: 10.5px; color: var(--muted); letter-spacing: .05em; }
   .inline { display: flex; align-items: center; gap: 6px; }
   .unit { font-size: 12px; color: var(--muted); }
   /* No max-width: the 40ch cap that used to sit here wrapped every hint at
      about half the modal and left the right side conspicuously empty
-     (reported 2026-08-17). The modal's own 480px is the measure; hints are
-     a line or two and read fine at it. */
+     (reported 2026-08-17). Hints follow the responsive modal width. */
   .hint { font-size: 11px; color: var(--muted); opacity: .85; line-height: 1.45; margin: 0;
           align-self: stretch; }
 
@@ -1530,14 +1527,15 @@
 
   .check { display: flex; align-items: center; gap: 7px; font-size: 12.5px; cursor: pointer; }
 
-  .account-row { display: flex; align-items: center; gap: 8px; }
+  .account-row { display: flex; align-items: center; gap: 12px; padding: 12px 0; }
   .acct-email { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
   .acct-prov { color: var(--muted); font-size: 11px; letter-spacing: 0.04em;
     text-transform: uppercase; }
   .account-row .danger { color: var(--danger, #e66); border-color: var(--danger, #e66); }
 
-  .caldav { display: flex; flex-direction: column; gap: 8px; margin-top: 10px; }
-  .provider-row { display: flex; gap: 8px; }
+  .caldav { align-self: stretch; min-width: 0; display: flex; flex-direction: column; gap: 16px; margin-top: 24px; }
+  .caldav.empty { display: none; }
+  .provider-row { display: flex; flex-wrap: wrap; gap: 8px; }
   .caldav-form { display: flex; flex-direction: column; gap: 6px; }
   .caldav-form input { font: inherit; font-size: 12.5px; color: var(--text);
     background: var(--bg); border: 1px solid var(--hairline); border-radius: 5px;

--- a/ui/src/lib/settings.ts
+++ b/ui/src/lib/settings.ts
@@ -111,6 +111,7 @@ export type AppSettings = {
    *  time and none of them owns the preference. */
   timeFormat: TimeFormat;
   dateFormat: DateFormat;
+  desktop: 'macos' | 'omarchy' | 'linux';
   /** The day a week begins on. Read by the grids through the
    *  `weekstartstore.svelte.ts` rune, for the same reason `timeFormat` is. */
   weekStart: WeekStartDay;

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -432,7 +432,7 @@ test.describe('App', () => {
   // never left syncing behind the user's back without them having seen it.
   test('signing in opens the picker with the new calendars in it', async ({ page }) => {
     await page.goto(app('sign-in-adds-account'));
-    await page.getByRole('button', { name: /Connect|Add account/ }).click();
+    await page.getByRole('button', { name: /Connect|Add Google account/ }).click();
     await expect(page.locator('.panel')).toBeVisible();
     await expect(page.locator('.acct')).toHaveCount(1);
   });
@@ -446,7 +446,7 @@ test.describe('App', () => {
   // true and unable to reopen the (by-then-closed) child.
   test('closing the picker then signing in again reopens it', async ({ page }) => {
     await page.goto(app('sign-in-adds-account'));
-    await page.getByRole('button', { name: /Connect|Add account/ }).click();
+    await page.getByRole('button', { name: /Connect|Add Google account/ }).click();
     await expect(page.locator('.panel')).toBeVisible();
     await page.keyboard.press('Escape');
     await expect(page.locator('.panel')).toHaveCount(0);
@@ -463,7 +463,7 @@ test.describe('App', () => {
   // reviewer who found this confirmed both propagate up correctly.
   test('clicking away then signing in again reopens it', async ({ page }) => {
     await page.goto(app('sign-in-adds-account'));
-    await page.getByRole('button', { name: /Connect|Add account/ }).click();
+    await page.getByRole('button', { name: /Connect|Add Google account/ }).click();
     await expect(page.locator('.panel')).toBeVisible();
     // **The picker's own scrim**, named exactly: the menu it now sits inside
     // has one too, and clicking the wrong one would close the wrong layer.
@@ -2365,17 +2365,17 @@ test.describe('App', () => {
     await page.getByRole('button', { name: 'Settings…' }).click();
     const modal = page.getByRole('dialog', { name: 'Settings' });
     await expect(modal.getByRole('tab')).toHaveText([
-      'General', 'Appearance', 'Calendars', 'Accounts', 'Notifications',
+      'General', 'Appearance', 'Menu bar', 'Calendars', 'Accounts', 'Notifications',
     ]);
     const look = ['#appearance', '#window-frame', '#week-view'];
     const behaviour = ['#sync-interval', '#time-format', '#display-tz', '#start-on-login'];
 
-    for (const id of look) await expect(modal.locator(id)).toHaveCount(0);
+    for (const id of look) await expect(modal.locator(id)).not.toBeVisible();
     for (const id of behaviour) await expect(modal.locator(id)).toHaveCount(1);
 
     await modal.getByRole('tab', { name: 'Appearance' }).click();
     for (const id of look) await expect(modal.locator(id)).toHaveCount(1);
-    for (const id of behaviour) await expect(modal.locator(id)).toHaveCount(0);
+    for (const id of behaviour) await expect(modal.locator(id)).not.toBeVisible();
   });
 
   /**
@@ -4135,6 +4135,7 @@ test.describe('App: the temperature unit', () => {
     await page.getByRole('button', { name: 'Menu' }).click();
     await page.getByRole('button', { name: 'Settings…' }).click();
     const modal = page.getByRole('dialog', { name: 'Settings' });
+    await modal.getByRole('tab', { name: 'Appearance', exact: true }).click();
     await modal.locator('#temperature-unit').selectOption({ label });
     await page.keyboard.press('Escape');
     await expect(modal).toHaveCount(0);
@@ -4928,7 +4929,7 @@ test.describe("App: showing today's date", () => {
     await page.getByRole('button', { name: 'Menu' }).click();
     await page.getByRole('button', { name: 'Settings…' }).click();
     const modal = page.getByRole('dialog', { name: 'Settings' });
-    await modal.getByRole('tab', { name: 'Appearance' }).click();
+    await modal.getByRole('tab', { name: 'Menu bar' }).click();
     const box = modal.getByLabel("Show today's date");
     await expect(box).not.toBeChecked();
 
@@ -4943,7 +4944,7 @@ test.describe("App: showing today's date", () => {
     await expect(modal).toHaveCount(0);
     await page.getByRole('button', { name: 'Menu' }).click();
     await page.getByRole('button', { name: 'Settings…' }).click();
-    await modal.getByRole('tab', { name: 'Appearance' }).click();
+    await modal.getByRole('tab', { name: 'Menu bar' }).click();
     await expect(modal.getByLabel("Show today's date")).toBeChecked();
   });
 });

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -423,7 +423,7 @@ test.describe('App', () => {
 
     // Behind the hamburger now (spec §1), so getting to it is part of the act.
     await page.getByRole('button', { name: 'Menu' }).click();
-    await page.getByRole('button', { name: 'Add account' }).click();
+    await page.getByRole('button', { name: 'Add Google account' }).click();
     await expect.poll(calendarCalls).toBeGreaterThan(before);
   });
 
@@ -454,7 +454,7 @@ test.describe('App', () => {
     // opened inside is still standing, which is what lets the next click reach
     // Add account — and is the behaviour three `window` keydown listeners
     // would otherwise collapse into one keystroke.
-    await page.getByRole('button', { name: 'Add account' }).click();
+    await page.getByRole('button', { name: 'Add Google account' }).click();
     await expect(page.locator('.panel')).toBeVisible();
   });
 
@@ -470,7 +470,7 @@ test.describe('App', () => {
     await page.getByRole('button', { name: 'Close', exact: true }).click();
     await expect(page.locator('.panel')).toHaveCount(0);
 
-    await page.getByRole('button', { name: 'Add account' }).click();
+    await page.getByRole('button', { name: 'Add Google account' }).click();
     await expect(page.locator('.panel')).toBeVisible();
   });
 
@@ -5189,7 +5189,7 @@ test('abandoned Google sign-in can be cancelled and Add account retried', async 
   await page.getByRole('button', { name: 'Settings…', exact: true }).click();
   let modal = page.getByRole('dialog', { name: 'Settings' });
   await modal.getByRole('tab', { name: 'Accounts', exact: true }).click();
-  await modal.getByRole('button', { name: 'Add account', exact: true }).click();
+  await modal.getByRole('button', { name: 'Add Google account', exact: true }).click();
   await expect(page.getByRole('status').filter({ hasText: 'Waiting for Google' })).toBeVisible();
   await page.getByRole('button', { name: 'Cancel sign-in', exact: true }).click();
   await expect(page.getByRole('button', { name: 'Cancel sign-in', exact: true })).toHaveCount(0);
@@ -5198,15 +5198,15 @@ test('abandoned Google sign-in can be cancelled and Add account retried', async 
   await page.getByRole('button', { name: 'Settings…', exact: true }).click();
   modal = page.getByRole('dialog', { name: 'Settings' });
   await modal.getByRole('tab', { name: 'Accounts', exact: true }).click();
-  await expect(modal.getByRole('button', { name: 'Add account', exact: true })).toBeEnabled();
-  await modal.getByRole('button', { name: 'Add account', exact: true }).click();
+  await expect(modal.getByRole('button', { name: 'Add Google account', exact: true })).toBeEnabled();
+  await modal.getByRole('button', { name: 'Add Google account', exact: true }).click();
   await expect.poll(() => page.evaluate(() => window.__harness.calls.filter(c => c.cmd === 'sign_in').length)).toBe(2);
   // Cancellation is also available after reopening Settings during consent.
   await page.getByRole('button', { name: 'Menu', exact: true }).click();
   await page.getByRole('button', { name: 'Settings…', exact: true }).click();
   await page.getByRole('dialog', { name: 'Settings' }).getByRole('tab', { name: 'Accounts', exact: true }).click();
   await page.getByRole('dialog', { name: 'Settings' }).getByRole('button', { name: 'Cancel sign-in', exact: true }).click();
-  await expect(page.getByRole('dialog', { name: 'Settings' }).getByRole('button', { name: 'Add account', exact: true })).toBeEnabled();
+  await expect(page.getByRole('dialog', { name: 'Settings' }).getByRole('button', { name: 'Add Google account', exact: true })).toBeEnabled();
 });
 
 test('date preference repaints event dates and survives a reload', async ({ page }) => {
@@ -5223,3 +5223,30 @@ test('date preference repaints event dates and survives a reload', async ({ page
   await page.locator('.col .ev').first().click();
   await expect(page.locator('.pop .when')).toContainText(/\d{2}\/\d{2}\/2024/);
 });
+
+test('settings measures every pane at 650px and keeps its height across tabs', async ({ page }) => {
+  await page.setViewportSize({ width: 1400, height: 3000 });
+  await page.goto(app());
+  await page.getByRole('button', { name: 'Menu' }).click();
+  await page.getByRole('button', { name: 'Settings…' }).click();
+  const modal = page.getByRole('dialog', { name: 'Settings' });
+  await expect(modal.locator('#sync-interval')).toBeEnabled();
+  await expect.poll(() => modal.evaluate(el => {
+    const tallest = Math.max(...Array.from(el.querySelectorAll('.pane-content'), pane => pane.getBoundingClientRect().height));
+    return Math.abs(el.getBoundingClientRect().height - tallest - el.querySelector('.tabs')!.getBoundingClientRect().height - (el.querySelector('.version')?.getBoundingClientRect().height ?? 0) - 2);
+  })).toBeLessThanOrEqual(2);
+  const first = (await modal.boundingBox())!;
+  expect(first.width).toBe(650);
+  expect(first.height).toBeLessThan(2400);
+  for (const name of ['Appearance', 'Menu bar', 'Calendars', 'Accounts', 'Notifications']) {
+    await modal.getByRole('tab', { name, exact: true }).click();
+    await expect(modal.getByRole('tabpanel')).toHaveCount(1);
+    await expect(modal.getByRole('tabpanel')).toHaveAttribute('aria-label', name);
+    expect(Math.abs((await modal.boundingBox())!.height - first.height)).toBeLessThanOrEqual(2);
+  }
+  await page.setViewportSize({ width: 420, height: 700 });
+  await expect.poll(async () => (await modal.boundingBox())!.width).toBeLessThanOrEqual(388);
+  await expect.poll(async () => (await modal.boundingBox())!.height).toBeLessThanOrEqual(560);
+});
+
+

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -1191,7 +1191,7 @@ test.describe('Header', () => {
     await page.goto(show('Header', 'connected'));
 
     await expect(page.getByRole('button', { name: 'Sync now' })).toHaveCount(0);
-    await expect(page.getByRole('button', { name: 'Add account' })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Add Google account' })).toHaveCount(0);
     await expect(page.getByRole('button', { name: /^Calendars/ })).toHaveCount(0);
     await expect(page.getByRole('button', { name: 'Menu' })).toBeVisible();
   });
@@ -1202,7 +1202,7 @@ test.describe('Header', () => {
     await openMenu(page);
 
     await expect(page.getByRole('button', { name: 'Sync now' })).toBeEnabled();
-    await expect(page.getByRole('button', { name: 'Add account' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Add Google account' })).toBeVisible();
     await expect(page.getByRole('button', { name: /^Calendars/ })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Settings…' })).toBeVisible();
   });
@@ -1265,13 +1265,13 @@ test.describe('Header', () => {
     await page.clock.setFixedTime(FIXED_NOW);
     await page.goto(show('Header', 'busy-connected'));
     await openMenu(page);
-    await expect(page.getByRole('button', { name: 'Add account' })).toBeDisabled();
+    await expect(page.getByRole('button', { name: 'Add Google account' })).toBeDisabled();
   });
 
   test('a connected account can add another', async ({ page }) => {
     await page.goto(show('Header', 'connected'));
     await openMenu(page);
-    await expect(page.getByRole('button', { name: 'Add account' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Add Google account' })).toBeVisible();
   });
 
   test('a disconnected user is asked to connect, not to add', async ({ page }) => {
@@ -1281,7 +1281,7 @@ test.describe('Header', () => {
     // user has to find.
     await expect(page.getByRole('button', { name: /Connect Google Calendar/ })).toBeVisible();
     await openMenu(page);
-    await expect(page.getByRole('button', { name: 'Add account' })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Add Google account' })).toHaveCount(0);
   });
 
   test('a signed-out light is muted, and says so rather than reading as broken', async ({ page }) => {
@@ -1304,7 +1304,7 @@ test.describe('Header', () => {
   test('demo mode offers neither', async ({ page }) => {
     await page.goto(show('Header', 'demo'));
     await openMenu(page);
-    await expect(page.getByRole('button', { name: 'Add account' })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Add Google account' })).toHaveCount(0);
     await expect(page.getByRole('button', { name: /Connect/ })).toHaveCount(0);
   });
 
@@ -1315,7 +1315,7 @@ test.describe('Header', () => {
 
     const modal = page.getByRole('dialog', { name: 'Settings' });
     await expect(modal).toBeVisible();
-    await expect(modal.getByRole('tab')).toHaveCount(5);
+    await expect(modal.getByRole('tab')).toHaveCount(6);
 
     await page.keyboard.press('Escape');
     await expect(modal).toHaveCount(0);
@@ -1429,9 +1429,9 @@ test.describe('Header', () => {
    */
   /** The weather knob (General): checked by default — the backend ships it
    *  on — and unchecking is a write through the command, not a redraw. */
-  test('General carries the weather toggle, on by default and saved off', async ({ page }) => {
+  test('Appearance carries the weather toggle, on by default and saved off', async ({ page }) => {
     await page.goto(show('Header', 'connected'));
-    const modal = await openSettings(page);
+    const modal = await openSettings(page, 'Appearance');
 
     const toggle = modal.getByRole('checkbox', { name: 'Weather in the day headers' });
     await expect(toggle).toBeChecked();
@@ -1745,7 +1745,7 @@ test.describe('Header', () => {
     const modal = await openSettings(page, 'Calendars');
 
     await expect(modal.locator('.acct')).toHaveText(['me@x.com']);
-    await expect(modal.locator('.row')).toHaveCount(3);
+    await expect(modal.getByRole('tabpanel').locator('.row')).toHaveCount(3);
     await expect(modal.locator('.name')).toHaveText(['Personal', 'Team', 'Holidays in Bulgaria']);
   });
 
@@ -1785,7 +1785,7 @@ test.describe('Header', () => {
   test('the tab keeps show and sync as two separate controls', async ({ page }) => {
     await page.goto(show('Header', 'connected'));
     const modal = await openSettings(page, 'Calendars');
-    const row = modal.locator('.row').first();
+    const row = modal.getByRole('tabpanel').locator('.row').first();
 
     await expect(row.locator('input[type=checkbox]')).toBeVisible();
     await expect(row.getByRole('button', { name: 'Remove' })).toBeVisible();
@@ -1795,7 +1795,7 @@ test.describe('Header', () => {
   test('a calendar can be hidden from the tab, and the app is told', async ({ page }) => {
     await page.goto(show('Header', 'connected'));
     const modal = await openSettings(page, 'Calendars');
-    await modal.locator('input[type=checkbox]').first().uncheck();
+    await modal.getByRole('tabpanel').locator('input[type=checkbox]').first().uncheck();
 
     // Through to the command, not just the checkbox: the tab is a second host
     // for these rows and a host that rendered them without wiring them would
@@ -1813,7 +1813,7 @@ test.describe('Header', () => {
     // but only the host can ask `App` to reload the grid afterwards.
     await page.goto(show('Header', 'connected'));
     const modal = await openSettings(page, 'Calendars');
-    await modal.locator('input[type=checkbox]').first().uncheck();
+    await modal.getByRole('tabpanel').locator('input[type=checkbox]').first().uncheck();
 
     await expect
       .poll(() => page.evaluate(() => (window as any).__calendarChanges))
@@ -1847,7 +1847,7 @@ test.describe('Header', () => {
     await page.goto(show('Header', 'connected'));
     const modal = await openSettings(page, 'Accounts');
     await expect(modal.getByRole('listitem')).toContainText(['me@x.com']);
-    await expect(modal.getByRole('button', { name: 'Add account' })).toBeVisible();
+    await expect(modal.getByRole('button', { name: 'Add Google account' })).toBeVisible();
   });
 
   test('signing an account out asks first, then empties the list', async ({ page }) => {

--- a/ui/tests/harness/tauri.ts
+++ b/ui/tests/harness/tauri.ts
@@ -577,6 +577,7 @@ type StubSettings = {
   transparentWindow: boolean;
   timeFormat: TimeFormat;
   dateFormat: import('../../src/lib/datefmt').DateFormat;
+  desktop: 'macos' | 'omarchy' | 'linux';
   weekStart: WeekStartDay;
   weekStartsToday: boolean;
   weekViewDays: WeekViewDays;
@@ -627,6 +628,7 @@ const DEFAULT_SETTINGS: StubSettings = {
   // committed screenshot golden goes on describing the same pixels.
   timeFormat: '24h',
   dateFormat: 'locale',
+  desktop: 'linux',
   // The week omacal has always drawn, so every golden holds.
   weekStart: 'monday',
   weekStartsToday: false,


### PR DESCRIPTION
Group tray controls in a Menu bar tab and weather controls in Appearance. Size the dialog to its tallest pane, capped at 650px wide and 80% of the window height, with a fixed version footer and scrolling content.

Adjust spacing between groups, clarify the Google/iCloud/CalDAV add-account buttons, and let account forms use the available width. Platform-specific copy follows the current desktop.

Validated with workspace Rust tests, Clippy, UI type checks, and 1,146 app/component tests in Chromium and WebKit.

<img src="https://raw.githubusercontent.com/jondkinney/omacal/1ffe3e426e98bd0c5ce9e726b862655284b67150/screenshots/settings.png" alt="Accounts preferences with a full-width CalDAV form; synthetic calendar data" width="480">
