### PR TITLE
feat(appearance): set active and inactive window transparency separately

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -29,6 +29,7 @@ pub const HOUR_HEIGHT_MAX: i64 = 160;
 const FALLBACK_KEY: &str = "fallback_reminder_minutes";
 const DEFAULT_CALENDAR_KEY: &str = "default_calendar_id";
 const DEFAULT_EVENT_DURATION_KEY: &str = "default_event_duration_minutes";
+const INACTIVE_BACKGROUND_TRANSPARENCY_KEY: &str = "inactive_background_transparency";
 const BACKGROUND_TRANSPARENCY_KEY: &str = "background_transparency";
 const EVENT_TRANSPARENCY_KEY: &str = "event_transparency";
 const EVENT_CORNER_STYLE_KEY: &str = "event_corner_style";
@@ -405,13 +406,15 @@ pub struct AppSettings {
     /// Minutes a new timed event lasts when the user names only its start.
     /// Sixty preserves the existing behavior for installs without this row.
     pub default_event_duration_minutes: u32,
-    /// Absolute transparency of the calendar canvas. Zero is fully opaque;
+    /// Calendar-canvas transparency in tenths of a percent, capped at 50. Zero is opaque;
     /// the default is [`appearance_baseline`]: Omarchy's former whole-window
     /// blend there, opaque anywhere else.
-    pub background_transparency: u8,
-    /// Absolute transparency of event fills only. Zero is fully opaque; text,
+    pub background_transparency: f64,
+    /// Falls back to the active value for existing installations.
+    pub inactive_background_transparency: f64,
+    /// Event-fill transparency in tenths of a percent, capped at 25. Text,
     /// colour spines, outlines and controls stay fully painted throughout.
-    pub event_transparency: u8,
+    pub event_transparency: f64,
     /// Rounded preserves the shapes omacal shipped with; square removes the
     /// corner radius from every event representation, not from other UI.
     pub event_corner_style: EventCornerStyle,
@@ -570,6 +573,18 @@ fn appearance_transparency(stored: Option<String>, absolute: bool, baseline: u8)
     }
 }
 
+fn surface_percentage(value: f64, cap: f64) -> f64 {
+    (value.min(cap) * 10.0).round() / 10.0
+}
+
+fn read_surface(stored: Option<String>, absolute: bool, baseline: u8, cap: f64) -> f64 {
+    if !absolute { return surface_percentage(appearance_transparency(stored, false, baseline) as f64, cap); }
+    let value = stored.and_then(|v| v.parse::<f64>().ok())
+        .filter(|v| v.is_finite() && (0.0..=100.0).contains(v))
+        .unwrap_or(baseline as f64);
+    surface_percentage(value, cap)
+}
+
 /// The settings as stored, with defaults for anything absent.
 ///
 /// Absent is the ordinary case on a fresh install and is not an error:
@@ -586,6 +601,9 @@ pub(crate) async fn read_settings_with(pool: &SqlitePool, baseline: u8) -> AppSe
         .await
         .as_deref()
         == Some(ABSOLUTE_TRANSPARENCY_SEMANTICS);
+    let background_transparency = read_surface(
+        read(pool, BACKGROUND_TRANSPARENCY_KEY).await, absolute_transparency, baseline, 50.0,
+    );
     AppSettings {
         sync_interval_ms: read(pool, SYNC_INTERVAL_KEY)
             .await
@@ -651,15 +669,12 @@ pub(crate) async fn read_settings_with(pool: &SqlitePool, baseline: u8) -> AppSe
         // values meant "extra alpha after Omarchy's 4% baseline"; lazily
         // translate those rows so an old 0 opens at 4 instead of changing the
         // user's appearance. The next write stores the marker atomically.
-        background_transparency: appearance_transparency(
-            read(pool, BACKGROUND_TRANSPARENCY_KEY).await,
-            absolute_transparency,
-            baseline,
-        ),
-        event_transparency: appearance_transparency(
-            read(pool, EVENT_TRANSPARENCY_KEY).await,
-            absolute_transparency,
-            baseline,
+        background_transparency,
+        inactive_background_transparency: read(pool, INACTIVE_BACKGROUND_TRANSPARENCY_KEY).await
+            .and_then(|v| v.parse::<f64>().ok()).filter(|v| v.is_finite() && (0.0..=100.0).contains(v))
+            .map(|v| surface_percentage(v, 50.0)).unwrap_or(background_transparency),
+        event_transparency: read_surface(
+            read(pool, EVENT_TRANSPARENCY_KEY).await, absolute_transparency, baseline, 25.0,
         ),
         transparent_window: cfg!(target_os = "linux"),
         event_corner_style: match read(pool, EVENT_CORNER_STYLE_KEY).await.as_deref() {
@@ -744,7 +759,7 @@ pub const EVENT_DURATION_TOO_SHORT: &str =
     "the default meeting duration must be at least one minute";
 
 pub const TRANSPARENCY_OUT_OF_RANGE: &str =
-    "transparency must be between 0 and 100 percent";
+    "background transparency must be between 0 and 50 percent; event transparency between 0 and 25 percent";
 
 #[tauri::command]
 pub async fn get_settings(state: tauri::State<'_, AppState>) -> Result<AppSettings, String> {
@@ -1173,21 +1188,23 @@ async fn set_default_event_duration_impl(
     Ok(read_settings(pool).await)
 }
 
-/// Stores the three appearance choices as one decision. The two sliders and
+/// Stores appearance choices as one decision. The sliders and
 /// the corner picker share one preview, so a crash or database failure must
 /// not leave half of that preview persisted for the next launch.
 #[tauri::command]
 pub async fn set_appearance_preferences(
     state: tauri::State<'_, AppState>,
-    background_transparency: u8,
-    event_transparency: u8,
+    background_transparency: f64,
+    event_transparency: f64,
     event_corner_style: EventCornerStyle,
+    inactive_background_transparency: Option<f64>,
 ) -> Result<AppSettings, String> {
     set_appearance_preferences_impl(
         &state.pool,
         background_transparency,
         event_transparency,
         event_corner_style,
+        inactive_background_transparency,
     )
     .await
     .map_err(|e| crate::errors::user_facing(&e))
@@ -1195,17 +1212,21 @@ pub async fn set_appearance_preferences(
 
 async fn set_appearance_preferences_impl(
     pool: &SqlitePool,
-    background_transparency: u8,
-    event_transparency: u8,
+    background_transparency: f64,
+    event_transparency: f64,
     event_corner_style: EventCornerStyle,
+    inactive_background_transparency: Option<f64>,
 ) -> anyhow::Result<AppSettings> {
-    if background_transparency > 100 || event_transparency > 100 {
+    let inactive = inactive_background_transparency.unwrap_or(background_transparency);
+    if !background_transparency.is_finite() || !(0.0..=50.0).contains(&background_transparency)
+        || !inactive.is_finite() || !(0.0..=50.0).contains(&inactive) || !event_transparency.is_finite() || !(0.0..=25.0).contains(&event_transparency) {
         anyhow::bail!(TRANSPARENCY_OUT_OF_RANGE);
     }
 
     let values = [
-        (BACKGROUND_TRANSPARENCY_KEY, background_transparency.to_string()),
-        (EVENT_TRANSPARENCY_KEY, event_transparency.to_string()),
+        (BACKGROUND_TRANSPARENCY_KEY, surface_percentage(background_transparency, 50.0).to_string()),
+        (INACTIVE_BACKGROUND_TRANSPARENCY_KEY, surface_percentage(inactive, 50.0).to_string()),
+        (EVENT_TRANSPARENCY_KEY, surface_percentage(event_transparency, 25.0).to_string()),
         (EVENT_CORNER_STYLE_KEY, event_corner_style.as_str().to_string()),
         (
             APPEARANCE_TRANSPARENCY_SEMANTICS_KEY,
@@ -1400,12 +1421,12 @@ mod tests {
         let baseline = appearance_baseline(crate::theme::omarchy_theme_dir().is_some());
         assert_eq!(
             s.background_transparency,
-            baseline,
+            baseline as f64,
             "a fresh install starts at this desktop's baseline: 4 where Omarchy blended the window, 0 elsewhere",
         );
         assert_eq!(
             s.event_transparency,
-            baseline,
+            baseline as f64,
             "event alpha starts at the same baseline",
         );
         assert_eq!(
@@ -1560,24 +1581,45 @@ mod tests {
     async fn appearance_round_trips_as_one_choice_and_rejects_bad_percentages() {
         let p = pool().await;
 
-        let s = set_appearance_preferences_impl(&p, 35, 70, EventCornerStyle::Square)
+        let s = set_appearance_preferences_impl(&p, 35.0, 20.0, EventCornerStyle::Square, None)
             .await
             .unwrap();
-        assert_eq!(s.background_transparency, 35);
-        assert_eq!(s.event_transparency, 70);
+        assert_eq!(s.background_transparency, 35.0);
+        assert_eq!(s.event_transparency, 20.0);
         assert_eq!(s.event_corner_style, EventCornerStyle::Square);
 
-        for (background, events) in [(101, 70), (35, 101)] {
-            let err = set_appearance_preferences_impl(&p, background, events, EventCornerStyle::Rounded)
+        for (background, events) in [(50.1, 20.0), (35.0, 25.1)] {
+            let err = set_appearance_preferences_impl(&p, background, events, EventCornerStyle::Rounded, None)
                 .await
                 .unwrap_err();
             assert_eq!(err.to_string(), TRANSPARENCY_OUT_OF_RANGE);
             assert_eq!(crate::errors::user_facing(&err), TRANSPARENCY_OUT_OF_RANGE);
             let unchanged = read_settings(&p).await;
-            assert_eq!(unchanged.background_transparency, 35);
-            assert_eq!(unchanged.event_transparency, 70);
+            assert_eq!(unchanged.background_transparency, 35.0);
+            assert_eq!(unchanged.event_transparency, 20.0);
             assert_eq!(unchanged.event_corner_style, EventCornerStyle::Square);
         }
+    }
+
+    #[tokio::test]
+    async fn inactive_transparency_falls_back_then_persists_independently() {
+        let p = omacal_store::connect_memory().await.unwrap();
+        write(&p, BACKGROUND_TRANSPARENCY_KEY, "35").await.unwrap();
+        let legacy = read_settings(&p).await;
+        assert_eq!(legacy.inactive_background_transparency, legacy.background_transparency);
+        write(&p, APPEARANCE_TRANSPARENCY_SEMANTICS_KEY, ABSOLUTE_TRANSPARENCY_SEMANTICS).await.unwrap();
+        write(&p, BACKGROUND_TRANSPARENCY_KEY, "80").await.unwrap();
+        write(&p, INACTIVE_BACKGROUND_TRANSPARENCY_KEY, "90").await.unwrap();
+        let capped = read_settings(&p).await;
+        assert_eq!((capped.background_transparency, capped.inactive_background_transparency), (50.0, 50.0));
+        write(&p, EVENT_TRANSPARENCY_KEY, "90").await.unwrap();
+        assert_eq!(read_settings(&p).await.event_transparency, 25.0);
+        let saved = set_appearance_preferences_impl(&p, 1.5, 20.5, EventCornerStyle::Rounded, Some(4.1)).await.unwrap();
+        assert_eq!((saved.background_transparency, saved.inactive_background_transparency), (1.5, 4.1));
+        assert_eq!(read_settings(&p).await.inactive_background_transparency, 4.1);
+        assert!(set_appearance_preferences_impl(&p, 10.0, 20.0, EventCornerStyle::Square, Some(50.1)).await.is_err());
+        let unchanged = read_settings(&p).await;
+        assert_eq!((unchanged.background_transparency, unchanged.inactive_background_transparency, unchanged.event_transparency), (1.5, 4.1, 20.5));
     }
 
     #[tokio::test]
@@ -1586,24 +1628,24 @@ mod tests {
 
         // No semantics row is the additive version. On Omarchy its 0 was
         // really the compositor's 4%; 50 was 50% alpha multiplied by 96%, or
-        // 52% total.
+        // 52% total, now capped at 25%.
         write(&p, BACKGROUND_TRANSPARENCY_KEY, "0").await.unwrap();
         write(&p, EVENT_TRANSPARENCY_KEY, "50").await.unwrap();
         let legacy = read_settings_with(&p, DEFAULT_APPEARANCE_TRANSPARENCY).await;
-        assert_eq!(legacy.background_transparency, 4);
-        assert_eq!(legacy.event_transparency, 52);
+        assert_eq!(legacy.background_transparency, 4.0);
+        assert_eq!(legacy.event_transparency, 25.0);
         // Off Omarchy nothing multiplied the window, so a legacy value was
-        // already the whole alpha and reads back as itself.
+        // already the whole alpha, still subject to the 25% event cap.
         let plain = read_settings_with(&p, 0).await;
-        assert_eq!(plain.background_transparency, 0);
-        assert_eq!(plain.event_transparency, 50);
+        assert_eq!(plain.background_transparency, 0.0);
+        assert_eq!(plain.event_transparency, 25.0);
 
         // Any new write marks the whole tuple absolute, including a real 0.
-        let absolute = set_appearance_preferences_impl(&p, 0, 50, EventCornerStyle::Rounded)
+        let absolute = set_appearance_preferences_impl(&p, 0.0, 25.0, EventCornerStyle::Rounded, None)
             .await
             .unwrap();
-        assert_eq!(absolute.background_transparency, 0);
-        assert_eq!(absolute.event_transparency, 50);
+        assert_eq!(absolute.background_transparency, 0.0);
+        assert_eq!(absolute.event_transparency, 25.0);
         assert_eq!(
             read(&p, APPEARANCE_TRANSPARENCY_SEMANTICS_KEY).await.as_deref(),
             Some(ABSOLUTE_TRANSPARENCY_SEMANTICS),
@@ -1621,12 +1663,12 @@ mod tests {
                 let s = read_settings_with(&p, baseline).await;
                 assert_eq!(
                     s.background_transparency,
-                    baseline,
+                    baseline as f64,
                     "{stored:?} changed the canvas at baseline {baseline}",
                 );
                 assert_eq!(
                     s.event_transparency,
-                    baseline,
+                    baseline as f64,
                     "{stored:?} changed event fills at baseline {baseline}",
                 );
             }
@@ -1648,15 +1690,15 @@ mod tests {
     async fn a_fresh_install_starts_opaque_unless_omarchy_blended_the_window_already() {
         let p = pool().await;
         let plain = read_settings_with(&p, appearance_baseline(false)).await;
-        assert_eq!((plain.background_transparency, plain.event_transparency), (0, 0));
+        assert_eq!((plain.background_transparency, plain.event_transparency), (0.0, 0.0));
         let omarchy = read_settings_with(&p, appearance_baseline(true)).await;
         assert_eq!(
             (omarchy.background_transparency, omarchy.event_transparency),
-            (DEFAULT_APPEARANCE_TRANSPARENCY, DEFAULT_APPEARANCE_TRANSPARENCY),
+            (DEFAULT_APPEARANCE_TRANSPARENCY as f64, DEFAULT_APPEARANCE_TRANSPARENCY as f64),
         );
         // The real read passes the host's own answer, whichever it is.
         let detected = appearance_baseline(crate::theme::omarchy_theme_dir().is_some());
-        assert_eq!(read_settings(&p).await.background_transparency, detected);
+        assert_eq!(read_settings(&p).await.background_transparency, detected as f64);
     }
 
     #[test]

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -3,7 +3,7 @@
   import { listen } from '@tauri-apps/api/event';
   import { tick, untrack } from 'svelte';
   import { applyPalette, setPalette, type Palette } from './lib/theme';
-  import { applyAppearance } from './lib/appearance';
+  import { applyAppearance, observeAppearanceFocus } from './lib/appearance';
   import {
     getWeek, getDay, getRange, getMonth, getYear, getBigYear, weekStart,
     type WeekPayload, type MonthPayload, type YearPayload, type BigYearPayload, type UiEvent,
@@ -179,6 +179,7 @@
   let pickerOpen = $state(false);
 
   $effect(() => { applyPalette(); });
+  $effect(() => observeAppearanceFocus());
 
   // Keep a rolling view literally anchored on today across midnight and a
   // laptop wake. A range the user has navigated away from today is left where

--- a/ui/src/lib/SettingsModal.svelte
+++ b/ui/src/lib/SettingsModal.svelte
@@ -296,6 +296,7 @@
     if (!settings) return;
     const requested = {
       backgroundTransparency: settings.backgroundTransparency,
+      inactiveBackgroundTransparency: settings.inactiveBackgroundTransparency,
       eventTransparency: settings.eventTransparency,
       eventCornerStyle: settings.eventCornerStyle,
     };
@@ -307,6 +308,7 @@
           requested.backgroundTransparency,
           requested.eventTransparency,
           requested.eventCornerStyle,
+          requested.inactiveBackgroundTransparency,
         );
         if (write !== appearanceWrite) return;
         settings = stored;
@@ -1084,14 +1086,14 @@
       <section class="appearance-section" aria-labelledby="background-style-heading">
         <h2 id="background-style-heading">Calendar background</h2>
         <div class="range-row">
-          <label for="background-transparency">Transparency</label>
+          <label for="background-transparency">Active window</label>
           <input
             id="background-transparency"
-            aria-label="Background transparency"
+            aria-label="Active background transparency"
             type="range"
             min="0"
-            max="100"
-            step="1"
+            max="50"
+            step="0.1"
             value={settings?.backgroundTransparency ?? 0}
             disabled={!settings}
             oninput={(e) => previewAppearance({
@@ -1103,10 +1105,29 @@
             {settings?.backgroundTransparency ?? 0}%
           </output>
         </div>
+        <div class="range-row">
+          <label for="inactive-background-transparency">Inactive window</label>
+          <input
+            id="inactive-background-transparency"
+            aria-label="Inactive background transparency"
+            type="range"
+            min="0"
+            max="50"
+            step="0.1"
+            value={settings?.inactiveBackgroundTransparency ?? 0}
+            disabled={!settings}
+            oninput={(e) => previewAppearance({
+              inactiveBackgroundTransparency: e.currentTarget.valueAsNumber,
+            })}
+            onchange={() => { void saveAppearancePreferences(); }}
+          />
+          <output for="inactive-background-transparency">
+            {settings?.inactiveBackgroundTransparency ?? 0}%
+          </output>
+        </div>
         <p class="hint">
-          0% is opaque; 100% makes the calendar canvas clear. Omarchy blends
-          every window a little on its own, so there the app starts at 4% to
-          match, and the compositor's share stays on top.
+          0% is opaque; 50% is half transparent. Adjust in 0.1% steps. Inactive applies when another window has focus.
+          Your compositor may apply additional transparency.
         </p>
       </section>
       {/if}
@@ -1120,8 +1141,8 @@
             aria-label="Event transparency"
             type="range"
             min="0"
-            max="100"
-            step="1"
+            max="25"
+            step="0.1"
             value={settings?.eventTransparency ?? 0}
             disabled={!settings}
             oninput={(e) => previewAppearance({

--- a/ui/src/lib/appearance.ts
+++ b/ui/src/lib/appearance.ts
@@ -3,9 +3,40 @@ export type EventCornerStyle = 'rounded' | 'square';
 
 export type AppearancePreferences = {
   backgroundTransparency: number;
+  inactiveBackgroundTransparency?: number;
   eventTransparency: number;
   eventCornerStyle: EventCornerStyle;
 };
+
+const current = new WeakMap<HTMLElement, AppearancePreferences>();
+const focused = new WeakMap<HTMLElement, boolean>();
+
+/** Track window focus, not focus moving between controls inside the app. */
+export function observeAppearanceFocus(root = document.documentElement): () => void {
+  const window = root.ownerDocument.defaultView!;
+  const update = (active: boolean) => {
+    focused.set(root, active);
+    const preferences = current.get(root);
+    if (preferences) applyBackground(preferences, root);
+  };
+  const activate = () => update(true);
+  const deactivate = () => update(false);
+  update(root.ownerDocument.hasFocus());
+  window.addEventListener('focus', activate);
+  window.addEventListener('blur', deactivate);
+  return () => {
+    window.removeEventListener('focus', activate);
+    window.removeEventListener('blur', deactivate);
+    focused.delete(root);
+  };
+}
+
+function applyBackground(preferences: AppearancePreferences, root: HTMLElement) {
+  const active = focused.get(root) ?? root.ownerDocument.hasFocus();
+  const value = active ? preferences.backgroundTransparency
+    : preferences.inactiveBackgroundTransparency ?? preferences.backgroundTransparency;
+  setTransparency(root, 'backgroundTransparency', '--background-fill-opacity', percent(value, 50));
+}
 
 /**
  * Applies absolute transparency: 0 is opaque and 100 is clear.
@@ -19,10 +50,10 @@ export function applyAppearance(
   preferences: AppearancePreferences,
   root: HTMLElement = document.documentElement,
 ): void {
-  const background = percent(preferences.backgroundTransparency);
-  const events = percent(preferences.eventTransparency);
+  current.set(root, { ...preferences });
+  const events = percent(preferences.eventTransparency, 25);
 
-  setTransparency(root, 'backgroundTransparency', '--background-fill-opacity', background);
+  applyBackground(preferences, root);
   setTransparency(root, 'eventTransparency', '--event-fill-opacity', events);
 
   if (preferences.eventCornerStyle === 'square') {
@@ -38,9 +69,9 @@ export function applyAppearance(
   }
 }
 
-function percent(value: number): number {
+function percent(value: number, cap: number): number {
   if (!Number.isFinite(value)) return 0;
-  return Math.max(0, Math.min(100, Math.round(value)));
+  return Math.round(Math.max(0, Math.min(cap, value)) * 10) / 10;
 }
 
 function setTransparency(

--- a/ui/src/lib/settings.ts
+++ b/ui/src/lib/settings.ts
@@ -92,9 +92,10 @@ export type AppSettings = {
   defaultCalendarId: number | null;
   /** Minutes used when a new timed event has a start but no explicit end. */
   defaultEventDurationMinutes: number;
-  /** Absolute calendar-canvas transparency, 0 (opaque) through 100 (clear). */
+  /** Absolute calendar-canvas transparency, 0 (opaque) through 50, in 0.1% steps. */
   backgroundTransparency: number;
-  /** Absolute event-fill transparency, without fading event text or outlines. */
+  inactiveBackgroundTransparency: number;
+  /** Event-fill transparency, 0–25 in 0.1% steps, without fading text or outlines. */
   eventTransparency: number;
   /** The shared corner treatment for every event representation. */
   eventCornerStyle: EventCornerStyle;
@@ -302,8 +303,10 @@ export const setAppearancePreferences = (
   backgroundTransparency: number,
   eventTransparency: number,
   eventCornerStyle: EventCornerStyle,
+  inactiveBackgroundTransparency: number = backgroundTransparency,
 ) => invoke<AppSettings>('set_appearance_preferences', {
   backgroundTransparency,
+  inactiveBackgroundTransparency,
   eventTransparency,
   eventCornerStyle,
 });

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -56,6 +56,46 @@ test.describe('App', () => {
     await expect(page.locator('.err')).toHaveCount(0);
   });
 
+  test('active and inactive background transparency switch on window focus and persist', async ({ page }) => {
+    await page.goto(app());
+    await page.getByRole('button', {name: 'Menu'}).click();
+    await page.getByRole('button', {name: 'Settings…'}).click();
+    let modal = page.getByRole('dialog', {name: 'Settings'});
+    await modal.getByRole('tab', {name: 'Appearance'}).click();
+    for (const name of ['Active background transparency', 'Inactive background transparency']) {
+      await expect(modal.getByRole('slider', {name, exact: true})).toHaveAttribute('max', '50');
+      await expect(modal.getByRole('slider', {name, exact: true})).toHaveAttribute('step', '0.1');
+    }
+    await expect(modal.getByRole('slider', {name: 'Event transparency', exact: true})).toHaveAttribute('max', '25');
+    await expect(modal.getByRole('slider', {name: 'Event transparency', exact: true})).toHaveAttribute('step', '0.1');
+    for (const [name, value] of [['Active background transparency', '1.5'], ['Inactive background transparency', '4.1'], ['Event transparency', '20.5']]) {
+      await modal.getByRole('slider', {name, exact: true}).evaluate((el, value) => {
+        (el as HTMLInputElement).value = value;
+        el.dispatchEvent(new Event('input', {bubbles: true}));
+        el.dispatchEvent(new Event('change', {bubbles: true}));
+      }, value);
+    }
+    await expect.poll(() => page.evaluate(() => (window as any).__harness.calls.filter((c: any) => c.cmd === 'set_appearance_preferences').length)).toBe(3);
+    const alpha = () => page.evaluate(() => ({background: document.documentElement.style.getPropertyValue('--background-fill-opacity'), events: document.documentElement.style.getPropertyValue('--event-fill-opacity')}));
+    await page.evaluate(() => window.dispatchEvent(new Event('focus')));
+    await expect.poll(alpha).toEqual({background: '98.5%', events: '79.5%'});
+    await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+    await expect.poll(alpha).toEqual({background: '95.9%', events: '79.5%'});
+    await page.evaluate(() => window.dispatchEvent(new Event('focus')));
+    await expect.poll(alpha).toEqual({background: '98.5%', events: '79.5%'});
+    await modal.getByRole('slider', {name: 'Event transparency', exact: true}).focus();
+    await expect.poll(alpha).toEqual({background: '98.5%', events: '79.5%'});
+    await page.reload();
+    await page.getByRole('button', {name: 'Menu'}).click();
+    await page.getByRole('button', {name: 'Settings…'}).click();
+    modal = page.getByRole('dialog', {name: 'Settings'});
+    await modal.getByRole('tab', {name: 'Appearance'}).click();
+    await expect(modal.getByRole('slider', {name: 'Active background transparency', exact: true})).toHaveValue('1.5');
+    await expect(modal.getByRole('slider', {name: 'Inactive background transparency', exact: true})).toHaveValue('4.1');
+    await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+    await expect.poll(alpha).toEqual({background: '95.9%', events: '79.5%'});
+  });
+
   test('stored appearance separately fades the canvas and event fill after reload', async ({ page }) => {
     await page.goto(app());
     await page.getByRole('button', { name: 'Menu' }).click();
@@ -64,16 +104,16 @@ test.describe('App', () => {
     await modal.getByRole('tab', { name: 'Appearance' }).click();
 
     const commit = (name: string, value: string) =>
-      modal.getByRole('slider', { name }).evaluate((el, next) => {
+      modal.getByRole('slider', { name, exact: true }).evaluate((el, next) => {
         (el as HTMLInputElement).value = next;
         el.dispatchEvent(new Event('input', { bubbles: true }));
         el.dispatchEvent(new Event('change', { bubbles: true }));
       }, value);
-    await commit('Background transparency', '50');
+    await commit('Active background transparency', '50');
     await expect.poll(() => page.evaluate(() =>
       (window as any).__harness.calls.filter((c: any) => c.cmd === 'set_appearance_preferences').length,
     )).toBe(1);
-    await commit('Event transparency', '70');
+    await commit('Event transparency', '25');
     await expect.poll(() => page.evaluate(() =>
       (window as any).__harness.calls.filter((c: any) => c.cmd === 'set_appearance_preferences').length,
     )).toBe(2);
@@ -90,7 +130,7 @@ test.describe('App', () => {
       background: document.documentElement.dataset.backgroundTransparency,
       events: document.documentElement.dataset.eventTransparency,
       corners: document.documentElement.dataset.eventCorners,
-    }))).toEqual({ background: '50', events: '70', corners: 'square' });
+    }))).toEqual({ background: '50', events: '25', corners: 'square' });
 
     const bodyColour = await page.locator('body').evaluate(
       (el) => getComputedStyle(el).backgroundColor,
@@ -106,7 +146,7 @@ test.describe('App', () => {
     const eventColour = await event.evaluate((el) => getComputedStyle(el).backgroundColor);
     expect(colourAlpha(bodyColour), JSON.stringify({ bodyColour, appearanceCss }))
       .toBeCloseTo(0.5, 2);
-    expect(colourAlpha(eventColour)).toBeCloseTo(0.3, 2);
+    expect(colourAlpha(eventColour)).toBeCloseTo(0.75, 2);
     await expect(event).toHaveCSS('border-radius', '0px');
     await expect(event).toHaveCSS('opacity', '1');
     await expect(event.locator('b')).toHaveCSS('opacity', '1');
@@ -133,8 +173,8 @@ test.describe('App', () => {
     await page.getByRole('button', { name: 'Settings…' }).click();
     const modal = page.getByRole('dialog', { name: 'Settings' });
     await modal.getByRole('tab', { name: 'Appearance' }).click();
-    for (const name of ['Background transparency', 'Event transparency']) {
-      await modal.getByRole('slider', { name }).evaluate((el) => {
+    for (const name of ['Active background transparency', 'Event transparency']) {
+      await modal.getByRole('slider', { name, exact: true }).evaluate((el) => {
         (el as HTMLInputElement).value = '0';
         el.dispatchEvent(new Event('input', { bubbles: true }));
       });

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -1346,13 +1346,13 @@ test.describe('Header', () => {
     // The rest of the tab is still there — only the canvas slider is missing.
     await expect(modal.getByRole('slider', { name: 'Event transparency' })).toHaveCount(1);
     await expect(modal.getByRole('radio', { name: 'Rounded' })).toHaveCount(1);
-    await expect(modal.getByRole('slider', { name: 'Background transparency' })).toHaveCount(0);
+    await expect(modal.getByRole('slider', { name: 'Active background transparency', exact: true })).toHaveCount(0);
   });
 
   test('Appearance starts opaque off Omarchy and persists absolute values', async ({ page }) => {
     await page.goto(show('Header', 'connected'));
     let modal = await openSettings(page, 'Appearance');
-    const background = modal.getByRole('slider', { name: 'Background transparency' });
+    const background = modal.getByRole('slider', { name: 'Active background transparency', exact: true });
     const events = modal.getByRole('slider', { name: 'Event transparency' });
 
     await expect(background).toHaveValue('0');
@@ -1385,7 +1385,7 @@ test.describe('Header', () => {
     )).toBe(1);
 
     await events.evaluate((el) => {
-      (el as HTMLInputElement).value = '65';
+      (el as HTMLInputElement).value = '25';
       el.dispatchEvent(new Event('input', { bubbles: true }));
       el.dispatchEvent(new Event('change', { bubbles: true }));
     });
@@ -1401,7 +1401,8 @@ test.describe('Header', () => {
       (window as any).__harness.calls.filter((c: any) => c.cmd === 'set_appearance_preferences').pop()?.args);
     expect(last).toEqual({
       backgroundTransparency: 40,
-      eventTransparency: 65,
+      inactiveBackgroundTransparency: 0,
+      eventTransparency: 25,
       eventCornerStyle: 'square',
     });
     expect(await page.evaluate(() => ({
@@ -1409,14 +1410,14 @@ test.describe('Header', () => {
       fill: document.documentElement.style.getPropertyValue('--event-fill-opacity'),
       corners: document.documentElement.dataset.eventCorners,
       radius: document.documentElement.style.getPropertyValue('--event-card-radius'),
-    }))).toEqual({ data: '65', fill: '35%', corners: 'square', radius: '0px' });
+    }))).toEqual({ data: '25', fill: '75%', corners: 'square', radius: '0px' });
 
     // A reopen fetches the stub's stored object; it cannot pass merely because
     // the range element kept the value typed into it.
     await page.keyboard.press('Escape');
     modal = await openSettings(page, 'Appearance');
-    await expect(modal.getByRole('slider', { name: 'Background transparency' })).toHaveValue('40');
-    await expect(modal.getByRole('slider', { name: 'Event transparency' })).toHaveValue('65');
+    await expect(modal.getByRole('slider', { name: 'Active background transparency', exact: true })).toHaveValue('40');
+    await expect(modal.getByRole('slider', { name: 'Event transparency' })).toHaveValue('25');
     await expect(modal.getByRole('radio', { name: 'Square' })).toBeChecked();
   });
 

--- a/ui/tests/harness/tauri.ts
+++ b/ui/tests/harness/tauri.ts
@@ -571,6 +571,7 @@ type StubSettings = {
   defaultCalendarId: number | null;
   defaultEventDurationMinutes: number;
   backgroundTransparency: number;
+  inactiveBackgroundTransparency: number;
   eventTransparency: number;
   eventCornerStyle: EventCornerStyle;
   transparentWindow: boolean;
@@ -612,6 +613,7 @@ const DEFAULT_SETTINGS: StubSettings = {
   // window that can be seen through. A spec telling the Omarchy story seeds
   // 4; one wanting the macOS answer seeds `transparentWindow: false`.
   backgroundTransparency: 0,
+  inactiveBackgroundTransparency: 0,
   eventTransparency: 0,
   eventCornerStyle: 'rounded',
   transparentWindow: true,
@@ -955,13 +957,16 @@ export function installTauriStub(scenario: string): Harness {
       case 'set_appearance_preferences': {
         const backgroundTransparency = args.backgroundTransparency as number;
         const eventTransparency = args.eventTransparency as number;
-        if (backgroundTransparency < 0 || backgroundTransparency > 100
-            || eventTransparency < 0 || eventTransparency > 100) {
-          throw new Error('transparency must be between 0 and 100 percent');
+        const inactive = args.inactiveBackgroundTransparency as number ?? backgroundTransparency;
+        if (!Number.isFinite(backgroundTransparency) || backgroundTransparency < 0 || backgroundTransparency > 50
+            || !Number.isFinite(inactive) || inactive < 0 || inactive > 50
+            || eventTransparency < 0 || eventTransparency > 25) {
+          throw new Error('background transparency must be between 0 and 50 percent; event transparency between 0 and 25 percent');
         }
         settings = saveSettings({
           ...settings,
           backgroundTransparency,
+          inactiveBackgroundTransparency: inactive,
           eventTransparency,
           eventCornerStyle: args.eventCornerStyle as EventCornerStyle,
         });


### PR DESCRIPTION
Give active and inactive backgrounds separate transparency controls and update the background when window focus changes. All transparency controls accept tenths of a percent; backgrounds are capped at 50% and event fills at 25%. Existing settings are retained.

The main benefit here is that we get to control the background separately from events and replicate the stock omarchy values instead of one static value for the background transparency. This makes it feel much more "native". 

Validated with workspace Rust tests, Clippy, UI type checks, and focus, rendering, and persistence regressions in Chromium and WebKit.

<img src="https://raw.githubusercontent.com/jondkinney/omacal/1ffe3e426e98bd0c5ce9e726b862655284b67150/screenshots/opacity.png" alt="Separate background and event transparency controls; synthetic calendar data" width="480">
