### PR TITLE
feat(menubar): show meeting controls and an interactive agenda

### DIFF
--- a/packaging/omarchy-plugin/MeetingPresence.d.mts
+++ b/packaging/omarchy-plugin/MeetingPresence.d.mts
@@ -1,0 +1,6 @@
+import type { Event } from './Timeline.mjs';
+export interface Window { key: string; appId: string; title: string }
+export interface Presence { key: string; signature: string; eventKey: string }
+export function eventKey(event: Event | null): string;
+export function observe(previous: Presence[], windows: Window[], events: Event[], now: number, leadMinutes: number, intent?: { at: number; eventKey: string } | null): Presence[];
+export function isPresent(records: Presence[], event: Event | null, now: number): boolean;

--- a/packaging/omarchy-plugin/MeetingPresence.mjs
+++ b/packaging/omarchy-plugin/MeetingPresence.mjs
@@ -1,0 +1,91 @@
+// Window presence, not a claim that a provider has connected audio/video.
+// Inputs come from Wayland; nothing is persisted or sent outside the shell.
+const MAX_WINDOWS = 256, MAX_EVENTS = 256, MAX_TEXT = 1024;
+function text(value) {
+  return typeof value === 'string' && value.length <= MAX_TEXT
+    && !/[\x00-\x1f\x7f-\x9f\u202a-\u202e\u2066-\u2069]/.test(value) ? value.trim().toLowerCase() : '';
+}
+function meeting(event) {
+  if (!event || event.all_day || !Number.isFinite(event.start_ms) || !Number.isFinite(event.end_ms)
+    || event.end_ms <= event.start_ms) return null;
+  const url = text(event.conference);
+  const match = /^https:\/\/([^/?#]+)(\/[^?#]*)?/.exec(url);
+  if (!match) return null;
+  const host = match[1], path = match[2] || '';
+  if (host === 'meet.google.com') {
+    const id = /^\/([a-z]{3}-[a-z]{4}-[a-z]{3})(?:\/|$)/.exec(path)?.[1];
+    return id ? { provider: 'meet', id } : null;
+  }
+  if (host === 'zoom.us' || host.endsWith('.zoom.us')) {
+    const id = /^\/(?:j|wc\/join)\/(\d{9,11})(?:\/|$)/.exec(path)?.[1];
+    return id ? { provider: 'zoom', id } : null;
+  }
+  if (['teams.microsoft.com', 'teams.live.com', 'teams.cloud.microsoft'].includes(host)) {
+    return /^\/(?:l\/meetup-join|meet)\//.test(path) ? { provider: 'teams', id: path } : null;
+  }
+  return null;
+}
+export function eventKey(event) {
+  const m = meeting(event);
+  return m ? m.provider + ':' + m.id + ':' + event.start_ms : '';
+}
+function windowKind(window) {
+  const app = text(window?.appId), title = text(window?.title);
+  if (!app || !title || /^(?:chat|calendar|activity|settings|calls)\s*[|–—-]/.test(title) || /(?:pre[- ]?join|preview|waiting room|you left|meeting (?:ended|has ended))/.test(title)) return null;
+  const browser = /^(?:google-chrome|chromium|chrome|brave|firefox|org\.mozilla\.firefox|microsoft-edge|msedge|vivaldi)(?:[.-]|$)/.test(app);
+  if (/^(?:zoom|us\.zoom\.xos|zoom\.real|com\.zoom\.zoom)(?:[.-]|$)/.test(app)) {
+    if (/^zoom (?:workplace|cloud meetings|settings|home)$/.test(title)) return null;
+    return { provider: 'zoom', title, generic: /^(?:zoom meeting|zoom - meeting)$/.test(title) };
+  }
+  if ((browser && /(?:google meet|\bmeet\b)/.test(title))) return { provider: 'meet', title, generic: false };
+  if ((browser || /^(?:teams|teams-for-linux|com\.microsoft\.teams)(?:[.-]|$)/.test(app))
+    && /microsoft teams/.test(title)) return { provider: 'teams', title, generic: false };
+  return null;
+}
+function matches(event, kind) {
+  const m = meeting(event);
+  if (!m || m.provider !== kind.provider) return false;
+  if (m.provider === 'meet' && kind.title.includes(m.id)) return true;
+  if (m.provider === 'zoom' && new RegExp('(^|\\D)' + m.id + '(\\D|$)').test(kind.title.replace(/[ -]/g, ''))) return true;
+  const title = text(event.title);
+  return title.length >= 4 && kind.title.split(/\s+[|–—-]\s+/).some(part => part === title);
+}
+
+// Once associated, a window cannot claim another occurrence merely because
+// the clock advanced. Closing it, or changing its title (e.g. a browser tab
+// switch), ends that association. Generic Zoom windows need one unambiguous
+// candidate, or a recent Join request plus a newly opened meeting window.
+export function observe(previous, windows, events, now, leadMinutes, intent = null) {
+  if (!Array.isArray(windows) || windows.length > MAX_WINDOWS || !Array.isArray(events)
+    || events.length > MAX_EVENTS || !Number.isFinite(now)) return [];
+  const lead = Math.max(0, Math.min(60, Number(leadMinutes) || 0)) * 60000;
+  const seen = new Set();
+  const candidates = events.filter(e => {
+    const key = eventKey(e);
+    if (!key || seen.has(key) || e.end_ms <= now || e.start_ms > now + lead) return false;
+    seen.add(key);
+    return true;
+  });
+  const records = Array.isArray(previous) ? previous.slice(0, MAX_WINDOWS) : [];
+  return windows.map(window => {
+    const key = text(window?.key), app = text(window?.appId), title = text(window?.title);
+    if (!key || !app || !title) return null;
+    const signature = app + '\n' + title;
+    const old = records.find(r => r.key === key);
+    if (old?.signature === signature) return old;
+    const kind = windowKind(window);
+    let found = kind ? candidates.filter(e => matches(e, kind)) : [];
+    if (kind?.generic) {
+      const providerEvents = candidates.filter(e => meeting(e).provider === kind.provider);
+      const intended = !old && intent && now >= intent.at && now - intent.at <= 90000
+        ? providerEvents.filter(e => eventKey(e) === intent.eventKey) : [];
+      found = intended.length === 1 ? intended : providerEvents;
+    }
+    return { key, signature, eventKey: found.length === 1 ? eventKey(found[0]) : '' };
+  }).filter(Boolean);
+}
+export function isPresent(records, event, now) {
+  const key = eventKey(event);
+  return !!key && event.start_ms <= now && now < event.end_ms
+    && Array.isArray(records) && records.slice(0, MAX_WINDOWS).some(r => r.eventKey === key);
+}

--- a/packaging/omarchy-plugin/Model.js
+++ b/packaging/omarchy-plugin/Model.js
@@ -38,8 +38,20 @@ function clock(ms) {
 var DAY_NAMES = ["SUNDAY", "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY"]
 var MONTH_NAMES = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"]
 
+function formattedDate(ms, format) {
+  var d = new Date(ms)
+  var y = d.getFullYear(), m = String(d.getMonth() + 1).padStart(2, "0"), day = String(d.getDate()).padStart(2, "0")
+  if (format === "iso") return y + "-" + m + "-" + day
+  if (format === "mdy") return m + "/" + day + "/" + y
+  if (format === "dmy") return day + "/" + m + "/" + y
+  var month = MONTH_NAMES[d.getMonth()]
+  if (format === "long-mdy") return month + " " + d.getDate() + ", " + y
+  return d.getDate() + " " + month + " " + y
+}
+
 // Section title for a day further out than tomorrow: "FRIDAY 22 AUG".
-function dayTitle(ms) {
+function dayTitle(ms, format) {
+  if (format && format !== "locale") return formattedDate(ms, format)
   var d = new Date(ms)
   return DAY_NAMES[d.getDay()] + " " + d.getDate() + " " + MONTH_NAMES[d.getMonth()]
 }
@@ -108,7 +120,7 @@ function endsText(ev, nowMs) {
 // syncs this is what keeps the list truthful. Rows beyond `cap` are cut from
 // the tail: losing the afternoon matters less than losing the meeting you
 // are in.
-function sections(events, nowMs, cap) {
+function sections(events, nowMs, cap, format) {
   if (!events) return []
   var today = dayStart(nowMs, 0)
   var ongoing = []
@@ -154,13 +166,13 @@ function sections(events, nowMs, cap) {
     out.push({ title: title, rows: kept })
   }
 
-  if (ongoing.length) push("ONGOING", ongoing)
   if (allDay.length) push("ALL DAY", allDay)
+  if (ongoing.length) push("ONGOING", ongoing)
   if (chosen === 0) push("UPCOMING", byOffset[0])
   else if (chosen === 1) push("TOMORROW", byOffset[1])
   // Title from the chosen day itself, not from an event's start instant —
   // an all-day start is a foreign-zone midnight and can misname the day.
-  else if (chosen > 1) push(dayTitle(dayStart(nowMs, chosen) + 43200000), byOffset[chosen])
+  else if (chosen > 1) push(dayTitle(dayStart(nowMs, chosen) + 43200000, format), byOffset[chosen])
   return out
 }
 
@@ -176,7 +188,8 @@ function isMultiDay(ev) {
 // the last covered day, which reads as the right local date for any
 // calendar-vs-machine zone skew under half a day (a 1 ms step does not —
 // verified against a Sofia calendar read from an IST machine).
-function untilText(ev) {
+function untilText(ev, format) {
+  if (format && format !== "locale") return "until " + formattedDate(ev.end_ms - 43200000, format)
   var d = new Date(ev.end_ms - 43200000)
   return "until " + d.getDate() + " " + MONTH_NAMES[d.getMonth()]
 }
@@ -218,13 +231,13 @@ function taskRows(feed, nowMs) {
       color: t.color || null,
       list: t.list || "",
       overdue: deadline <= nowMs,
-      label: taskLabel(t, nowMs)
+      label: taskLabel(t, nowMs, feed.panel ? feed.panel.date_format : null)
     })
   }
   return out
 }
 
-function taskLabel(t, nowMs) {
+function taskLabel(t, nowMs, format) {
   var deadline = t.all_day ? t.due_ms + 86400000 : t.due_ms
   if (deadline <= nowMs) return "OVERDUE"
   var today = dayStart(nowMs, 0)
@@ -232,5 +245,27 @@ function taskLabel(t, nowMs) {
   var offset = Math.floor((dayStart(anchor, 0) - today) / 86400000)
   if (offset <= 0) return t.all_day ? "today" : clock(t.due_ms)
   if (offset === 1) return "tomorrow"
-  return dayTitle(anchor)
+  return dayTitle(anchor, format)
+}
+
+// A full day retains completed rows, while future-only readers keep the
+// original sections contract. Past rows have their own quiet section.
+function agendaSections(feed, nowMs, cap) {
+  if (!feed || !feed.panel) return sections(feed ? feed.events : null, nowMs, cap)
+  if (Array.isArray(feed.panel.agenda_days)) {
+    var out = []
+    var days = feed.panel.agenda_days
+    var today = days.length ? days[0].events : []
+    function push(title, rows) { if (rows.length) out.push({title: title, rows: rows}) }
+    push("ALL DAY", today.filter(function(e) { return e.all_day }))
+    push("EARLIER TODAY", today.filter(function(e) { return !e.all_day && e.end_ms <= nowMs }))
+    push("ONGOING", today.filter(function(e) { return !e.all_day && e.start_ms <= nowMs && e.end_ms > nowMs }))
+    push("UPCOMING", today.filter(function(e) { return !e.all_day && e.start_ms > nowMs }))
+    for (var d = 1; d < days.length; d++) push(d === 1 ? "TOMORROW" : days[d].date_label, days[d].events)
+    return out
+  }
+  var past = feed.panel.events.filter(function(e) { return !e.all_day && e.end_ms <= nowMs })
+  var remaining = sections(feed.events, nowMs, cap, feed.panel.date_format)
+  if (past.length) remaining.splice(remaining.length && remaining[0].title === "ALL DAY" ? 1 : 0, 0, { title: "EARLIER TODAY", rows: past.slice(-cap) })
+  return remaining
 }

--- a/packaging/omarchy-plugin/Panel.qml
+++ b/packaging/omarchy-plugin/Panel.qml
@@ -3,9 +3,12 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import Quickshell
 import Quickshell.Io
+import Quickshell.Wayland
 import qs.Commons
 import qs.Ui
 import "Model.js" as Model
+import "Timeline.mjs" as Timeline
+import "MeetingPresence.mjs" as MeetingPresence
 
 // OmaCal's bar widget: a calendar glyph in the bar, and a popup listing what
 // is happening now and what is coming up, in the same visual grammar as the
@@ -31,6 +34,9 @@ Panel {
     function hide(): void { root.close() }
     function toggle(): void { root.toggle() }
     function openApp(): void { root.openApp() }
+    function preferences(): void { root.openApp("--preferences") }
+    function quickAdd(): void { root.openApp("--quick-add") }
+    function refresh(): void { feedFile.reload() }
     function syncNow(): string { root.syncNow(); return "ok" }
     function quitApp(): string { root.quitApp(); return "ok" }
   }
@@ -54,6 +60,44 @@ Panel {
 
   property var feed: null
   readonly property var events: feed ? feed.events : null
+  readonly property var day: feed && feed.panel ? feed.panel : null
+  readonly property var callEvent: Timeline.joinable(events || [], nowMs, day ? day.join_minutes : 5)
+  property var meetingWindows: []
+  property var meetingPresence: []
+  property int nextMeetingWindowKey: 0
+  property var joinIntent: null
+  readonly property bool meetingWindowOpen: MeetingPresence.isPresent(meetingPresence, callEvent, nowMs)
+  function observeMeetingWindows() {
+    if (!feed) return
+    var windows = ToplevelManager.toplevels.values
+    if (windows.length > 256) { meetingPresence = []; meetingWindows = []; return }
+    var current = [], snapshots = []
+    for (var i = 0; i < windows.length; i++) {
+      var window = windows[i]
+      var known = meetingWindows.find(function(row) { return row.window === window })
+      var key = known ? known.key : String(++nextMeetingWindowKey)
+      current.push({ window: window, key: key })
+      snapshots.push({ key: key, appId: window.appId, title: window.title })
+    }
+    meetingPresence = MeetingPresence.observe(meetingPresence, snapshots, events || [], nowMs,
+      day ? day.join_minutes : 5, joinIntent)
+    meetingWindows = current
+    if (joinIntent && nowMs - joinIntent.at > 90000) joinIntent = null
+  }
+  readonly property var barEvent: callEvent || runningEvent || nextEvent
+  readonly property bool showLabel: !barVertical && (!day || day.label) && !!barEvent
+  readonly property string barLabel: {
+    if (!barEvent) return ""
+    var ongoing = barEvent.start_ms <= nowMs
+    var minutes = Math.max(1, Math.ceil(((ongoing ? barEvent.end_ms : barEvent.start_ms) - nowMs) / 60000))
+    var duration = Timeline.countdownDuration(minutes)
+    var title = Model.title(barEvent)
+    if (title.length > 18) title = title.slice(0, 17) + "…"
+    return title + " @ " + displayClock(barEvent.start_ms) + "  " + (ongoing ? duration + " left" : "in " + duration)
+  }
+  function displayClock(ms) { return day && day.clocks[String(ms)] ? day.clocks[String(ms)] : Model.clock(ms) }
+  function displayTime(ev) { return ev.all_day ? "ALL DAY" : displayClock(ev.start_ms) + " – " + displayClock(ev.end_ms) }
+
 
   // Whether the OmaCal process itself is alive. The popup keeps showing the
   // last feed either way (a stale agenda beats a blank one), but the hero
@@ -61,7 +105,7 @@ Panel {
   // — a Quit that silently no-ops reads as broken, and was reported as such.
   property bool appRunning: true
   readonly property var taskRows: Model.taskRows(feed, nowMs)
-  readonly property var panelSections: Model.sections(events, nowMs, root.setting("maxEvents", 12))
+  readonly property var panelSections: Model.agendaSections(feed, nowMs, root.setting("maxEvents", 12))
   readonly property var runningEvent: Model.current(events, nowMs)
   readonly property var nextEvent: Model.nextAhead(events, nowMs)
   readonly property bool empty: panelSections.length === 0
@@ -78,7 +122,7 @@ Panel {
     && todayFeed.show === true
     && root.setting("showDate", true) === true
     && !barVertical
-  readonly property string dateText: todayFeed && todayFeed.day > 0 ? String(todayFeed.day) : ""
+  readonly property string dateText: todayFeed ? (todayFeed.label !== undefined ? todayFeed.label : todayFeed.day > 0 ? String(todayFeed.day) : "") : ""
 
   // The bar glyph turns urgent-coloured when a meeting is less than ten
   // minutes out — the glanceable version of "wrap this conversation up".
@@ -101,10 +145,9 @@ Panel {
   // when it ends is exactly the glance the bar is for.
   function heroMeta() {
     if (!appRunning) return "OmaCal is not running"
-    if (runningEvent)
-      return Model.title(runningEvent) + " · " + Model.endsText(runningEvent, nowMs)
-    if (nextEvent)
-      return Model.title(nextEvent) + " · " + Model.leadText(nextEvent.start_ms, nowMs)
+    if (barEvent)
+      return Model.title(barEvent) + " · " + (barEvent.start_ms <= nowMs
+        ? Model.endsText(barEvent, nowMs) : Model.leadText(barEvent.start_ms, nowMs))
     if (!feed) return "Waiting for OmaCal"
     return "Nothing scheduled"
   }
@@ -123,7 +166,7 @@ Panel {
     return ""
   }
 
-  // `ymd` optional: with it, the app lands on that day (a row's own date);
+  // `ymd` is a generated date or the fixed --quick-add action;
   // without, this is the plain "bring up the calendar" it always was.
   function openApp(ymd) {
     if (root.appRunning) {
@@ -186,7 +229,8 @@ Panel {
   // up the app — the two things a calendar row in a status bar is for.
   function activateRow(ev) {
     if (!ev) return
-    if (ev.conference) {
+    if (Timeline.joinable([ev], nowMs, day ? day.join_minutes : 5)) {
+      joinIntent = { eventKey: MeetingPresence.eventKey(ev), at: Date.now() }
       Qt.openUrlExternally(ev.conference)
       root.close()
     } else {
@@ -196,20 +240,14 @@ Panel {
     }
   }
 
-  // `j`: join the call most worth joining — the running meeting first,
-  // failing that the nearest upcoming one that has a link at all. The same
+  // `j`: join the call most worth joining — the next meeting inside its lead window,
+  // otherwise the ongoing call. The same
   // URL a row's own camera button would open; this is just the keyboard
   // reaching it without arrowing down.
   function joinCall() {
-    let pick = null
-    for (let i = 0; i < flatRows.length; i++) {
-      const r = flatRows[i]
-      if (!r.event || !r.event.conference) continue
-      if (r.inOngoing) { pick = r.event; break }
-      if (!pick) pick = r.event
-    }
-    if (pick) {
-      Qt.openUrlExternally(pick.conference)
+    if (callEvent) {
+      joinIntent = { eventKey: MeetingPresence.eventKey(callEvent), at: Date.now() }
+      Qt.openUrlExternally(callEvent.conference)
       root.close()
     }
   }
@@ -220,7 +258,10 @@ Panel {
     rowCursor = Math.max(0, Math.min(flatRows.length - 1, rowCursor + dy))
   }
 
-  implicitWidth: button.implicitWidth
+  readonly property bool showTray: !feed || feed.tray_icon !== false
+  visible: showTray
+  onShowTrayChanged: if (!showTray) root.close()
+  implicitWidth: showTray ? button.implicitWidth + (barJoin.visible ? barJoin.implicitWidth : 0) + (barTitle.visible ? barTitle.implicitWidth : 0) : 0
   implicitHeight: button.implicitHeight
 
   onOpenedChanged: if (opened) {
@@ -245,26 +286,52 @@ Panel {
     onTriggered: if (!appCheck.running) appCheck.running = true
   }
 
-  FileView {
+  Process {
     id: feedFile
-    path: root.feedPath
-    watchChanges: true
-    printErrors: false
-    onLoaded: root.feed = Model.parseFeed(text())
-    onFileChanged: reload()
-    onLoadFailed: root.feed = null
+    command: ["/usr/bin/python3", decodeURIComponent(Qt.resolvedUrl("read-feed.py").toString().replace(/^file:\/\//, "")), root.feedPath]
+    running: true
+    property bool reloadPending: false
+    function reload() { if (running) reloadPending = true; else running = true }
+    stdout: StdioCollector {
+      onStreamFinished: {
+        var parsed = text.length <= 1048576 ? Model.parseFeed(text) : null
+        if (parsed) {
+          parsed.events = Timeline.uniqueAllDay(parsed.events)
+          if (parsed.panel) {
+            parsed.panel.events = Timeline.uniqueAllDay(parsed.panel.events)
+            if (Array.isArray(parsed.panel.agenda_days))
+              parsed.panel.agenda_days.forEach(function(day) { day.events = Timeline.uniqueAllDay(day.events) })
+          }
+        }
+        root.feed = parsed
+      }
+    }
+    onExited: function(code) {
+      if (code !== 0) root.feed = null
+      if (reloadPending) { reloadPending = false; Qt.callLater(reload) }
+    }
   }
 
   Timer {
-    interval: root.opened ? 15000 : 60000
+    interval: 15000
     running: true
     repeat: true
-    onTriggered: root.nowMs = Date.now()
+    onTriggered: feedFile.reload()
+  }
+
+  Timer {
+    interval: root.opened || !!root.callEvent ? 1000 : 60000
+    running: true
+    repeat: true
+    onTriggered: { root.nowMs = Date.now(); root.observeMeetingWindows() }
   }
 
   BarIconButton {
     id: button
-    anchors.fill: parent
+    anchors.left: parent.left
+    anchors.top: parent.top
+    anchors.bottom: parent.bottom
+    width: implicitWidth
     bar: root.bar
     active: root.imminent
     dimmed: !root.appRunning || root.events === null || root.events.length === 0
@@ -276,20 +343,20 @@ Panel {
     slotSize: Style.bar.iconSlot
       + (root.showDate ? dateMetrics.width + Style.space(4) : 0)
     // The app's own mark, not a generic glyph: with the tray icon off this
-    // is omacal's one presence in the bar. Monochrome like its neighbours;
-    // urgent-tinted when a meeting is imminent, as the glyph was — and the
-    // date, when shown, is tinted with it: one voice, not two.
+    // is omacal's one presence in the bar. Preserve its orange brand dot.
     iconComponent: Component {
       Item {
         Row {
           anchors.centerIn: parent
-          spacing: root.showDate ? Style.space(4) : 0
+          spacing: root.showDate || root.showLabel ? Style.space(4) : 0
           OmacalMark {
             anchors.verticalCenter: parent.verticalCenter
             iconSize: Style.space(12)
+            dotColor: "#F97316"
             color: root.imminent ? root.urgent : button.foreground
           }
           Text {
+            textFormat: Text.PlainText
             anchors.verticalCenter: parent.verticalCenter
             visible: root.showDate
             text: root.dateText
@@ -298,12 +365,122 @@ Panel {
             font.pixelSize: Style.font.body
             font.weight: Font.DemiBold
           }
+
         }
       }
     }
     onPressed: function(buttonCode) {
-      if (buttonCode === Qt.MiddleButton) root.openApp()
-      else root.toggle()
+      if (buttonCode === Qt.LeftButton) root.toggle()
+      else if (buttonCode === Qt.RightButton) root.openApp("--quick-add")
+      else if (buttonCode === Qt.MiddleButton) root.openApp()
+    }
+  }
+
+  TextMetrics { id: labelMetrics; text: root.barLabel; font.family: root.fontFamily; font.pixelSize: Style.font.body }
+  BarIconButton {
+    id: barJoin
+    anchors.left: button.right
+    anchors.top: parent.top
+    anchors.bottom: parent.bottom
+    bar: root.bar
+    visible: !!root.callEvent && !root.barVertical
+    readonly property bool live: root.meetingWindowOpen
+    iconComponent: Component {
+      Item {
+        Text {
+          anchors.centerIn: parent
+          visible: !barJoin.live
+          text: ""
+          textFormat: Text.PlainText
+          font.family: barJoin.fontFamily
+          font.pixelSize: barJoin.fontSize
+          color: barJoin.foreground
+        }
+        Item {
+          anchors.centerIn: parent
+          width: Style.space(16)
+          height: Style.space(12)
+          visible: barJoin.live
+          readonly property color liveColor: "#ff7b86"
+          Rectangle {
+            id: cameraBody
+            x: 0
+            anchors.verticalCenter: parent.verticalCenter
+            width: Style.space(11)
+            height: Style.space(9)
+            radius: Style.space(2)
+            color: "transparent"
+            border.width: Style.space(1)
+            border.color: parent.liveColor
+            Rectangle {
+              anchors.centerIn: parent
+              width: Style.space(3)
+              height: width
+              radius: width / 2
+              color: cameraBody.border.color
+              SequentialAnimation on opacity {
+                running: barJoin.live && barJoin.visible
+                loops: Animation.Infinite
+                NumberAnimation { from: 0.4; to: 1; duration: 850; easing.type: Easing.InOutSine }
+                NumberAnimation { from: 1; to: 0.4; duration: 850; easing.type: Easing.InOutSine }
+              }
+            }
+          }
+          Canvas {
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            width: Style.space(5)
+            height: Style.space(8)
+            onPaint: {
+              var ctx = getContext("2d")
+              ctx.clearRect(0, 0, width, height)
+              ctx.strokeStyle = "#ff7b86"
+              ctx.lineWidth = Style.space(1)
+              ctx.beginPath()
+              ctx.moveTo(0.5, height * 0.3)
+              ctx.lineTo(width - 0.5, 0.5)
+              ctx.lineTo(width - 0.5, height - 0.5)
+              ctx.lineTo(0.5, height * 0.7)
+              ctx.closePath()
+              ctx.stroke()
+            }
+          }
+        }
+      }
+    }
+    tooltipText: root.callEvent ? (barJoin.live ? "Meeting window open · " : "Join ") + Model.title(root.callEvent) : ""
+    onPressed: root.joinCall()
+  }
+
+  BarIconButton {
+    id: barTitle
+    anchors.left: barJoin.visible ? barJoin.right : button.right
+    anchors.top: parent.top
+    anchors.bottom: parent.bottom
+    bar: root.bar
+    visible: root.showLabel
+    active: root.imminent
+    dimmed: !root.appRunning
+    slotSize: labelMetrics.advanceWidth + Style.space(8)
+    tooltipText: root.heroMeta()
+    iconComponent: Component {
+      Item {
+      Text {
+        anchors.centerIn: parent
+        textFormat: Text.PlainText
+        width: labelMetrics.advanceWidth
+        text: root.barLabel
+        elide: Text.ElideRight
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.body
+        color: root.imminent ? root.urgent : barTitle.foreground
+      }
+      }
+    }
+    onPressed: function(buttonCode) {
+      if (buttonCode === Qt.LeftButton) root.toggle()
+      else if (buttonCode === Qt.RightButton) root.openApp("--quick-add")
+      else if (buttonCode === Qt.MiddleButton) root.openApp()
     }
   }
 
@@ -325,7 +502,7 @@ Panel {
     open: root.opened
     focusTarget: keyCatcher
     contentWidth: panel.fittedContentWidth(Style.space(380))
-    contentHeight: panel.fittedContentHeight(column.implicitHeight, Style.space(560))
+    contentHeight: panel.fittedContentHeight(header.implicitHeight + column.implicitHeight + footer.implicitHeight + Style.space(24), panel.screenH > 0 ? panel.screenH * 0.8 : Style.space(560))
 
     PanelKeyCatcher {
       id: keyCatcher
@@ -334,7 +511,9 @@ Panel {
         if (!root.cursorActive) { root.cursorActive = true; return }
         root.moveCursor(dy)
       }
-      onActivateRequested: if (root.cursorActive) root.activateRow(root.flatRows[root.rowCursor])
+      onActivateRequested: {
+        if (root.cursorActive) root.activateRow(root.flatRows[root.rowCursor])
+      }
       onCloseRequested: root.close()
       onTabRequested: function(direction) { root.switchPanel(direction) }
       onTextKey: function(t) {
@@ -345,9 +524,110 @@ Panel {
         else if (t === "j" || t === "J") root.joinCall()
       }
 
+      Column {
+        id: header
+        anchors.top: parent.top
+        width: parent.width
+        spacing: Style.space(12)
+          PanelHero {
+            width: parent.width
+            title: "OmaCal"
+            meta: root.popupHeroMeta()
+            foreground: root.foreground
+            fontFamily: root.fontFamily
+            iconComponent: Component {
+              OmacalMark {
+                iconSize: Style.font.display
+                color: root.foreground
+                // Preserve the brand accent.
+                dotColor: "#F97316"
+              }
+            }
+            trailingControl: Component {
+              Row {
+                spacing: Style.space(8)
+                PanelActionButton {
+                  iconText: "+"
+                  foreground: root.foreground
+                  fontFamily: root.fontFamily
+                  tooltipText: "Add event with natural language"
+                  onClicked: root.openApp("--quick-add")
+                }
+                PanelActionButton {
+                  iconText: ""
+                  foreground: root.foreground
+                  fontFamily: root.fontFamily
+                  tooltipText: "OmaCal preferences"
+                  onClicked: root.openApp("--preferences")
+                }
+              PanelActionButton {
+                iconText: ""
+                foreground: root.foreground
+                fontFamily: root.fontFamily
+                onClicked: root.openApp()
+
+                tooltipText: "Open OmaCal"
+              }
+              }
+            }
+          }
+
+          Text {
+            textFormat: Text.PlainText
+            visible: !!root.day
+            width: parent.width
+            text: root.day ? (root.day.date_label || root.day.date) + " · " + Timeline.currentClock(root.nowMs, root.day.time_format, root.day.utc_offset_seconds === undefined ? -new Date(root.nowMs).getTimezoneOffset() * 60 : root.day.utc_offset_seconds) : ""
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.body
+          }
+
+      }
+
+      Column {
+            id: footer
+            anchors.bottom: parent.bottom
+            width: parent.width
+            spacing: Style.space(6)
+
+            PanelSeparator {
+              foreground: root.foreground
+            }
+
+            Row {
+              anchors.right: parent.right
+              spacing: Style.space(6)
+
+              PanelActionButton {
+                id: syncButton
+                iconText: ""
+                enabled: root.appRunning
+                foreground: root.foreground
+                fontFamily: root.fontFamily
+                onClicked: root.syncNow()
+
+                tooltipText: "Sync now"
+              }
+
+              PanelActionButton {
+                id: quitButton
+                iconText: root.appRunning ? "\uf011" : "\uf04b"
+                foreground: root.foreground
+                fontFamily: root.fontFamily
+                onClicked: root.appRunning ? root.quitApp() : root.openApp()
+
+                tooltipText: root.appRunning ? "Quit OmaCal" : "Start OmaCal"
+              }
+            }
+          }
+
       Flickable {
         id: panelFlick
-        anchors.fill: parent
+        anchors.top: header.bottom
+        anchors.bottom: footer.top
+        anchors.topMargin: Style.space(12)
+        anchors.bottomMargin: Style.space(12)
+        width: parent.width
         contentWidth: width
         contentHeight: column.implicitHeight
         clip: true
@@ -361,39 +641,10 @@ Panel {
           width: panelFlick.width
           spacing: Style.space(12)
 
-          PanelHero {
-            width: parent.width
-            title: "OmaCal"
-            meta: root.popupHeroMeta()
-            foreground: root.foreground
-            fontFamily: root.fontFamily
-            iconComponent: Component {
-              OmacalMark {
-                iconSize: Style.font.display
-                color: root.foreground
-                // The hero can afford the brand's own orange; the bar cannot.
-                dotColor: "#F97316"
-              }
-            }
-            trailingControl: Component {
-              PanelActionButton {
-                iconText: ""
-                foreground: root.foreground
-                fontFamily: root.fontFamily
-                onClicked: root.openApp()
-
-                PanelToolTip {
-                  visible: parent.containsMouse
-                  text: "Open OmaCal"
-                  fontFamily: root.fontFamily
-                }
-              }
-            }
-          }
-
           // Feed missing entirely: OmaCal has never run (or never on this
           // version). Say what to do, not just that there is nothing.
           Text {
+            textFormat: Text.PlainText
             visible: root.feed === null
             width: parent.width
             text: "No calendar data yet.\nStart OmaCal to populate this panel."
@@ -405,6 +656,7 @@ Panel {
           }
 
           Text {
+            textFormat: Text.PlainText
             visible: root.feed !== null && root.empty && root.taskRows.length === 0
             width: parent.width
             text: "Nothing scheduled in the next two weeks."
@@ -412,6 +664,16 @@ Panel {
             font.family: root.fontFamily
             font.pixelSize: Style.font.body
             horizontalAlignment: Text.AlignHCenter
+          }
+
+          Text {
+            visible: root.day && root.day.truncated === true
+            width: parent.width
+            text: "Showing the first 200 events. Open OmaCal for the complete calendar."
+            color: root.dim
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.caption
+            wrapMode: Text.WordWrap
           }
 
           Repeater {
@@ -433,27 +695,57 @@ Panel {
                 return base
               }
 
-              PanelSeparator {
-                visible: sectionColumn.index > 0
-                foreground: root.foreground
-              }
-
               PanelSectionHeader {
+                visible: sectionColumn.modelData.title !== "ONGOING"
                 text: sectionColumn.modelData.title
-                foreground: sectionColumn.modelData.title === "ONGOING" ? root.urgent : root.foreground
+                foreground: root.foreground
                 fontFamily: root.fontFamily
               }
 
-              Repeater {
-                model: sectionColumn.modelData.rows
+              RowLayout {
+                visible: sectionColumn.modelData.title === "ONGOING"
+                width: parent.width
+                spacing: Style.space(10)
 
-                EventRow {
-                  required property var modelData
-                  required property int index
-                  width: sectionColumn.width
-                  event: modelData
-                  flatIndex: sectionColumn.rowBase + index
-                  sectionTitle: sectionColumn.modelData.title
+                Text {
+                  text: "NOW"
+                  color: root.foreground
+                  font.family: root.fontFamily
+                  font.pixelSize: Style.font.caption
+                  font.bold: true
+                }
+                Item {
+                  Layout.fillWidth: true
+                  implicitHeight: Style.space(3)
+                  Accessible.role: root.runningEvent ? Accessible.ProgressBar : Accessible.StaticText
+                  Accessible.name: root.runningEvent ? "Elapsed time: " + Model.title(root.runningEvent) : "Current time"
+                  Accessible.description: root.runningEvent ? Math.round(Timeline.progress(root.runningEvent, root.nowMs) * 100) + "% elapsed" : "No event in progress"
+                  Rectangle { anchors.fill: parent; radius: height / 2; color: root.foreground; opacity: 0.15 }
+                  Rectangle {
+                    width: root.runningEvent ? parent.width * Timeline.progress(root.runningEvent, root.nowMs) : 0
+                    height: parent.height
+                    radius: height / 2
+                    color: root.urgent
+                  }
+                }
+              }
+
+              Column {
+                width: parent.width
+                spacing: 0
+
+                Repeater {
+                  model: sectionColumn.modelData.rows
+
+                  EventRow {
+                    required property var modelData
+                    required property int index
+                    width: sectionColumn.width
+                    event: modelData
+                    flatIndex: sectionColumn.rowBase + index
+                    lastInSection: index === sectionColumn.modelData.rows.length - 1
+                    sectionTitle: sectionColumn.modelData.title
+                  }
                 }
               }
             }
@@ -514,6 +806,7 @@ Panel {
                   }
 
                   Text {
+            textFormat: Text.PlainText
                     Layout.fillWidth: true
                     text: taskRow.modelData.title
                     color: root.foreground
@@ -523,6 +816,7 @@ Panel {
                   }
 
                   Text {
+            textFormat: Text.PlainText
                     text: taskRow.modelData.label
                     color: taskRow.modelData.overdue ? root.urgent : root.dim
                     font.family: root.fontFamily
@@ -534,50 +828,6 @@ Panel {
             }
           }
 
-          // The tray menu's remaining vocabulary, so the tray icon is
-          // dispensable: sync (s) and quit (q). Open lives on the hero.
-          Column {
-            width: parent.width
-            spacing: Style.space(6)
-
-            PanelSeparator {
-              foreground: root.foreground
-            }
-
-            Row {
-              anchors.right: parent.right
-              spacing: Style.space(6)
-
-              PanelActionButton {
-                id: syncButton
-                iconText: ""
-                enabled: root.appRunning
-                foreground: root.foreground
-                fontFamily: root.fontFamily
-                onClicked: root.syncNow()
-
-                PanelToolTip {
-                  visible: syncButton.containsMouse
-                  text: "Sync now"
-                  fontFamily: root.fontFamily
-                }
-              }
-
-              PanelActionButton {
-                id: quitButton
-                iconText: root.appRunning ? "\uf011" : "\uf04b"
-                foreground: root.foreground
-                fontFamily: root.fontFamily
-                onClicked: root.appRunning ? root.quitApp() : root.openApp()
-
-                PanelToolTip {
-                  visible: quitButton.containsMouse
-                  text: root.appRunning ? "Quit OmaCal" : "Start OmaCal"
-                  fontFamily: root.fontFamily
-                }
-              }
-            }
-          }
         }
       }
     }
@@ -588,13 +838,25 @@ Panel {
     property var event: null
     property int flatIndex: 0
     property string sectionTitle: ""
+    property bool lastInSection: true
     readonly property bool inOngoing: sectionTitle === "ONGOING"
+    opacity: event && !event.all_day && event.end_ms <= root.nowMs ? 0.5 : 1.0
     readonly property bool inAllDay: sectionTitle === "ALL DAY"
 
     hasCursor: root.cursorActive && root.rowCursor === flatIndex
     foreground: root.foreground
 
     implicitHeight: rowContent.implicitHeight + Style.spacing.rowPaddingX
+
+    Rectangle {
+      anchors.left: parent.left
+      anchors.bottom: parent.bottom
+      width: row.lastInSection ? 0 : parent.width
+      height: 1
+      color: "#808080"
+      // Past text is dimmed by the row, but separators stay equally subtle.
+      opacity: 0.2 / row.opacity
+    }
 
     MouseArea {
       anchors.fill: parent
@@ -628,6 +890,7 @@ Panel {
         spacing: Style.space(1)
 
         Text {
+          textFormat: Text.PlainText
           Layout.fillWidth: true
           text: Model.title(row.event)
           color: root.foreground
@@ -637,6 +900,7 @@ Panel {
         }
 
         Text {
+          textFormat: Text.PlainText
           Layout.fillWidth: true
           visible: text !== ""
           text: {
@@ -645,7 +909,7 @@ Panel {
             if (row.inOngoing) lead = Model.endsText(row.event, root.nowMs)
             // A single-day event under ALL DAY needs no caption — the
             // section header already says everything its dates could.
-            else if (row.inAllDay && Model.isMultiDay(row.event)) lead = Model.untilText(row.event)
+            else if (row.inAllDay && Model.isMultiDay(row.event)) lead = Model.untilText(row.event, root.day ? root.day.date_format : null)
             if (lead === "") return meta
             return meta === "" ? lead : lead + "  ·  " + meta
           }
@@ -657,11 +921,12 @@ Panel {
       }
 
       Text {
+          textFormat: Text.PlainText
         // In the ALL DAY section the time column would only repeat the
         // header, so the whole column goes.
         visible: !row.inAllDay
-        text: row.inAllDay ? "" : Model.timeText(row.event)
-        color: row.inOngoing ? root.urgent : root.foreground
+        text: row.inAllDay ? "" : root.displayTime(row.event)
+        color: root.foreground
         opacity: row.inOngoing ? 1.0 : 0.75
         font.family: root.fontFamily
         font.pixelSize: Style.font.bodySmall
@@ -669,20 +934,15 @@ Panel {
       }
 
       PanelActionButton {
-        visible: row.event !== null && !!row.event.conference
+        visible: !!Timeline.joinable(row.event ? [row.event] : [], root.nowMs, root.day ? root.day.join_minutes : 5)
         iconText: ""
-        // The running meeting's Join wears the urgent colour — it is the one
-        // button in the popup you are probably here to press.
-        foreground: row.inOngoing ? root.urgent : root.foreground
+        // Actionable text/icons use the readable foreground; red marks time.
+        foreground: root.foreground
         fontFamily: root.fontFamily
         Layout.alignment: Qt.AlignVCenter
         onClicked: root.activateRow(row.event)
 
-        PanelToolTip {
-          visible: parent.containsMouse
-          text: "Join the call"
-          fontFamily: root.fontFamily
-        }
+        tooltipText: "Join the call"
       }
     }
   }

--- a/packaging/omarchy-plugin/README.md
+++ b/packaging/omarchy-plugin/README.md
@@ -1,16 +1,24 @@
 # OmaCal bar widget for the Omarchy shell
 
-An Omarchy 4 `bar-widget` plugin: a calendar icon in the bar, and a popup —
-in the same visual grammar as the stock network and bluetooth panels —
-listing what is happening **now** and the rest of **today's** agenda: time,
-title, location, headcount, your RSVP state, and a join button when the
-event carries a conferencing link. When today has nothing left, the popup
-shows the nearest day that does (an empty Saturday is skipped straight to
-Sunday's plans); multi-day events you are inside appear under ONGOING.
-The icon takes the bar's urgent colour when a meeting is less than ten
-minutes out.
+An Omarchy 4 `bar-widget` plugin. The bar shows the current or next event,
+its start time, and a countdown (`Design sync @ 13:30  39m left`). A camera
+button beside it joins the eligible call without opening the popup.
 
-All data comes from the feed OmaCal itself writes to
+The agenda keeps completed events under EARLIER TODAY, dims them, and draws
+elapsed progress beside NOW for an ongoing event. Its header and footer stay
+visible while events scroll, with the popup capped at 80% of the screen height.
+The number of agenda days follows the Week view preference.
+
+In **OmaCal → Settings → Menu bar**, show/hide the meeting label and choose
+when Join appears.
+The same preferences control the macOS popup: show/hide the bar label and
+choose when Join appears (at start time, or 1–60 minutes before). The default
+is five minutes; Join remains available until the meeting ends. Calendar
+selection and conference links continue to come from OmaCal.
+
+Settings changes refresh the widget immediately through IPC. The widget also
+checks the local feed every 15 seconds and when opened. All data comes from
+the feed OmaCal itself writes to
 `$XDG_STATE_HOME/omacal/upcoming.json` (default `~/.local/state/...`; see
 `src-tauri/src/upcoming.rs` for the contract). The widget never touches the
 app's database or the network, so without OmaCal it simply shows a quiet
@@ -42,17 +50,19 @@ so hack in the repo checkout, not in `~/.config`.)
 ## Drive it
 
 - Click the bar icon (or `omarchy-shell omacal.upcoming toggle`) to open.
+- Right-click opens OmaCal’s existing natural-language Quick Add form.
 - Middle-click the icon opens the OmaCal app directly.
 - In the popup: arrows move, Enter joins the call (or opens the app),
-  `j` joins the running meeting's call (or the nearest one with a link),
+  `J` joins the eligible call,
   `o` opens the app, `s` syncs now, `q` quits OmaCal, `r` reloads the
   feed, Esc closes. Sync and Quit also sit at the popup's foot.
 - A row with a joinable link shows a camera button; on the running
   meeting it wears the urgent colour. Zoom, Meet, Teams, Webex and
   Jitsi links are recognised even when the invitation only carries
   them in its location field.
-- Clicking a row joins its call when there is one, and opens OmaCal
-  otherwise.
+- Clicking a row joins its call inside the configured Join window, and opens
+  OmaCal on the event's date otherwise. Day-view arrows select timed events;
+  Enter activates the selected event.
 
 ## One icon, not two
 
@@ -60,8 +70,45 @@ The bar button is OmaCal's own mark, and the popup carries everything the
 app's tray menu does — open, sync now, quit (the latter two need OmaCal ≥
 0.1.10, which accepts `--sync-now` and `--quit` on a second invocation).
 So with this widget installed the tray icon is redundant: turn it off in
-OmaCal's **Settings → General → "Show the tray icon"**, and the mark in
-the bar becomes the app's one presence.
+the shell's tray settings. **OmaCal → Settings → Menu bar → Show the tray icon**
+controls the OmaCal widget as well as its native tray icon.
 
-The `maxEvents` setting (default 12) caps the rows shown; edit it from the
-bar's widget settings or in `shell.json`.
+The `maxEvents` setting (default 12) caps each of the agenda's past and
+remaining slices; edit it from the bar's widget settings or in `shell.json`.
+The agenda snapshot includes completed events, capped at 200 with a visible
+notice if there are more. Times use OmaCal's display clock. The original
+upcoming-only feed remains compatible with older readers.
+
+`Timeline.mjs` supplies the same elapsed-progress and Join-window
+calculations to this widget and the macOS webview. The app embeds it and
+the shared agenda helpers alongside the existing plugin files.
+
+The shell reads snapshots through the bundled `read-feed.py`, using the
+system `/usr/bin/python3` (no Python packages or provider CLIs). It opens the
+state file once without following links or blocking on special files, checks
+ownership and type, reads at most 2 MiB plus one sentinel byte, and has a
+two-second deadline. Malformed input is refused, text is capped and cleaned,
+and stdout is limited to 1 MiB, checked again before QML parses it. Failures
+leave the widget in its existing unavailable-data state.
+
+### Meeting window indicator
+
+The menu-bar camera has a red outline and a pulsing dot only while its selected
+meeting is scheduled to run **and a matching meeting window is open**. This is
+window presence, not confirmation that audio/video connected or that your camera
+is enabled. The tooltip says “Meeting window open.”
+
+On Omarchy/Wayland, OmaCal observes window app IDs and titles locally. Meet codes
+and meeting titles identify Google Meet and Teams windows; Zoom meeting IDs or
+meeting titles identify named Zoom windows. A generic “Zoom Meeting” window is
+associated only with an unambiguous eligible calendar meeting, or with a recent
+OmaCal Join request when a new meeting window opens. Clicking Join alone never
+activates the indicator. Window associations do not move to another occurrence
+when the clock advances. Closing the window or changing tabs clears the match.
+
+Unsupported/localized titles, generic Teams windows, and browser meetings hidden
+behind another tab can remain neutral. A provider's lobby and connected call may
+share a title, so an open-window match is deliberately not labeled “connected.”
+No browser extension, browser history access, microphone access, or network
+request is involved. Observation is bounded to 256 windows/events and 1,024
+characters per input field; oversized or ambiguous input stays neutral.

--- a/packaging/omarchy-plugin/Timeline.d.mts
+++ b/packaging/omarchy-plugin/Timeline.d.mts
@@ -1,0 +1,11 @@
+export interface Event {
+  title: string | null; start_ms: number; end_ms: number; all_day: boolean;
+  conference?: string | null; color?: string | null; calendar?: string | null;
+}
+export function progress(event: Event, now: number): number;
+export function joinable<T extends Event>(events: T[], now: number, minutes: number): T | null;
+export function uniqueAllDay<T extends Event>(events: T[]): T[];
+
+export function currentClock(ms: number, format: '12h' | '24h', offsetSeconds: number): string;
+
+export function countdownDuration(minutes: number): string;

--- a/packaging/omarchy-plugin/Timeline.mjs
+++ b/packaging/omarchy-plugin/Timeline.mjs
@@ -1,0 +1,39 @@
+// Shared by the QML widget and the webview popup. All positions use real
+// instants, including the repeated/missing hour on daylight-saving days.
+export function progress(event, now) {
+  return Math.max(0, Math.min(1, (now - event.start_ms) / Math.max(1, event.end_ms - event.start_ms)));
+}
+export function joinable(events, now, minutes) {
+  return (events || []).filter(e => !e.all_day && e.end_ms > now
+    && e.start_ms <= now + Math.max(0, Math.min(60, minutes)) * 60000
+    && /^https?:\/\//.test(e.conference || ''))
+    .sort((a, b) => {
+      const aNext = a.start_ms > now, bNext = b.start_ms > now;
+      if (aNext !== bNext) return aNext ? -1 : 1;
+      return aNext ? a.start_ms - b.start_ms : b.start_ms - a.start_ms;
+    })[0] || null;
+}
+// Presentation only: preserve the first calendar's color and never merge
+// unnamed entries or entries with different date spans.
+export function uniqueAllDay(events) {
+  const seen = new Set();
+  return (events || []).filter(event => {
+    if (!event.all_day || !event.title) return true;
+    const key = JSON.stringify([event.title, event.start_ms, event.end_ms]);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function currentClock(ms, format, offsetSeconds) {
+  const d = new Date(ms + offsetSeconds * 1000);
+  const h = d.getUTCHours(), m = String(d.getUTCMinutes()).padStart(2, '0');
+  return format === '12h' ? `${h % 12 || 12}:${m}${h < 12 ? 'am' : 'pm'}` : `${String(h).padStart(2, '0')}:${m}`;
+}
+
+export function countdownDuration(minutes) {
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60), remainder = minutes % 60;
+  return `${hours}h${remainder ? ` ${remainder}m` : ''}`;
+}

--- a/packaging/omarchy-plugin/manifest.json
+++ b/packaging/omarchy-plugin/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "omacal.upcoming",
   "name": "OmaCal upcoming events",
-  "version": "1.7.0",
+  "version": "1.10.1",
   "author": "OmaCal",
   "description": "Current and upcoming Google Calendar events, fed by the OmaCal app",
   "kinds": [

--- a/packaging/omarchy-plugin/read-feed.py
+++ b/packaging/omarchy-plugin/read-feed.py
@@ -1,0 +1,86 @@
+#!/usr/bin/python3
+"""Read one bounded snapshot for the shell; never wait on a FIFO or follow a link."""
+import json
+import os
+import signal
+import stat
+import sys
+
+INPUT_LIMIT = 2 * 1024 * 1024
+OUTPUT_LIMIT = 1024 * 1024 - 1
+
+
+def clean(value, depth=0):
+    if depth > 10:
+        raise ValueError('nested feed')
+    if isinstance(value, str):
+        return ''.join(c for c in value[:2048] if ord(c) >= 32
+                       and not 127 <= ord(c) <= 159
+                       and ord(c) not in {0x61c, 0x200e, 0x200f, *range(0x202a, 0x202f), *range(0x2066, 0x206a)})
+    if isinstance(value, list):
+        return [clean(v, depth + 1) for v in value[:200]]
+    if isinstance(value, dict):
+        return {k: clean(v, depth + 1) for k, v in list(value.items())[:600] if len(k) <= 64}
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    raise ValueError('invalid field')
+
+
+def events_valid(events):
+    # The app can publish point-in-time events. Rejecting an equal start/end
+    # here blanks the entire widget, including every other upcoming meeting.
+    return isinstance(events, list) and len(events) <= 200 and all(isinstance(e, dict)
+        and all(type(e.get(k)) in (int, float) and abs(e[k]) < 8640000000000000 for k in ('start_ms', 'end_ms'))
+        and e['end_ms'] >= e['start_ms'] and type(e.get('all_day')) is bool
+        and all(e.get(k) is None or isinstance(e[k], str) for k in ('title', 'color', 'conference', 'location', 'calendar', 'response'))
+        for e in events)
+
+
+def read_feed(path):
+    fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK | os.O_CLOEXEC)
+    with os.fdopen(fd, 'rb') as source:
+        info = os.fstat(source.fileno())
+        if not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid() or info.st_size > INPUT_LIMIT:
+            raise ValueError('unexpected feed file')
+        snapshot = source.read(INPUT_LIMIT + 1)
+    if len(snapshot) > INPUT_LIMIT:
+        raise ValueError('feed too large')
+    feed = json.loads(snapshot)
+    if not isinstance(feed, dict) or not events_valid(feed.get('events')):
+        raise ValueError('invalid events')
+    panel = feed.get('panel')
+    if panel is not None:
+        if not isinstance(panel, dict) or not events_valid(panel.get('events')):
+            raise ValueError('invalid day')
+        if 'agenda_days' in panel:
+            days = panel['agenda_days']
+            if not isinstance(days, list) or not 1 <= len(days) <= 7 or not all(
+                isinstance(d, dict) and isinstance(d.get('date_label'), str) and events_valid(d.get('events')) for d in days
+            ) or sum(len(d['events']) for d in days) > 200:
+                raise ValueError('invalid agenda days')
+        if not all(type(panel.get(k)) is int for k in ('day_start_ms', 'day_end_ms', 'join_minutes')):
+            raise ValueError('invalid day clock')
+        if not 0 < panel['day_end_ms'] - panel['day_start_ms'] <= 26 * 3600000 or not 0 <= panel['join_minutes'] <= 60:
+            raise ValueError('invalid day bounds')
+        if not isinstance(panel.get('clocks'), dict) or not isinstance(panel.get('hours'), list):
+            raise ValueError('invalid clocks')
+        if any(abs(panel[k]) >= 8640000000000000 for k in ('day_start_ms', 'day_end_ms')):
+            raise ValueError('day out of range')
+        if not all(type(panel.get(k)) is bool for k in ('label',)):
+            raise ValueError('invalid preferences')
+        if len(panel['hours']) > 26 or not all(type(h) is int and panel['day_start_ms'] <= h < panel['day_end_ms'] for h in panel['hours']):
+            raise ValueError('invalid hours')
+        if len(panel['clocks']) > 600 or not all(isinstance(v, str) and len(v) <= 32 for v in panel['clocks'].values()):
+            raise ValueError('invalid labels')
+    result = json.dumps(clean(feed), ensure_ascii=True, allow_nan=False, separators=(',', ':'))
+    if len(result) > OUTPUT_LIMIT:
+        raise ValueError('result too large')
+    return result
+
+
+if __name__ == '__main__':
+    signal.alarm(2)
+    try:
+        print(read_feed(sys.argv[1]))
+    except (OSError, ValueError, TypeError, IndexError, RecursionError):
+        sys.exit(1)

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for the main window",
-  "windows": ["main"],
+  "windows": ["main", "menubar"],
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -1259,7 +1259,7 @@ mod tests {
     /// usage instead of syncing.
     #[test]
     fn everything_the_gui_owns_falls_through() {
-        for s in ["", "--sync-now", "--quit", "2026-09-01"] {
+        for s in ["", "--sync-now", "--quit", "--quick-add", "2026-09-01"] {
             assert_eq!(parse(&argv(s)), None, "{s:?} was claimed by the CLI");
         }
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -39,6 +39,7 @@ mod tasks;
 mod theme;
 mod theme_watch;
 mod tray;
+mod menubar;
 mod tray_date;
 mod tz_watch;
 #[cfg(target_os = "linux")]
@@ -851,7 +852,6 @@ where
         };
 
         let client = omacal_google::CalendarClient::new(api_base, &access_token);
-
         // Names can change without reconnecting an account. Update only known
         // calendars: this must not import or re-enable calendars during sync.
         if let Err(e) = refresh_calendar_names(pool, *account_id, &client).await {
@@ -1288,6 +1288,8 @@ fn single_instance_plugin() -> tauri::plugin::TauriPlugin<tauri::Wry> {
                     }
                 }
                 tray::TrayAction::Open => tray::show_main_window(app),
+                tray::TrayAction::QuickAdd => tray::quick_add(app),
+                tray::TrayAction::Preferences => tray::preferences(app),
             }
         },
     );
@@ -1316,6 +1318,12 @@ pub fn run() {
     #[allow(unused_mut)]
     let mut builder = tauri::Builder::default()
         .manage(SignInAttempt::default())
+        .manage(tray::PreferencesRequest(std::sync::atomic::AtomicBool::new(
+            tray::instance_action(&std::env::args().collect::<Vec<_>>()) == tray::TrayAction::Preferences,
+        )))
+        .manage(tray::QuickAddRequest(std::sync::atomic::AtomicBool::new(
+            tray::instance_action(&std::env::args().collect::<Vec<_>>()) == tray::TrayAction::QuickAdd,
+        )))
         // First, before every other plugin, per its own docs — a second
         // process must be turned away before anything else initialises.
         // Closing the window only hides omacal (see `tray`), so "start it
@@ -1596,6 +1604,13 @@ pub fn run() {
             Ok(())
         })
         .on_window_event(|window, event| match event {
+            tauri::WindowEvent::Focused(false) if window.label() == "menubar" => {
+                let _ = window.hide();
+            }
+            tauri::WindowEvent::CloseRequested { api, .. } if window.label() == "menubar" => {
+                api.prevent_close();
+                let _ = window.hide();
+            }
             tauri::WindowEvent::Focused(true) => {
                 sync_loop::request_now(window.app_handle());
                 // The update notice rides the same "the user is back" signal,
@@ -1644,6 +1659,8 @@ pub fn run() {
             get_big_year,
             get_status,
             take_open_date,
+            tray::take_quick_add,
+            tray::take_preferences,
             sign_in,
             cancel_sign_in,
             sync_now,
@@ -1685,6 +1702,9 @@ pub fn run() {
             settings::set_list_mode,
             settings::set_hour_height,
             settings::set_show_date,
+            settings::set_menubar_preferences,
+            menubar::menubar_feed,
+            menubar::menubar_action,
             settings::set_fallback_reminders,
             settings::set_default_calendar,
             settings::set_default_event_duration,

--- a/src-tauri/src/menubar.rs
+++ b/src-tauri/src/menubar.rs
@@ -1,0 +1,70 @@
+//! The menu bar's graphical popup. Data stays in the existing calendar feed;
+//! this window owns no calendar store, authentication, or sync loop.
+use tauri::{AppHandle, Manager};
+
+pub(crate) fn toggle(app: &AppHandle, rect: tauri::Rect) -> tauri::Result<()> {
+    let window = match app.get_webview_window("menubar") {
+        Some(w) => w,
+        None => tauri::WebviewWindowBuilder::new(app, "menubar",
+                tauri::WebviewUrl::App("index.html?menubar".into()))
+            .title("OmaCal agenda").inner_size(420.0, 600.0)
+            .decorations(false).resizable(false).always_on_top(true)
+            .skip_taskbar(true).visible(false).build()?,
+    };
+    if window.is_visible()? { return window.hide(); }
+    let scale = window.scale_factor()?;
+    let point = rect.position.to_physical::<f64>(scale);
+    let size = rect.size.to_physical::<f64>(scale);
+    let monitor = window.monitor_from_point(point.x, point.y)?;
+    let scale = monitor.as_ref().map(|m| m.scale_factor()).unwrap_or(scale);
+    let width = 420.0 * scale;
+    let mut x = point.x + size.width - width;
+    let mut y = point.y + size.height;
+    if let Some(m) = monitor {
+        let area = m.work_area();
+        x = x.max(area.position.x as f64)
+            .min((area.position.x as f64 + area.size.width as f64 - width).max(area.position.x as f64));
+        y = y.max(area.position.y as f64);
+        let height = (area.position.y as f64 + area.size.height as f64 - y).min(m.size().height as f64 * 0.8).max(200.0 * scale);
+        window.set_size(tauri::PhysicalSize::new(width, height))?;
+    }
+    window.set_position(tauri::PhysicalPosition::new(x, y))?;
+    window.show()?;
+    window.set_focus()
+}
+
+#[tauri::command]
+pub async fn menubar_feed(state: tauri::State<'_, crate::AppState>) -> Result<crate::upcoming::Feed, String> {
+    crate::upcoming::current(&state.pool, crate::now_ms()).await.map_err(|e| crate::errors::user_facing(&e))
+}
+
+pub(crate) fn joinable(feed: &crate::upcoming::Feed, now: i64) -> Option<&crate::upcoming::FeedEvent> {
+    let early = i64::from(feed.panel.as_ref().map(|p| p.join_minutes).unwrap_or(5)) * 60_000;
+    feed.events.iter().filter(|e| !e.all_day && e.start_ms <= now + early && e.end_ms > now
+        && e.conference.as_deref().is_some_and(|url| url.starts_with("https://") || url.starts_with("http://")))
+        .min_by_key(|e| (e.start_ms <= now, if e.start_ms > now { i128::from(e.start_ms) } else { -i128::from(e.start_ms) }))
+}
+
+#[tauri::command]
+pub async fn menubar_action(app: AppHandle, state: tauri::State<'_, crate::AppState>, action: String) -> Result<(), String> {
+    match action.as_str() {
+        "close" => {},
+        "open" => crate::tray::show_main_window(&app),
+        "preferences" => crate::tray::preferences(&app),
+        "quick-add" => crate::tray::quick_add(&app),
+        "sync" => { crate::sync_loop::request_now(&app); return Ok(()); },
+        "quit" => app.exit(0),
+        "join" => {
+            let now = crate::now_ms();
+            let feed = crate::upcoming::current(&state.pool, now).await.map_err(|e| e.to_string())?;
+            let event = joinable(&feed, now).ok_or("No meeting is ready to join.")?;
+            crate::browser::open_external(event.conference.as_deref().unwrap()).map_err(|e| e.to_string())?;
+        },
+        date => match crate::tray::action_for(&format!("at:{date}")) {
+            Some(crate::tray::TrayAction::OpenAt(date)) => crate::tray::open_at(&app, &date),
+            _ => return Err("Unknown menu bar action.".into()),
+        },
+    }
+    if let Some(w) = app.get_webview_window("menubar") { let _ = w.hide(); }
+    Ok(())
+}

--- a/src-tauri/src/omarchy_plugin.rs
+++ b/src-tauri/src/omarchy_plugin.rs
@@ -39,6 +39,9 @@ const PLUGIN_ID: &str = "omacal.upcoming";
 const FILES: &[(&str, &str)] = &[
     ("manifest.json", include_str!("../../packaging/omarchy-plugin/manifest.json")),
     ("Panel.qml", include_str!("../../packaging/omarchy-plugin/Panel.qml")),
+    ("read-feed.py", include_str!("../../packaging/omarchy-plugin/read-feed.py")),
+    ("MeetingPresence.mjs", include_str!("../../packaging/omarchy-plugin/MeetingPresence.mjs")),
+    ("Timeline.mjs", include_str!("../../packaging/omarchy-plugin/Timeline.mjs")),
     ("Model.js", include_str!("../../packaging/omarchy-plugin/Model.js")),
     ("OmacalMark.qml", include_str!("../../packaging/omarchy-plugin/OmacalMark.qml")),
     ("README.md", include_str!("../../packaging/omarchy-plugin/README.md")),

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -400,6 +400,8 @@ pub struct AppSettings {
     /// widget can still opt out on its own side. Off by default: the mark
     /// is what says which app it is at a glance.
     pub show_date: bool,
+    pub menubar_label: bool,
+    pub menubar_join_minutes: u32,
     /// Pixels per hour in Day and Week (2026-09-03): what a pinch,
     /// Ctrl+scroll or Ctrl+=/- left the grid at. Here for `list_mode`'s
     /// reason — a zoom that lasted one session would be redone every
@@ -654,6 +656,9 @@ pub(crate) async fn read_settings_with(pool: &SqlitePool, baseline: u8) -> AppSe
         // The mark unless the row says otherwise, for `list_mode`'s reason:
         // a hand-edited value must land on what the app has always drawn.
         show_date: read(pool, SHOW_DATE_KEY).await.map(|v| v == "1").unwrap_or(false),
+        menubar_label: read(pool, "menubar_label").await.as_deref() != Some("0"),
+        menubar_join_minutes: read(pool, "menubar_join_minutes").await
+            .and_then(|v| v.parse().ok()).filter(|v| *v <= 60).unwrap_or(5),
         // **Clamped, not discarded.** A number outside the range is still an
         // answer to "how tall do you like your hours" — when the floor rose
         // from 30 to 48, discarding sent everyone who had zoomed out past it
@@ -1039,6 +1044,7 @@ pub async fn set_tray_icon(
         .await
         .map_err(|e| crate::errors::user_facing(&e))?;
     crate::tray::set_visible(&app, on);
+    refresh_menu_surfaces(&app, &state).await;
     Ok(read_settings(&state.pool).await)
 }
 
@@ -1307,7 +1313,7 @@ pub async fn set_show_date(
     write(&state.pool, SHOW_DATE_KEY, if on { "1" } else { "0" })
         .await
         .map_err(|e| crate::errors::user_facing(&e))?;
-    crate::tray::refresh(&app);
+    refresh_menu_surfaces(&app, &state).await;
     Ok(read_settings(&state.pool).await)
 }
 
@@ -1331,6 +1337,31 @@ pub(crate) async fn refresh_menu_surfaces(app: &tauri::AppHandle, state: &AppSta
     }
 }
 
+/// Shared preferences for the Omarchy widget and macOS menu bar popup.
+#[tauri::command]
+pub async fn set_menubar_preferences(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+    label: bool,
+    join_minutes: u32,
+) -> Result<AppSettings, String> {
+    store_menubar_preferences(&state.pool, label, join_minutes).await?;
+    refresh_menu_surfaces(&app, &state).await;
+    Ok(read_settings(&state.pool).await)
+}
+
+async fn store_menubar_preferences(pool: &SqlitePool, label: bool, join_minutes: u32) -> Result<(), String> {
+    if join_minutes > 60 { return Err("Choose a Join window from 0 to 60 minutes.".into()); }
+    let mut tx = pool.begin().await.map_err(|e| e.to_string())?;
+    for (key, value) in [
+        ("menubar_label", if label { "1".into() } else { "0".into() }),
+        ("menubar_join_minutes", join_minutes.to_string()),
+    ] {
+        sqlx::query("INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value")
+            .bind(key).bind(value).execute(&mut *tx).await.map_err(|e| e.to_string())?;
+    }
+    tx.commit().await.map_err(|e| e.to_string())
+}
 
 /// Stores the hour height, clamped rather than refused: the value comes off
 /// a gesture, and the honest answer to "a little past the end" is the end,
@@ -1350,8 +1381,7 @@ pub async fn set_hour_height(
 #[tauri::command]
 pub async fn set_date_format(app: tauri::AppHandle, state: tauri::State<'_, AppState>, format: DateFormat) -> Result<AppSettings, String> {
     write(&state.pool, "date_format", format.as_str()).await.map_err(|e| crate::errors::user_facing(&e))?;
-    crate::upcoming::refresh(&state.pool, state.demo).await;
-    crate::tray::refresh(&app);
+    refresh_menu_surfaces(&app, &state).await;
     Ok(read_settings(&state.pool).await)
 }
 
@@ -1360,12 +1390,14 @@ pub async fn set_date_format(app: tauri::AppHandle, state: tauri::State<'_, AppS
 /// [`TimeFormat`] has no third variant for a caller to send.
 #[tauri::command]
 pub async fn set_time_format(
+    app: tauri::AppHandle,
     state: tauri::State<'_, AppState>,
     format: TimeFormat,
 ) -> Result<AppSettings, String> {
     write(&state.pool, TIME_FORMAT_KEY, format.as_str())
         .await
         .map_err(|e| crate::errors::user_facing(&e))?;
+    refresh_menu_surfaces(&app, &state).await;
     Ok(read_settings(&state.pool).await)
 }
 
@@ -1433,12 +1465,15 @@ pub async fn set_week_starts_today(
 /// the backend to allocate an arbitrary number of day columns.
 #[tauri::command]
 pub async fn set_week_view_days(
+    app: tauri::AppHandle,
     state: tauri::State<'_, AppState>,
     days: u8,
 ) -> Result<AppSettings, String> {
-    set_week_view_days_impl(&state.pool, days)
+    let result = set_week_view_days_impl(&state.pool, days)
         .await
-        .map_err(|e| crate::errors::user_facing(&e))
+        .map_err(|e| crate::errors::user_facing(&e))?;
+    refresh_menu_surfaces(&app, &state).await;
+    Ok(result)
 }
 
 async fn set_week_view_days_impl(pool: &SqlitePool, days: u8) -> anyhow::Result<AppSettings> {
@@ -1455,6 +1490,22 @@ mod tests {
 
     async fn pool() -> SqlitePool {
         omacal_store::connect_memory().await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn menubar_preferences_persist_and_refuse_invalid_windows_atomically() {
+        let p = pool().await;
+        let initial = read_settings(&p).await;
+        assert!(initial.menubar_label);
+        assert_eq!(initial.menubar_join_minutes, 5);
+        store_menubar_preferences(&p, false, 0).await.unwrap();
+        let stored = read_settings(&p).await;
+        assert!(!stored.menubar_label);
+        assert_eq!(stored.menubar_join_minutes, 0);
+        assert!(store_menubar_preferences(&p, true, 61).await.is_err());
+        assert!(!read_settings(&p).await.menubar_label);
+        store_menubar_preferences(&p, true, 60).await.unwrap();
+        assert_eq!(read_settings(&p).await.menubar_join_minutes, 60);
     }
 
     /// A fresh install has written none of these, and that is the ordinary

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -21,6 +21,8 @@ pub(crate) const MENU: [(&str, &str); 3] =
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum TrayAction {
     Open,
+    QuickAdd,
+    Preferences,
     /// Open a meeting's conference link — the one thing a menu bar does
     /// better than a window, and the reason the macOS section exists
     /// (spec 2026-08-29 §2). Carries the URL the feed already resolved.
@@ -55,6 +57,10 @@ pub(crate) fn instance_action(argv: &[String]) -> TrayAction {
         TrayAction::Quit
     } else if argv.iter().any(|a| a == "--sync-now") {
         TrayAction::SyncNow
+    } else if argv.iter().any(|a| a == "--preferences") {
+        TrayAction::Preferences
+    } else if argv.iter().any(|a| a == "--quick-add") {
+        TrayAction::QuickAdd
     } else if let Some(ymd) = argv.iter().skip(1).find_map(|a| parse_date(a)) {
         TrayAction::OpenAt(ymd)
     } else if let Some(path) = argv.iter().skip(1).find_map(|a| calendar_file(a)) {
@@ -306,7 +312,7 @@ fn zoned(ms: i64, tz: &jiff::tz::TimeZone) -> jiff::Zoned {
 /// trustworthy. The process's zone already honours the display-timezone
 /// setting — `apply_display_tz_early` exports `TZ` before anything renders —
 /// so the system zone *is* the user's chosen zone.
-fn clock(ms: i64, tz: &jiff::tz::TimeZone, fmt: crate::settings::TimeFormat) -> String {
+pub(crate) fn clock(ms: i64, tz: &jiff::tz::TimeZone, fmt: crate::settings::TimeFormat) -> String {
     let z = zoned(ms, tz);
     match fmt {
         crate::settings::TimeFormat::H24 => format!("{:02}:{:02}", z.hour(), z.minute()),
@@ -334,8 +340,8 @@ fn day_prefix(ms: i64, now_ms: i64, tz: &jiff::tz::TimeZone) -> String {
 
 /// The macOS menu bar's text, or `None` for the icon alone.
 ///
-/// The event running now wins over the next one — knowing you are *in*
-/// something beats knowing what follows it. All-day entries never claim the
+/// The next joinable call takes over at its configured lead time. Otherwise
+/// the current event stays in view. All-day entries never claim the
 /// title: a day-long "Trip" would sit in the menu bar all day saying nothing
 /// about the next hour, and the width it costs is the width every other
 /// menu extra loses. Nothing upcoming yields `None` rather than an empty
@@ -351,16 +357,21 @@ pub(crate) fn menu_title(
     tz: &jiff::tz::TimeZone,
     fmt: crate::settings::TimeFormat,
 ) -> Option<String> {
+    if feed.panel.as_ref().is_some_and(|p| !p.label) { return None; }
     let timed = || feed.events.iter().filter(|e| !e.all_day);
     let now = timed().find(|e| running(e, now_ms));
     let next = || timed().find(|e| e.start_ms > now_ms);
-    let ev = now.or_else(next)?;
+    let ev = crate::menubar::joinable(feed, now_ms).or(now).or_else(next)?;
     let title = ellipsize(ev.title.as_deref().unwrap_or(UNTITLED), TITLE_CAP);
-    Some(if now.is_some() {
-        format!("▸ {title}")
-    } else {
-        format!("{}{}  {title}", day_prefix(ev.start_ms, now_ms, tz), clock(ev.start_ms, tz, fmt))
-    })
+    let minutes = ((if running(ev, now_ms) { ev.end_ms } else { ev.start_ms } - now_ms) + 59_999) / 60_000;
+    let duration = match (minutes / 60, minutes % 60) {
+        (0, _) => format!("{minutes}m"),
+        (hours, 0) => format!("{hours}h"),
+        (hours, remainder) => format!("{hours}h {remainder}m"),
+    };
+    let countdown = if running(ev, now_ms) { format!("{duration} left") } else { format!("in {duration}") };
+    let start = format!("{}{}", day_prefix(ev.start_ms, now_ms, tz), clock(ev.start_ms, tz, fmt));
+    Some(format!("{title} @ {start}  {countdown}"))
 }
 
 /// What a row *is*, so [`apply`] can dress it without deciding anything.
@@ -444,7 +455,12 @@ pub(crate) fn rows(
     for ev in feed.events.iter().filter(|e| !e.all_day).take(EVENT_ROWS) {
         let key = day_key(ev.start_ms, tz);
         if key != day {
-            out.push(Row::heading(heading_for(ev.start_ms, now_ms, tz)));
+            let heading = heading_for(ev.start_ms, now_ms, tz);
+            let heading = match feed.panel.as_ref() {
+                Some(panel) if panel.date_format != crate::settings::DateFormat::Locale && heading != "Today" && heading != "Tomorrow" => panel.date_format.display(zoned(ev.start_ms, tz).date()),
+                _ => heading,
+            };
+            out.push(Row::heading(heading));
             day = key.clone();
         }
         let title = ellipsize(ev.title.as_deref().unwrap_or(UNTITLED), ROW_CAP);
@@ -459,8 +475,7 @@ pub(crate) fn rows(
     // One Join, for the meeting at hand — the running one, else the next.
     // Not one per row: a dropdown of Join buttons is a way to join the
     // wrong call, and the feed's later rows are hours away.
-    let timed = || feed.events.iter().filter(|e| !e.all_day);
-    let at_hand = timed().find(|e| running(e, now_ms)).or_else(|| timed().find(|e| e.start_ms > now_ms));
+    let at_hand = crate::menubar::joinable(feed, now_ms);
     if let Some(url) = at_hand.and_then(|e| e.conference.as_deref()) {
         if url.starts_with("https://") || url.starts_with("http://") {
             out.push(Row {
@@ -550,6 +565,10 @@ fn swatch(hex: &str) -> Option<tauri::image::Image<'static>> {
 /// `tray_icon` setting. A no-op when the tray never built (macOS refusals,
 /// headless oddities): the setting still persists and applies next launch.
 pub(crate) fn set_visible(app: &AppHandle, on: bool) {
+    if !on {
+        if let Some(join) = app.tray_by_id("omacal-join") { let _ = join.set_visible(false); }
+        if let Some(popup) = app.get_webview_window("menubar") { let _ = popup.hide(); }
+    }
     if let Some(tray) = app.tray_by_id(TRAY_ID) {
         if let Err(e) = tray.set_visible(on) {
             tracing::warn!(%e, on, "could not change tray icon visibility");
@@ -578,12 +597,30 @@ pub(crate) fn build(app: &AppHandle) -> tauri::Result<()> {
     // Built with an id so `set_visible` below can find it again: the tray
     // icon is now a *setting*, because on Omarchy 4 the bar widget carries
     // the same three actions and a second omacal icon is one too many.
-    TrayIconBuilder::with_id(TRAY_ID)
-        .menu(&menu)
-        .show_menu_on_left_click(true)
+    let mut builder = TrayIconBuilder::with_id(TRAY_ID)
+        .show_menu_on_left_click(!cfg!(target_os = "macos"))
+        .on_tray_icon_event(|tray, event| {
+            if cfg!(target_os = "macos") {
+                if let tauri::tray::TrayIconEvent::Click {
+                    button, button_state: tauri::tray::MouseButtonState::Up, rect, ..
+                } = event {
+                    match button {
+                        tauri::tray::MouseButton::Left => {
+                            if let Err(e) = crate::menubar::toggle(tray.app_handle(), rect) {
+                                tracing::warn!(%e, "could not open menu bar popup");
+                            }
+                        },
+                        tauri::tray::MouseButton::Right => quick_add(tray.app_handle()),
+                        tauri::tray::MouseButton::Middle => show_main_window(tray.app_handle()),
+                    }
+                }
+            }
+        })
         .icon(tauri::include_image!("icons/tray.png"))
         .on_menu_event(|app, event| match action_for(event.id.as_ref()) {
             Some(TrayAction::Open) => show_main_window(app),
+            Some(TrayAction::QuickAdd) => quick_add(app),
+            Some(TrayAction::Preferences) => preferences(app),
             // Unreachable from a menu — `action_for` never returns it, the
             // menu has no dated entry — but honoured rather than ignored,
             // because a match arm that discards an action is how a future
@@ -600,8 +637,31 @@ pub(crate) fn build(app: &AppHandle) -> tauri::Result<()> {
             // An id the menu did not put there. Nothing to do, and nothing
             // worth crashing the app over.
             None => tracing::warn!(id = %event.id.as_ref(), "unknown tray menu id"),
-        })
-        .build(app)?;
+        });
+    // A native macOS menu consumes right-click before the handler can open
+    // Quick Add. Linux's separate tray still needs its host-provided menu.
+    if !cfg!(target_os = "macos") { builder = builder.menu(&menu); }
+    builder.build(app)?;
+
+    if cfg!(target_os = "macos") {
+        let join = TrayIconBuilder::with_id("omacal-join")
+            .title("Join").tooltip("Join meeting").show_menu_on_left_click(false)
+            .on_tray_icon_event(|tray, event| {
+                if let tauri::tray::TrayIconEvent::Click {
+                    button: tauri::tray::MouseButton::Left,
+                    button_state: tauri::tray::MouseButtonState::Up, ..
+                } = event {
+                    let app = tray.app_handle().clone();
+                    tauri::async_runtime::spawn(async move {
+                        let state = app.state::<crate::AppState>();
+                        if let Err(e) = crate::menubar::menubar_action(app.clone(), state, "join".into()).await {
+                            tracing::warn!(%e, "could not join the meeting");
+                        }
+                    });
+                }
+            }).build(app)?;
+        join.set_visible(false)?;
+    }
 
     Ok(())
 }
@@ -669,7 +729,9 @@ fn apply(app: &AppHandle, feed: &crate::upcoming::Feed, now_ms: i64,
     for i in &fixed {
         refs.push(i);
     }
-    tray.set_menu(Some(Menu::with_items(app, &refs)?))?;
+    if !cfg!(target_os = "macos") {
+        tray.set_menu(Some(Menu::with_items(app, &refs)?))?;
+    }
 
     // `cfg!` and not `#[cfg]`, deliberately. `set_title` is not
     // platform-gated in Tauri, so writing the decision as a runtime branch
@@ -682,6 +744,12 @@ fn apply(app: &AppHandle, feed: &crate::upcoming::Feed, now_ms: i64,
     // more, and Tauri's own note says the title needs the icon shown anyway.
     let title =
         if cfg!(target_os = "macos") { menu_title(feed, now_ms, &tz, fmt) } else { None };
+    let title = if cfg!(target_os = "macos") {
+        match feed.today.as_ref().filter(|today| today.show) {
+            Some(today) => Some(match title { Some(event) => format!("{}  {event}", today.label), None => today.label.clone() }),
+            None => title,
+        }
+    } else { title };
     tray.set_title(title)?;
 
     // The date *is* the icon where it is wanted (2026-09-04): a tray host
@@ -690,7 +758,7 @@ fn apply(app: &AppHandle, feed: &crate::upcoming::Feed, now_ms: i64,
     // turns, because the minute tick is already here and a comparison
     // against the icon currently shown is not something the tray can be
     // asked for.
-    tray.set_icon(Some(if date_icon {
+    tray.set_icon(Some(if date_icon && !cfg!(target_os = "macos") {
         crate::tray_date::icon_for(crate::today_of_month(now_ms, &tz))
     } else {
         crate::tray_date::mark()
@@ -725,6 +793,11 @@ pub(crate) fn refresh(app: &AppHandle) {
             }
         };
         let settings = crate::settings::read_settings(&pool).await;
+        if let Some(join) = app.tray_by_id("omacal-join") {
+            let call = crate::menubar::joinable(&feed, now);
+            let _ = join.set_visible(settings.tray_icon && call.is_some());
+            let _ = join.set_tooltip(call.map(|e| format!("Join {}", e.title.as_deref().unwrap_or(UNTITLED))));
+        }
         if let Err(e) = apply(&app, &feed, now, settings.time_format, settings.show_date) {
             tracing::warn!(%e, "could not update the tray menu");
         }
@@ -756,6 +829,42 @@ pub(crate) fn show_main_window(app: &AppHandle) {
         let _ = w.unminimize();
         let _ = w.set_focus();
     }
+}
+
+/// Requests survive the gap before the frontend installs its listener.
+/// Consuming the flag, rather than trusting an event payload, prevents the
+/// startup read and a simultaneous notification from opening the form twice.
+pub(crate) struct QuickAddRequest(pub std::sync::atomic::AtomicBool);
+
+impl QuickAddRequest {
+    fn take(&self) -> bool { self.0.swap(false, std::sync::atomic::Ordering::SeqCst) }
+}
+
+#[tauri::command]
+pub(crate) fn take_quick_add(state: tauri::State<'_, QuickAddRequest>) -> bool { state.take() }
+
+pub(crate) fn quick_add(app: &AppHandle) {
+    use tauri::Emitter;
+    app.state::<QuickAddRequest>().0.store(true, std::sync::atomic::Ordering::SeqCst);
+    if let Some(popup) = app.get_webview_window("menubar") { let _ = popup.hide(); }
+    show_main_window(app);
+    let _ = app.emit_to("main", "quick-add-requested", ());
+}
+
+/// Park the request until the main webview is ready, including a cold launch.
+pub(crate) struct PreferencesRequest(pub std::sync::atomic::AtomicBool);
+
+#[tauri::command]
+pub(crate) fn take_preferences(state: tauri::State<'_, PreferencesRequest>) -> bool {
+    state.0.swap(false, std::sync::atomic::Ordering::SeqCst)
+}
+
+pub(crate) fn preferences(app: &AppHandle) {
+    use tauri::Emitter;
+    app.state::<PreferencesRequest>().0.store(true, std::sync::atomic::Ordering::SeqCst);
+    if let Some(popup) = app.get_webview_window("menubar") { let _ = popup.hide(); }
+    show_main_window(app);
+    let _ = app.emit_to("main", "preferences-requested", ());
 }
 
 /// What a dated invocation emits once the window is up, carrying the ISO
@@ -862,7 +971,7 @@ mod tests {
     }
 
     fn feed(events: Vec<FeedEvent>) -> Feed {
-        Feed { version: 1, generated_ms: T0, events, tasks: Vec::new(), today: None }
+        Feed { tray_icon: true, version: 1, generated_ms: T0, events, tasks: Vec::new(), today: None, panel: None }
     }
 
     /// The wearer's zone. Fixed rather than `TimeZone::system()` so these
@@ -888,6 +997,53 @@ mod tests {
             .collect()
     }
 
+    #[test]
+    fn join_window_excludes_future_and_finished_calls() {
+        let mut call = ev("Call", T0, T0 + 3_600_000);
+        call.conference = Some("https://meet.google.com/abc".into());
+        let mut f = feed(vec![call]);
+        assert!(crate::menubar::joinable(&f, T0 - 300_001).is_none());
+        assert!(crate::menubar::joinable(&f, T0 - 300_000).is_some());
+        assert!(crate::menubar::joinable(&f, T0 + 3_600_000).is_none());
+        f.panel = Some(crate::upcoming::FeedPanel {
+            agenda_days: Vec::new(),
+            truncated: false, day_start_ms: T0, day_end_ms: T0 + 86_400_000, date: "2026-08-29".into(),
+            date_label: String::new(), utc_offset_seconds: 0, date_format: crate::settings::DateFormat::Locale,
+            clocks: Default::default(), hours: Vec::new(), timezone: "UTC".into(),
+            time_format: TimeFormat::H24, label: false, join_minutes: 0, events: Vec::new(),
+        });
+        assert!(crate::menubar::joinable(&f, T0 - 1).is_none());
+        assert!(crate::menubar::joinable(&f, T0).is_some());
+        assert!(menu_title(&f, T0, &sofia(), TimeFormat::H24).is_none());
+        f.panel.as_mut().unwrap().join_minutes = 60;
+        assert!(crate::menubar::joinable(&f, T0 - 3_600_000).is_some());
+    }
+
+    #[test]
+    fn back_to_back_join_and_title_switch_at_the_lead_window() {
+        let mut current = ev("Current", T0 - 3_600_000, T0 + 3_600_000);
+        current.conference = Some("https://meet.google.com/current".into());
+        let mut next = ev("Next", T0, T0 + 3_600_000);
+        next.conference = Some("https://meet.google.com/next".into());
+        let f = feed(vec![current, next]);
+        assert_eq!(crate::menubar::joinable(&f, T0 - 300_001).unwrap().title.as_deref(), Some("Current"));
+        for now in [T0 - 300_000, T0 - 60_000, T0] {
+            assert_eq!(crate::menubar::joinable(&f, now).unwrap().title.as_deref(), Some("Next"));
+            let label = menu_title(&f, now, &sofia(), TimeFormat::H24).unwrap();
+            assert!(label.starts_with("Next @"), "{label}");
+            assert!(label.ends_with(if now == T0 { "1h left" } else if now == T0 - 60_000 { "in 1m" } else { "in 5m" }), "{label}");
+        }
+    }
+
+    #[test]
+    fn a_quick_add_request_is_consumed_once() {
+        let request = QuickAddRequest(std::sync::atomic::AtomicBool::new(true));
+        assert!(request.take());
+        assert!(!request.take());
+        request.0.store(true, std::sync::atomic::Ordering::SeqCst);
+        assert!(request.take());
+    }
+
     /// The running meeting outranks the next one: being *in* something is
     /// the more useful fact, and the marker is what tells the two apart.
     #[test]
@@ -896,7 +1052,17 @@ mod tests {
             ev("Standup", T0 - 600_000, T0 + 600_000),
             ev("Review", T0 + 3_600_000, T0 + 7_200_000),
         ]);
-        assert_eq!(menu_title(&f, T0, &sofia(), TimeFormat::H24).as_deref(), Some("▸ Standup"));
+        assert_eq!(menu_title(&f, T0, &sofia(), TimeFormat::H24).as_deref(), Some("Standup @ 11:50  10m left"));
+    }
+
+    #[test]
+    fn countdowns_use_hours_at_sixty_minutes_for_upcoming_and_running_events() {
+        for (minutes, duration) in [(59, "59m"), (60, "1h"), (64, "1h 4m"), (120, "2h"), (642, "10h 42m")] {
+            let next = feed(vec![ev("Next", T0 + minutes * 60_000, T0 + (minutes + 30) * 60_000)]);
+            assert!(menu_title(&next, T0, &sofia(), TimeFormat::H24).unwrap().ends_with(&format!("in {duration}")));
+            let active = feed(vec![ev("Active", T0 - 60_000, T0 + minutes * 60_000)]);
+            assert!(menu_title(&active, T0, &sofia(), TimeFormat::H24).unwrap().ends_with(&format!("{duration} left")));
+        }
     }
 
     /// With nothing running, the next one — and it carries the start time,
@@ -904,7 +1070,7 @@ mod tests {
     #[test]
     fn the_title_falls_to_the_next_meeting_with_its_clock() {
         let f = feed(vec![ev("Review", T0 + 3_600_000, T0 + 7_200_000)]);
-        assert_eq!(menu_title(&f, T0, &sofia(), TimeFormat::H24).as_deref(), Some("13:00  Review"));
+        assert_eq!(menu_title(&f, T0, &sofia(), TimeFormat::H24).as_deref(), Some("Review @ 13:00  in 1h"));
     }
 
     /// An event that ended exactly now has ended — the half-open rule every
@@ -939,8 +1105,8 @@ mod tests {
         let long = "Консулски услуги в посолството на Република България";
         let f = feed(vec![ev(long, T0 + 60_000, T0 + 600_000)]);
         let title = menu_title(&f, T0, &sofia(), TimeFormat::H24).expect("a next meeting");
-        assert!(title.ends_with('…'), "{title}");
-        assert!(title.chars().count() <= TITLE_CAP + 8, "{title}");
+        assert!(title.contains('…'), "{title}");
+        assert!(title.chars().count() <= TITLE_CAP + 24, "{title}");
     }
 
     /// The row's id has to survive the trip out to AppKit and back through
@@ -1076,7 +1242,7 @@ mod tests {
     #[test]
     fn the_twelve_hour_setting_is_honoured() {
         let f = feed(vec![ev("Review", T0 + 3_600_000, T0 + 7_200_000)]);
-        assert_eq!(menu_title(&f, T0, &sofia(), TimeFormat::H12).as_deref(), Some("1:00pm  Review"));
+        assert_eq!(menu_title(&f, T0, &sofia(), TimeFormat::H12).as_deref(), Some("Review @ 1:00pm  in 1h"));
     }
 
     /// Open, Sync now, Quit — in that order, and Quit present at all.
@@ -1142,6 +1308,10 @@ mod tests {
     /// as Open.
     #[test]
     fn a_second_invocations_argv_maps_to_an_action() {
+        assert_eq!(instance_action(&argv(&["omacal", "--preferences"])), TrayAction::Preferences);
+        assert_eq!(instance_action(&argv(&["omacal", "--preferences", "--quit"])), TrayAction::Quit);
+        assert_eq!(instance_action(&argv(&["omacal", "--quick-add"])), TrayAction::QuickAdd);
+        assert_eq!(instance_action(&argv(&["omacal", "--quick-add", "--quit"])), TrayAction::Quit);
         assert_eq!(instance_action(&argv(&["omacal", "--quit"])), TrayAction::Quit);
         assert_eq!(instance_action(&argv(&["omacal", "--sync-now"])), TrayAction::SyncNow);
         assert_eq!(instance_action(&argv(&["omacal"])), TrayAction::Open);

--- a/src-tauri/src/upcoming.rs
+++ b/src-tauri/src/upcoming.rs
@@ -44,6 +44,7 @@ const VERSION: u32 = 1;
 #[derive(Debug, Serialize, PartialEq)]
 pub struct Feed {
     pub version: u32,
+    pub tray_icon: bool,
     /// When this snapshot was computed — the reader's staleness check.
     pub generated_ms: i64,
     pub events: Vec<FeedEvent>,
@@ -62,10 +63,39 @@ pub struct Feed {
     /// keeps working (2026-09-04).
     #[serde(default)]
     pub today: Option<FeedToday>,
+    pub panel: Option<FeedPanel>,
+}
+
+/// A complete display-zone day, separate from the forward-looking feed so
+/// older readers never announce a completed meeting as the next one.
+#[derive(Debug, Serialize, PartialEq)]
+pub struct FeedPanel {
+    pub agenda_days: Vec<FeedAgendaDay>,
+    pub truncated: bool,
+    pub day_start_ms: i64,
+    pub day_end_ms: i64,
+    pub date: String,
+    pub date_label: String,
+    pub utc_offset_seconds: i32,
+    pub date_format: crate::settings::DateFormat,
+    pub clocks: HashMap<i64, String>,
+    pub hours: Vec<i64>,
+    pub timezone: String,
+    pub time_format: crate::settings::TimeFormat,
+    pub label: bool,
+    pub join_minutes: u32,
+    pub events: Vec<FeedEvent>,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+pub struct FeedAgendaDay {
+    pub date_label: String,
+    pub events: Vec<FeedEvent>,
 }
 
 #[derive(Debug, Serialize, PartialEq)]
 pub struct FeedToday {
+    pub label: String,
     /// `1..=31` in the display zone at generation time.
     pub day: u32,
     /// The user's `show_date` setting. The reader draws the day only when
@@ -233,7 +263,10 @@ pub(crate) fn assemble(
     calendar_names: &HashMap<i64, String>,
     now_ms: i64,
 ) -> Feed {
-    let to_ms = now_ms.saturating_add(HORIZON_MS);
+    assemble_window(stored, calendar_names, now_ms, now_ms.saturating_add(HORIZON_MS), CAP)
+}
+
+fn assemble_window(stored: &[StoredEvent], calendar_names: &HashMap<i64, String>, now_ms: i64, to_ms: i64, cap: usize) -> Feed {
     let suppressed = crate::commands::suppressed_slots(stored);
 
     let mut events = Vec::new();
@@ -278,11 +311,11 @@ pub(crate) fn assemble(
     events.sort_by(|a, b| {
         (a.start_ms, a.end_ms, &a.title).cmp(&(b.start_ms, b.end_ms, &b.title))
     });
-    events.truncate(CAP);
+    events.truncate(cap);
 
     // `assemble` stays pure over its events — the tasks and today's date are
     // both filled in by `current`, which has the pool the settings live in.
-    Feed { version: VERSION, generated_ms: now_ms, events, tasks: Vec::new(), today: None }
+    Feed { tray_icon: true, version: VERSION, generated_ms: now_ms, events, tasks: Vec::new(), today: None, panel: None }
 }
 
 /// How far ahead a due date still counts as "worth a glance in the bar".
@@ -377,9 +410,49 @@ pub(crate) async fn current(pool: &SqlitePool, now_ms: i64) -> anyhow::Result<Fe
     // without a single CalDAV account contributes an empty list for free.
     let task_rows = omacal_store::tasks_for_ui(pool, now_ms).await?;
     feed.tasks = assemble_tasks(&task_rows, now_ms);
+    let settings = crate::settings::read_settings(pool).await;
+    let tz = jiff::tz::TimeZone::system();
+    let today = jiff::Timestamp::from_millisecond(now_ms)?.to_zoned(tz.clone()).date();
+    let start = today.to_zoned(tz.clone())?.timestamp().as_millisecond();
+    let end = today.tomorrow()?.to_zoned(tz.clone())?.timestamp().as_millisecond();
+    let day_stored = omacal_store::events_in_window(pool, start, end).await?;
+    // The agenda needs completed events too, and a larger bound than the
+    // glance-sized upcoming slice. Report truncation instead of hiding it.
+    let mut day = assemble_window(&day_stored, &names, start, end, 201);
+    let truncated = day.events.len() > 200;
+    day.events.truncate(200);
+    let mut agenda_days = Vec::new();
+    let mut agenda_date = today;
+    let mut remaining = 200usize;
+    let mut agenda_truncated = false;
+    for _ in 0..settings.week_view_days {
+        let from = agenda_date.to_zoned(tz.clone())?.timestamp().as_millisecond();
+        let next = agenda_date.tomorrow()?;
+        let to = next.to_zoned(tz.clone())?.timestamp().as_millisecond();
+        let stored = omacal_store::events_in_window(pool, from, to).await?;
+        let mut slice = assemble_window(&stored, &names, from, to, remaining + 1);
+        agenda_truncated |= slice.events.len() > remaining;
+        slice.events.truncate(remaining);
+        remaining -= slice.events.len();
+        agenda_days.push(FeedAgendaDay { date_label: settings.date_format.display(agenda_date), events: slice.events });
+        agenda_date = next;
+    }
+    let hours: Vec<_> = (start..end).step_by(3_600_000).collect();
+    let clocks = day.events.iter().chain(feed.events.iter()).chain(agenda_days.iter().flat_map(|d| d.events.iter()))
+        .flat_map(|e| [e.start_ms, e.end_ms]).chain(hours.iter().copied())
+        .map(|ms| (ms, crate::tray::clock(ms, &tz, settings.time_format))).collect();
+    feed.panel = Some(FeedPanel {
+        agenda_days, truncated: truncated || agenda_truncated, day_start_ms: start, day_end_ms: end, date: today.to_string(), clocks, hours, timezone: tz.iana_name().unwrap_or("UTC").into(),
+        date_label: settings.date_format.display(today), utc_offset_seconds: jiff::Timestamp::from_millisecond(now_ms)?.to_zoned(tz.clone()).offset().seconds(), date_format: settings.date_format,
+        time_format: settings.time_format,
+        label: settings.menubar_label, join_minutes: settings.menubar_join_minutes,
+        events: day.events,
+    });
+    feed.tray_icon = settings.tray_icon;
     feed.today = Some(FeedToday {
+        label: today.day().to_string(),
         day: crate::today_of_month(now_ms, &jiff::tz::TimeZone::system()),
-        show: crate::settings::read_settings(pool).await.show_date,
+        show: settings.show_date,
     });
     Ok(feed)
 }
@@ -413,6 +486,17 @@ mod tests {
     const DAY: i64 = 24 * HOUR;
     /// 2026-08-10T09:00:00Z, borrowed from the scheduler's tests.
     const T0900Z: i64 = 1_786_352_400_000;
+
+    #[test]
+    fn a_day_snapshot_keeps_completed_events_without_leaking_the_next_day() {
+        let start = T0900Z - 9 * HOUR;
+        let stored = vec![event("morning", start + HOUR, start + 2 * HOUR),
+            event("tomorrow", start + DAY + HOUR, start + DAY + 2 * HOUR)];
+        let day = assemble_window(&stored, &names(), start, start + DAY, 200);
+        assert_eq!(day.events.len(), 1);
+        assert_eq!(day.events[0].start_ms, start + HOUR);
+        assert_eq!(assemble(&stored, &names(), T0900Z).events[0].start_ms, start + DAY + HOUR);
+    }
 
     fn event(google_id: &str, start: i64, end: i64) -> StoredEvent {
         StoredEvent {
@@ -753,6 +837,33 @@ mod today_field_tests {
     /// and carries the day rather than leaving the reader to compute one: the
     /// zone is the app's setting, and a widget reading the desktop's clock
     /// would disagree with the grid beside it for hours at a time.
+    #[tokio::test]
+    async fn agenda_horizon_follows_week_view_days() {
+        let pool = omacal_store::connect_memory().await.unwrap();
+        for count in [3, 5, 7] {
+            sqlx::query("INSERT OR REPLACE INTO settings (key, value) VALUES ('week_view_days', ?1)")
+                .bind(count.to_string()).execute(&pool).await.unwrap();
+            let panel = current(&pool, 1_786_352_400_000).await.unwrap().panel.unwrap();
+            assert_eq!(panel.agenda_days.len(), count);
+            assert!(panel.agenda_days.windows(2).all(|d| d[0].date_label != d[1].date_label));
+        }
+    }
+
+    #[tokio::test]
+    async fn the_feed_publishes_live_menu_preferences() {
+        let pool = omacal_store::connect_memory().await.unwrap();
+        let now = 1_788_564_600_000;
+        assert!(current(&pool, now).await.unwrap().tray_icon);
+        for (key, value) in [("tray_icon", "0"), ("show_date", "1"), ("menubar_label", "0")] {
+            crate::settings::write(&pool, key, value).await.unwrap();
+        }
+        let feed = current(&pool, now).await.unwrap();
+        assert!(!feed.tray_icon);
+        assert!(feed.today.unwrap().show);
+        let panel = feed.panel.unwrap();
+        assert!(!panel.label);
+    }
+
     #[tokio::test]
     async fn the_feed_publishes_today_and_the_switch() {
         let pool = omacal_store::connect_memory().await.unwrap();

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -11,7 +11,7 @@
     getWeek, getDay, getRange, getMonth, getYear, getBigYear, weekStart,
     type WeekPayload, type MonthPayload, type YearPayload, type BigYearPayload, type UiEvent,
   } from './lib/api';
-  import { cancelSignIn, getStatus, installUpdate, openLatestRelease, restartApp, signIn, syncNow, takeOpenDate, type AppStatus } from './lib/status';
+  import { cancelSignIn, getStatus, installUpdate, openLatestRelease, restartApp, signIn, syncNow, takeOpenDate, takeQuickAdd, takePreferences, type AppStatus } from './lib/status';
   import { dateKey, freshness, getWeather, weatherByDate, type DayWeather, type WeatherReport } from './lib/weather';
   import WeatherPopover from './lib/WeatherPopover.svelte';
   import ImportPanel from './lib/ImportPanel.svelte';
@@ -1184,9 +1184,36 @@
    * move underneath a line left open across midnight. */
   let quickAdd = $state<{ nowMs: number; anchorDayMs: number } | null>(null);
 
-  function openQuickAdd() {
-    quickAdd = { nowMs: Date.now(), anchorDayMs: createDayMs() };
+  function openQuickAdd(fromBar = false) {
+    if (quickAdd) return;
+    const nowMs = Date.now();
+    quickAdd = { nowMs, anchorDayMs: fromBar === true ? dayStart(nowMs) : createDayMs() };
   }
+
+  $effect(() => {
+    let active = true;
+    async function receive() {
+      try {
+        if (await takeQuickAdd() && active) openQuickAdd(true);
+      } catch (e) { if (active) error = String(e); }
+    }
+    // Listen first, then drain the parked launch request. Requests arriving
+    // during startup are consumed by exactly one of these two entrances.
+    const un = listen('quick-add-requested', () => { void receive(); });
+    void un.then(receive).catch((e) => { if (active) error = String(e); });
+    return () => { active = false; void un.then(f => f()); };
+  });
+
+  $effect(() => {
+    let active = true;
+    async function receive() {
+      try { if (await takePreferences() && active) settingsOpen = true; }
+      catch (e) { if (active) error = String(e); }
+    }
+    const un = listen('preferences-requested', () => { void receive(); });
+    void un.then(receive).catch(e => { if (active) error = String(e); });
+    return () => { active = false; void un.then(f => f()); };
+  });
 
   /**
    * A result was chosen (spec §6): move the calendar to that date **in the

--- a/ui/src/lib/Menubar.svelte
+++ b/ui/src/lib/Menubar.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+  import { formatDate, type DateFormat } from './datefmt';
+  import { onMount } from 'svelte';
+  import { listen } from '@tauri-apps/api/event';
+  import { invoke } from '@tauri-apps/api/core';
+  import { applyPalette } from './theme';
+  import { progress, joinable, uniqueAllDay, type Event } from '../../../packaging/omarchy-plugin/Timeline.mjs';
+
+  type Panel = { agenda_days?: { date_label: string; events: Event[] }[]; truncated?: boolean; day_start_ms: number; day_end_ms: number; timezone: string;
+    time_format: '12h' | '24h'; date_format?: DateFormat; label: boolean; join_minutes: number; events: Event[] };
+  type Feed = { events: Event[]; panel: Panel; tasks: { title: string; overdue: boolean }[] };
+  let feed = $state<Feed | null>(null);
+  let now = $state(Date.now());
+  let error = $state('');
+  const panel = $derived(feed?.panel);
+  const today = $derived(uniqueAllDay(panel?.events ?? []));
+  const timed = $derived(today.filter(e => !e.all_day));
+  const active = $derived(timed.find(e => e.start_ms <= now && e.end_ms > now));
+  const nowIndex = $derived(timed.findIndex(e => e.end_ms > now));
+  const allDay = $derived(today.filter(e => e.all_day));
+  const call = $derived(feed ? joinable(feed.events, now, panel?.join_minutes ?? 5) : null);
+  const heading = $derived(panel ? formatDate(panel.day_start_ms, panel.date_format, { weekday: 'long', month: 'short', day: 'numeric', timeZone: panel.timezone }) : 'Today');
+  function clock(ms: number) {
+    return new Intl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit', hour12: panel?.time_format === '12h', timeZone: panel?.timezone }).format(ms);
+  }
+  function color(e: Event) { return /^#[0-9a-f]{6}$/i.test(e.color ?? '') ? e.color! : 'var(--accent)'; }
+  function date(ms: number) {
+    return new Intl.DateTimeFormat('en-CA', { year: 'numeric', month: '2-digit', day: '2-digit', timeZone: panel?.timezone }).format(ms);
+  }
+  async function refresh() {
+    try { feed = await invoke<Feed>('menubar_feed'); now = Date.now(); error = ''; }
+    catch (e) { error = String(e); }
+  }
+  async function action(action: string) {
+    try { await invoke('menubar_action', { action }); error = ''; }
+    catch (e) { error = String(e); }
+  }
+  onMount(() => {
+    void applyPalette(); void refresh();
+    const changes = listen("menubar-changed", () => { void refresh(); });
+    const timer = setInterval(() => { void refresh(); }, 15000);
+    const clockTimer = setInterval(() => { now = Date.now(); }, 1000);
+    const focus = () => { void applyPalette(); void refresh(); };
+    window.addEventListener('focus', focus);
+    return () => { void changes.then(unlisten => unlisten()); clearInterval(timer); clearInterval(clockTimer); window.removeEventListener('focus', focus); };
+  });
+</script>
+
+{#snippet nowMarker()}
+  <div class="now-marker">
+    <span>NOW</span>
+    <div class="now-track" role={active ? 'progressbar' : undefined} aria-label={active ? `Elapsed time: ${active.title ?? '(no title)'}` : 'Current time'} aria-valuemin="0" aria-valuemax="100" aria-valuenow={active ? Math.round(progress(active, now) * 100) : 0}>
+      <span class="now-fill" style:width={`${active ? progress(active, now) * 100 : 0}%`}></span>
+    </div>
+  </div>
+{/snippet}
+
+<svelte:window onkeydown={(e) => { if (e.key === 'Escape') void action('close'); if (e.key === 'j' && call) void action('join'); }} />
+<div class="popup">
+  <header><div><strong>OmaCal</strong><p>{heading} · {clock(now)}</p></div><button aria-label="Add event" title="Add event with natural language" onclick={() => action('quick-add')}>+</button><button aria-label="Open preferences" title="OmaCal preferences" onclick={() => action('preferences')}>⚙</button><button aria-label="Close agenda" onclick={() => action('close')}>×</button></header>
+  {#if call}<button class="join" title={call.title ?? 'Meeting'} onclick={() => action('join')}>Join · {call.title ?? '(no title)'}</button>{/if}
+  {#if error}<p role="alert">{error}</p>{/if}
+  {#if panel?.truncated}<p>Showing the first 200 events. Open OmaCal for the complete day.</p>{/if}
+  <div class="scroll">
+    {#if !feed}<p class="empty">Loading calendar…</p>
+    {:else}
+      <div class="agenda">
+        {#if allDay.length}<div class="all-day"><small>ALL DAY</small>{#each allDay as event}<button onclick={() => action(date(panel!.day_start_ms))}>{event.title ?? '(no title)'}</button>{/each}</div>{/if}
+        {#if timed.length === 0}<p class="empty">No timed events today</p>{/if}
+        {#each timed as event, i}
+          {#if active && i === nowIndex}{@render nowMarker()}{/if}
+          <button class="agenda-row" class:past={event.end_ms <= now} style:--event-color={color(event)} onclick={() => action(date(event.start_ms))}>
+            <time>{clock(event.start_ms)}</time><span><strong>{event.title ?? '(no title)'}</strong><small>{event.end_ms <= now ? 'Ended' : event.start_ms <= now ? `${Math.ceil((event.end_ms - now) / 60000)}m left` : clock(event.end_ms)}{event.calendar ? ` · ${event.calendar}` : ''}</small></span>
+          </button>
+        {/each}
+        {#each panel?.agenda_days?.slice(1) ?? [] as day, i}
+          <small class="section-label">{i === 0 ? 'TOMORROW' : day.date_label}</small>
+          {#each uniqueAllDay(day.events) as event}
+            <button class="agenda-row" style:--event-color={color(event)} onclick={() => action(date(event.start_ms))}>
+              <time>{event.all_day ? 'All day' : clock(event.start_ms)}</time>
+              <span><strong>{event.title ?? '(no title)'}</strong><small>{event.calendar ?? ''}</small></span>
+            </button>
+          {/each}
+        {/each}
+      </div>
+    {/if}
+    {#if feed?.tasks.length}<div class="all-day"><small>DUE</small>{#each feed.tasks as task}<button onclick={() => action('open')}>{task.overdue ? '⚠ ' : ''}{task.title}</button>{/each}</div>{/if}
+  </div>
+  <footer><button onclick={() => action('open')}>Open OmaCal</button><button onclick={() => action('sync')}>Sync</button><button onclick={() => action('quit')}>Quit</button></footer>
+</div>
+
+<style>
+  :global(body) { margin: 0; background: var(--bg, #20232b); color: var(--text, #e5e7eb); font-family: system-ui, sans-serif; font-size: 13px; }
+  :global(*) { box-sizing: border-box; }
+  .popup { height: 100vh; padding: 16px; display: flex; flex-direction: column; gap: 12px; border: 1px solid var(--muted, #555); }
+  header, footer { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
+  header { justify-content: space-between; } header strong { font-size: 17px; } p { margin: 4px 0 0; color: var(--muted, #999); }
+  button { font: inherit; color: inherit; background: transparent; border: 1px solid transparent; border-radius: 5px; cursor: pointer; padding: 6px 10px; }
+  button:hover { background: var(--surface, #303540); } button:focus-visible { outline: 2px solid var(--accent, #87b7ff); outline-offset: -2px; }
+  .join { background: var(--accent, #87b7ff); color: var(--on-accent, #10151c); flex-shrink: 0; text-overflow: ellipsis; overflow: hidden; white-space: nowrap; }
+  .scroll { overflow: auto; flex: 1; min-height: 0; } footer { border-top: 1px solid var(--hairline, #444); padding-top: 8px; } footer button:first-child { margin-right: auto; }
+  .past { opacity: .5; }
+  .agenda-row { display: flex; width: 100%; text-align: left; align-items: center; gap: 12px; padding: 12px 8px; position: relative; border-left: 3px solid var(--event-color); margin: 5px 0; overflow: hidden; }
+  time { width: 66px; flex-shrink: 0; font-variant-numeric: tabular-nums; font-size: 12px; } .agenda-row > span { min-width: 0; } .agenda-row strong, .agenda-row small { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; } small { color: var(--muted, #999); font-size: 11px; } .agenda-row small { margin-top: 4px; }
+  .now-marker { display: flex; align-items: center; gap: 10px; color: var(--text, #e5e7eb); padding: 6px 0; margin: 8px 0; font-size: 11px; font-weight: 600; }
+  .now-track { flex: 1; height: 3px; border-radius: 2px; background: color-mix(in srgb, var(--text, #e5e7eb) 15%, transparent); overflow: hidden; }
+  .now-fill { display: block; height: 100%; border-radius: inherit; background: var(--now, #e2564a); }
+  .all-day { border-top: 1px solid var(--hairline, #444); margin-top: 12px; padding-top: 10px; } .all-day button { display: block; width: 100%; text-align: left; } .section-label { display: block; margin-top: 16px; } .empty { padding: 14px 0; }
+</style>

--- a/ui/src/lib/SettingsModal.svelte
+++ b/ui/src/lib/SettingsModal.svelte
@@ -22,7 +22,7 @@
     setDisplayTimezone, setFallbackReminders, setNotificationsEnabled,
     setAppearance, APPEARANCE_OPTIONS,
     setQuitOnClose, setSecondTimezone, setSyncInterval, setTemperatureUnit, setTimeFormat,
-    setShowDate, setTrayIcon, setWeatherEnabled, setWeekStart,
+    setMenubarPreferences, setShowDate, setTrayIcon, setWeatherEnabled, setWeekStart,
     setWeekStartsToday, setWeekViewDays,
     type AppSettings, type Appearance, type StartOnLogin, type WeekViewDays,
     type WindowFrame, WINDOW_FRAME_OPTIONS, setWindowFrame,
@@ -98,6 +98,14 @@
       })
       .catch((e) => (note = { text: String(e), kind: 'error' }));
   });
+
+  async function saveMenubar(label = settings?.menubarLabel ?? true, joinMinutes = settings?.menubarJoinMinutes ?? 5) {
+    try {
+      settings = await setMenubarPreferences(label, joinMinutes);
+      onsettingschange?.(settings);
+      note = { text: 'Saved.', kind: 'info' };
+    } catch (e) { note = { text: String(e), kind: 'error' }; }
+  }
 
   const floorMinutes = $derived(settings ? minutesOf(settings.minSyncIntervalMs) : 1);
 
@@ -1186,6 +1194,21 @@
         {#if settings?.desktop === 'omarchy'}The Omarchy bar widget also shows the date beside its mark.{/if}
         The number follows the clock without a restart.
       </p>
+      <section class="appearance-section" aria-labelledby="menubar-heading">
+        <h2 id="menubar-heading">Menu bar calendar</h2>
+        <label class="check"><input type="checkbox" disabled={!settings}
+          checked={settings?.menubarLabel ?? true}
+          onchange={(e) => saveMenubar(e.currentTarget.checked)} />
+          Show meeting title and countdown</label>
+        <label class="lab" for="menubar-join">Show Join before a meeting</label>
+        <select id="menubar-join" disabled={!settings} value={settings?.menubarJoinMinutes ?? 5}
+          onchange={(e) => saveMenubar(undefined, Number(e.currentTarget.value))}>
+          {#each [0, 1, 5, 10, 15, 30, 60] as minutes}
+            <option value={minutes}>{minutes === 0 ? 'At start time' : `${minutes} minutes before`}</option>
+          {/each}
+        </select>
+        <p class="hint">Join stays available while the meeting is running. These preferences apply to the {settings?.desktop === 'macos' ? 'macOS menu bar' : settings?.desktop === 'omarchy' ? 'Omarchy widget' : 'menu bar'}.</p>
+      </section>
     {:else if pane === 'Calendars'}
       <!-- **The same rows the header's popover shows, from the same
            component.** Extracted rather than reimplemented, which is what

--- a/ui/src/lib/settings.ts
+++ b/ui/src/lib/settings.ts
@@ -130,6 +130,8 @@ export type AppSettings = {
    *  which *becomes* the date because a tray host draws icons and nothing
    *  else, and the Omarchy bar widget, which reads it from the feed. */
   showDate: boolean;
+  menubarLabel?: boolean;
+  menubarJoinMinutes?: number;
   /** Which palette the app wears. `'auto'` by default — omacal has no theme
    *  of its own and wears Omarchy's, which is exactly why the other two rows
    *  exist: off Omarchy there was no theme to wear and dark was the only
@@ -322,3 +324,6 @@ export const minutesOf = (ms: number): number => Math.round(ms / 60_000);
 export const msOfMinutes = (min: number): number => Math.round(min * 60_000);
 
 export const setDateFormatPreference = (format: DateFormat) => invoke<AppSettings>('set_date_format', { format });
+
+export const setMenubarPreferences = (label: boolean, joinMinutes: number) =>
+  invoke<AppSettings>('set_menubar_preferences', { label, joinMinutes });

--- a/ui/src/lib/status.ts
+++ b/ui/src/lib/status.ts
@@ -173,3 +173,7 @@ export function relativeTime(ms: number | null, now = Date.now()): string {
   if (s < 86400) return `${Math.floor(s / 3600)} h ago`;
   return `${Math.floor(s / 86400)} d ago`;
 }
+
+export const takeQuickAdd = () => invoke<boolean>('take_quick_add');
+
+export const takePreferences = () => invoke<boolean>('take_preferences');

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -1,9 +1,12 @@
 import "./app.css";
 import { mount } from "svelte";
-import App from "./App.svelte";
 
-const app = mount(App, {
-  target: document.getElementById("app")!,
-});
-
-export default app;
+// Load only this window's root and styles; a popup must not boot the main
+// calendar's listeners, nor change its typography through global CSS.
+async function start() {
+  const { default: Root } = new URLSearchParams(location.search).has("menubar")
+    ? await import("./lib/Menubar.svelte")
+    : await import("./App.svelte");
+  return mount(Root, { target: document.getElementById("app")! });
+}
+export default start();

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -4920,6 +4920,28 @@ test.describe("App: showing today's date", () => {
     await page.clock.setFixedTime(APP_NOW);
   });
 
+  test('menu bar label and Join timing are saved and remembered', async ({ page }) => {
+    await page.goto(app('writable'));
+    await page.getByRole('button', { name: 'Menu' }).click();
+    await page.getByRole('button', { name: 'Settings…' }).click();
+    const modal = page.getByRole('dialog', { name: 'Settings' });
+    await modal.getByRole('tab', { name: 'Menu bar' }).click();
+    await modal.getByLabel('Show Join before a meeting').selectOption('15');
+    await modal.getByLabel('Show meeting title and countdown').uncheck();
+    const calls = await page.evaluate(() => window.__harness.calls
+      .filter(c => c.cmd === 'set_menubar_preferences').map(c => c.args));
+    expect(calls).toEqual([
+      { label: true, joinMinutes: 15 },
+      { label: false, joinMinutes: 15 },
+    ]);
+    await page.keyboard.press('Escape');
+    await page.getByRole('button', { name: 'Menu' }).click();
+    await page.getByRole('button', { name: 'Settings…' }).click();
+    await modal.getByRole('tab', { name: 'Menu bar' }).click();
+    await expect(modal.getByLabel('Show Join before a meeting')).toHaveValue('15');
+    await expect(modal.getByLabel('Show meeting title and countdown')).not.toBeChecked();
+  });
+
   test("today's date can be asked for, and is remembered", async ({ page }) => {
     // Asked for 2026-09-04. One switch dresses two surfaces: the tray icon
     // *becomes* the date, because a tray host draws icons and nothing else,
@@ -5251,3 +5273,44 @@ test('settings measures every pane at 650px and keeps its height across tabs', a
 });
 
 
+  test('a menu bar quick-add request opens the NLP form without submitting', async ({ page }) => {
+    await page.goto(app('writable'));
+    await page.evaluate(() => window.__harness.emit('quick-add-requested', null));
+    const quick = page.getByRole('dialog', { name: 'Quick add event' });
+    await expect(quick).toBeVisible();
+    const input = quick.getByRole('textbox', { name: 'Describe the event' });
+    await expect(input).toBeFocused();
+    await input.fill('30 min at 2pm Design sync');
+    await expect(quick.getByText('Design sync', { exact: true })).toBeVisible();
+    await page.evaluate(() => window.__harness.emit('quick-add-requested', null));
+    await expect(input).toHaveValue('30 min at 2pm Design sync');
+    const writes = await page.evaluate(() => window.__harness.calls.filter(c => c.cmd === 'create_event'));
+    expect(writes).toHaveLength(0);
+    await page.keyboard.press('Escape');
+    await expect(quick).not.toBeVisible();
+  });
+
+  test('a fresh quick-add launch delivers its parked request once', async ({ page }) => {
+    await page.goto(app('launched-with-quick-add'));
+    const quick = page.getByRole('dialog', { name: 'Quick add event' });
+    await expect(quick).toBeVisible();
+    await expect(quick.getByRole('textbox', { name: 'Describe the event' })).toBeFocused();
+    await page.keyboard.press('Escape');
+    await expect(quick).not.toBeVisible();
+    expect(await page.evaluate(() => (window as any).__TAURI_INTERNALS__.invoke('take_quick_add', {}))).toBe(false);
+  });
+
+
+for (const cold of [true, false]) {
+  test(`preferences request opens Settings on ${cold ? 'cold launch' : 'running app'}`, async ({ page }) => {
+    await page.goto(app(cold ? 'launched-with-preferences' : 'default'));
+    if (!cold) {
+      await expect(page.getByRole('button', { name: 'Menu', exact: true })).toBeVisible();
+      await page.evaluate(() => window.__harness.emit('preferences-requested', null));
+    }
+    await expect(page.getByRole('dialog', { name: 'Settings' })).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(page.getByRole('dialog', { name: 'Settings' })).toHaveCount(0);
+    expect(await page.evaluate(() => (window as any).__TAURI_INTERNALS__.invoke('take_preferences'))).toBe(false);
+  });
+}

--- a/ui/tests/harness/tauri.ts
+++ b/ui/tests/harness/tauri.ts
@@ -134,6 +134,8 @@ const RESPOND_STUB_DETAIL = {
   attendees: [],
 };
 
+let quickAddPending = false;
+let preferencesPending = false;
 const listeners = new Map<string, Set<(e: unknown) => void>>();
 const callbacks = new Map<number, (e: unknown) => void>();
 const hold = new Set<number>();
@@ -187,6 +189,8 @@ async function whenListening(event: string, polls = 300): Promise<void> {
 const harness: Harness = {
   calls: [],
   async emit(event, payload) {
+    if (event === 'preferences-requested') preferencesPending = true;
+    if (event === 'quick-add-requested') quickAddPending = true;
     await whenListening(event);
     for (const fn of listeners.get(event) ?? []) fn({ event, id: 0, payload });
   },
@@ -566,6 +570,8 @@ type StubSettings = {
   minSyncIntervalMs: number;
   listMode: boolean;
   showDate: boolean;
+  menubarLabel?: boolean;
+  menubarJoinMinutes?: number;
   hourHeight: number;
   fallbackReminderMinutes: number[];
   defaultCalendarId: number | null;
@@ -711,6 +717,8 @@ const SEARCHABLE = [
 ];
 
 export function installTauriStub(scenario: string): Harness {
+  quickAddPending = scenario === 'launched-with-quick-add';
+  preferencesPending = scenario === 'launched-with-preferences';
   // Reassigned by `sign_in` for the `sign-in-adds-account` scenario: a real
   // `sign_in` leaves the account durably connected, so the next `get_status`
   // must reflect it too, not just `get_calendars`.
@@ -762,6 +770,14 @@ export function installTauriStub(scenario: string): Harness {
         return status;
       // The date a dated fresh launch parked on the backend. One scenario
       // carries one; everything else launched bare.
+      case 'take_preferences': {
+        const requested = preferencesPending; preferencesPending = false; return requested;
+      }
+      case 'take_quick_add': {
+        const requested = quickAddPending;
+        quickAddPending = false;
+        return requested;
+      }
       case 'take_open_date': {
         if (scenario === 'launched-with-date' && !openDateTaken) {
           openDateTaken = true;
@@ -931,6 +947,10 @@ export function installTauriStub(scenario: string): Harness {
       case 'set_list_mode':
         settings = saveSettings({ ...settings, listMode: args.on as boolean });
         return { ...settings };
+      case 'set_menubar_preferences':
+        settings = saveSettings({ ...settings,
+          menubarLabel: args.label as boolean, menubarJoinMinutes: args.joinMinutes as number });
+        return settings;
       case 'set_show_date':
         settings = saveSettings({ ...settings, showDate: args.on as boolean });
         return { ...settings };

--- a/ui/tests/meeting-presence.spec.ts
+++ b/ui/tests/meeting-presence.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test';
+import { observe, isPresent, eventKey, type Window } from '../../packaging/omarchy-plugin/MeetingPresence.mjs';
+import type { Event } from '../../packaging/omarchy-plugin/Timeline.mjs';
+const now = 1_800_000;
+const meeting = (conference: string, extra = {}): Event => ({ title: 'Design sync', conference, start_ms: now - 60000, end_ms: now + 3600000, all_day: false, ...extra });
+const zoom = meeting('https://us02web.zoom.us/j/12345678901?pwd=private');
+const meet = meeting('https://meet.google.com/abc-defg-hij');
+const teams = meeting('https://teams.microsoft.com/l/meetup-join/example');
+const window = (appId: string, title: string): Window => ({ key: 'one', appId, title });
+const zm = window('zoom', 'Zoom Meeting');
+
+test('scheduled time and clicking Join alone never establish window presence', () => {
+  expect(isPresent(observe([], [], [zoom], now, 5, { at: now, eventKey: eventKey(zoom) }), zoom, now)).toBe(false);
+  for (const title of ['Zoom Workplace', 'Zoom Settings', 'Waiting Room', 'Preview']) {
+    expect(isPresent(observe([], [window('zoom', title)], [zoom], now, 5), zoom, now)).toBe(false);
+  }
+});
+
+test('a specific meeting window matches its provider and calendar identity', () => {
+  for (const [event, win] of [
+    [zoom, zm], [zoom, window('zoom', 'Zoom Meeting - 123 4567 8901')],
+    [meet, window('google-chrome', 'Meet - abc-defg-hij - Google Chrome')],
+    [meet, window('firefox', 'Design sync - Google Meet — Mozilla Firefox')],
+    [teams, window('teams-for-linux', 'Design sync | Microsoft Teams')],
+  ] as const) {
+    expect(isPresent(observe([], [win], [event], now, 5), event, now)).toBe(true);
+  }
+  expect(isPresent(observe([], [window('code', 'Meet - abc-defg-hij')], [meet], now, 5), meet, now)).toBe(false);
+  expect(isPresent(observe([], [window('chromium', 'Meet - xxx-yyyy-zzz')], [meet], now, 5), meet, now)).toBe(false);
+  expect(isPresent(observe([], [window('teams-for-linux', 'Chat | Design sync | Microsoft Teams')], [teams], now, 5), teams, now)).toBe(false);
+});
+
+test('presence turns red only during the event and disappears on close or tab change', () => {
+  const event = meeting(meet.conference!, { start_ms: now + 60000 });
+  const win = window('chromium', 'Meet - abc-defg-hij');
+  const records = observe([], [win], [event], now, 5);
+  expect(isPresent(records, event, now)).toBe(false);
+  expect(isPresent(records, event, event.start_ms)).toBe(true);
+  expect(isPresent(records, event, event.end_ms)).toBe(false);
+  expect(isPresent(observe(records, [], [event], now + 60000, 5), event, now + 60000)).toBe(false);
+  const changed = { ...win, title: 'Mail - Chromium' };
+  expect(isPresent(observe(records, [changed], [event], now + 60000, 5), event, now + 60000)).toBe(false);
+});
+
+test('an old window never migrates to the next occurrence as the clock advances', () => {
+  const next = meeting(zoom.conference!, { start_ms: zoom.end_ms, end_ms: zoom.end_ms + 3600000 });
+  const records = observe([], [zm], [zoom, next], now, 5);
+  const later = observe(records, [zm], [next], next.start_ms, 5);
+  expect(isPresent(later, next, next.start_ms)).toBe(false);
+  expect(isPresent(observe(later, [], [next], next.start_ms, 5), next, next.start_ms)).toBe(false);
+  expect(isPresent(observe([], [{ ...zm, key: 'new' }], [next], next.start_ms, 5), next, next.start_ms)).toBe(true);
+});
+
+test('a new Zoom window can use a recent Join target while ambiguous windows stay neutral', () => {
+  const next = meeting('https://zoom.us/j/98765432109', { start_ms: now + 60000 });
+  const events = [zoom, next];
+  expect(isPresent(observe([], [zm], events, now, 5), zoom, now)).toBe(false);
+  const intent = { at: now, eventKey: eventKey(next) };
+  const records = observe([], [zm], events, now, 5, intent);
+  expect(isPresent(records, next, next.start_ms)).toBe(true);
+  expect(isPresent(records, zoom, now)).toBe(false);
+  const old = observe([], [zm], [zoom], now, 5);
+  expect(isPresent(observe(old, [zm], events, now, 5, intent), next, next.start_ms)).toBe(false);
+  expect(isPresent(observe([], [zm], events, now, 5, { ...intent, at: now - 90001 }), zoom, now)).toBe(false);
+});
+
+test('duplicate calendar copies do not make one meeting ambiguous', () => {
+  const duplicate = { ...zoom, calendar: 'Other calendar' };
+  expect(isPresent(observe([], [zm], [zoom, duplicate], now, 5), zoom, now)).toBe(true);
+});
+
+test('malformed, oversized and hostile metadata fail neutral', () => {
+  for (const title of [null, 'x'.repeat(1025), 'Zoom\u202e Meeting', '<b>Zoom Meeting</b>']) {
+    expect(observe([], [window('zoom', title as string)], [zoom], now, 5).some(r => r.eventKey)).toBe(false);
+  }
+  expect(observe([], Array(257).fill(zm), [zoom], now, 5)).toEqual([]);
+  expect(observe([], [zm], Array(257).fill(zoom), now, 5)).toEqual([]);
+  for (const url of ['https://zoom.us.attacker.test/j/12345678901', 'file:///zoom.us/j/12345678901', 'https://zoom.us@attacker.test/j/12345678901']) {
+    expect(eventKey(meeting(url))).toBe('');
+  }
+});

--- a/ui/tests/menubar.spec.ts
+++ b/ui/tests/menubar.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect } from '@playwright/test';
+import { countdownDuration, progress, joinable, uniqueAllDay, type Event } from '../../packaging/omarchy-plugin/Timeline.mjs';
+const at = (hour: number) => Date.UTC(2026, 8, 7, hour);
+const event = (title: string, start: number, end: number, extra = {}): Event => ({
+  title, start_ms: at(start), end_ms: at(end), all_day: false, ...extra,
+});
+
+test('Join respects the configured window and exclusive end, skipping focus blocks', () => {
+  const events = [event('Focus', 9, 17), event('Call', 13, 14, { conference: 'https://meet.google.com/abc' })];
+  expect(joinable(events, at(13) - 5 * 60000 - 1, 5)).toBeNull();
+  expect(joinable(events, at(13) - 5 * 60000, 5)?.title).toBe('Call');
+  expect(joinable(events, at(13) - 1, 0)).toBeNull();
+  expect(joinable(events, at(13), 0)?.title).toBe('Call');
+  expect(joinable(events, at(14), 60)).toBeNull();
+  expect(joinable([event('Bad', 13, 14, { conference: 'file:///tmp/example' })], at(13), 5)).toBeNull();
+});
+
+test('back-to-back Join switches at the lead window and stays with the new call', () => {
+  const current = event('Current', 12, 14, { conference: 'https://meet.google.com/current' });
+  const next = event('Next', 13, 14, { conference: 'https://meet.google.com/next' });
+  const later = event('Later', 14, 15, { conference: 'https://meet.google.com/later' });
+  const events = [later, current, next];
+  expect(joinable(events, at(13) - 300001, 5)?.title).toBe('Current');
+  expect(joinable(events, at(13) - 300000, 5)?.title).toBe('Next');
+  expect(joinable(events, at(13) - 60000, 0)?.title).toBe('Current');
+  expect(joinable(events, at(13), 0)?.title).toBe('Next');
+  expect(joinable(events, at(14), 0)?.title).toBe('Later');
+});
+
+test('progress clamps completed and future meetings', () => {
+  const e = event('Design', 13, 14);
+  expect([progress(e, at(12)), progress(e, at(13) + 30 * 60000), progress(e, at(15))]).toEqual([0, .5, 1]);
+
+});
+
+async function popup(page: import('@playwright/test').Page) {
+  await page.clock.install({ time: at(13) + 21 * 60000 });
+  await page.setViewportSize({ width: 420, height: 600 });
+  await page.addInitScript(({ start, end }) => {
+    const calls: { action: string }[] = [];
+    (window as any).__actions = calls;
+    const events = [
+      { title: 'Morning planning', start_ms: start + 9 * 3600000, end_ms: start + 10 * 3600000, all_day: false, color: '#7da9e8' },
+      { title: 'Design sync', start_ms: start + 13 * 3600000, end_ms: start + 14 * 3600000, all_day: false, color: '#7da9e8', conference: 'https://meet.google.com/abc', calendar: 'Work' },
+      { title: '<b>Project review</b>', start_ms: start + 13.5 * 3600000, end_ms: start + 14.5 * 3600000, all_day: false, color: '#dba575' },
+      { title: 'Labor Day', start_ms: start, end_ms: end, all_day: true, color: '#a8bd94', calendar: 'Personal' },
+      { title: 'Labor Day', start_ms: start, end_ms: end, all_day: true, color: '#abcdef', calendar: 'Work' },
+    ];
+    const panel = { day_start_ms: start, day_end_ms: end, events, timezone: 'UTC', date_format: 'dmy', time_format: '24h', label: true, join_minutes: 5 };
+    const callbacks = new Map<number, (event: unknown) => void>();
+    let nextCallback = 0;
+    let changedCallback: number | undefined;
+    (window as any).__changeMenuFormat = () => {
+      panel.time_format = '12h';
+      if (changedCallback !== undefined) callbacks.get(changedCallback)?.({ event: 'menubar-changed', payload: null });
+    };
+    (window as any).__TAURI_INTERNALS__ = {
+      transformCallback: (callback: (event: unknown) => void) => { callbacks.set(++nextCallback, callback); return nextCallback; },
+      invoke: async (cmd: string, args: any) => {
+        if (cmd === 'plugin:event|listen') { if (args.event === 'menubar-changed') changedCallback = args.handler; return 1; }
+        if (cmd === 'plugin:event|unlisten') return;
+        if (cmd === 'menubar_feed') return { events: events.filter(e => e.end_ms > start + 13 * 3600000), panel, tasks: [] };
+        if (cmd === 'get_palette') return { bg: '#20232b', surface: '#303540', text: '#e5e7eb', muted: '#9ca3af', accent: '#87b7ff', is_dark: true };
+        if (cmd === 'menubar_action') { calls.push(args); return; }
+        throw new Error(cmd);
+      },
+    };
+  }, { start: at(0), end: at(24) });
+  await page.goto('/?menubar');
+}
+
+test('popup shows elapsed time, renders titles as text, and joins', async ({ page }) => {
+  await popup(page);
+  await expect(page.getByRole('button', { name: 'Join · Design sync' })).toBeVisible();
+  await expect(page.getByRole('button', { name: /Morning planning/ })).toHaveClass(/past/);
+  await expect(page.getByText('39m left')).toBeVisible();
+  await expect(page.locator('header p')).toHaveText('07/09/2026 · 13:21');
+  await page.clock.fastForward(60000);
+  await expect(page.locator('header p')).toHaveText('07/09/2026 · 13:22');
+  await page.getByRole('button', { name: 'Add event', exact: true }).click();
+  expect(await page.evaluate(() => (window as any).__actions)).toContainEqual({ action: 'quick-add' });
+  await expect(page.getByRole('button', { name: 'Labor Day', exact: true })).toHaveCount(1);
+  await expect(page.locator('.agenda > :first-child')).toHaveClass(/all-day/);
+  await expect(page.getByText('<b>Project review</b>')).toBeVisible();
+  const elapsed = page.getByRole('progressbar', { name: 'Elapsed time: Design sync' });
+  await expect(elapsed).toHaveAttribute('aria-valuenow', '37');
+  const track = await elapsed.boundingBox();
+  const fill = await elapsed.locator('.now-fill').boundingBox();
+  expect(fill!.width / track!.width).toBeCloseTo(22 / 60, 2);
+  const marker = await page.locator('.now-marker').boundingBox();
+  const activeRow = await page.getByRole('button', { name: /Design sync.*38m left/ }).boundingBox();
+  expect(marker!.y + marker!.height).toBeLessThanOrEqual(activeRow!.y);
+  await page.screenshot({ path: '/tmp/omacal-menubar-agenda.png' });
+  await page.getByRole('button', { name: 'Join · Design sync' }).click();
+  expect(await page.evaluate(() => (window as any).__actions)).toEqual([{ action: 'quick-add' }, { action: 'join' }]);
+  await page.keyboard.press('Escape');
+  expect(await page.evaluate(() => (window as any).__actions)).toContainEqual({ action: 'close' });
+});
+
+test('all-day duplicates combine only matching titles and spans without changing the feed', () => {
+  const holiday = event('Holiday', 0, 24, { all_day: true, calendar: 'Personal' });
+  const otherSpan = event('Holiday', 0, 48, { all_day: true });
+  const unnamed = event('', 0, 24, { all_day: true });
+  const meeting = event('Call', 9, 10);
+  const events = [holiday, { ...holiday, calendar: 'Work' }, otherSpan, unnamed, unnamed, meeting, meeting];
+  expect(uniqueAllDay(events)).toEqual([holiday, otherSpan, unnamed, unnamed, meeting, meeting]);
+  expect(events).toHaveLength(7);
+});
+
+
+test('popup gear opens OmaCal preferences', async ({ page }) => {
+  await popup(page);
+  await page.getByRole('button', { name: 'Open preferences' }).click();
+  expect(await page.evaluate(() => (window as any).__actions)).toEqual([{ action: 'preferences' }]);
+});
+
+
+test('countdown uses hours at sixty minutes and omits zero remaining minutes', () => {
+  expect([1, 59, 60, 64, 120, 642].map(countdownDuration)).toEqual(['1m', '59m', '1h', '1h 4m', '2h', '10h 42m']);
+});
+
+test('open agenda applies a changed clock format without waiting for polling', async ({ page }) => {
+  await popup(page);
+  await expect(page.locator('header p')).toHaveText('07/09/2026 · 13:21');
+  await page.evaluate(() => (window as any).__changeMenuFormat());
+  await expect(page.locator('header p')).toHaveText('07/09/2026 · 1:21 PM');
+});

--- a/ui/tests/popup-clock.spec.ts
+++ b/ui/tests/popup-clock.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+import { currentClock } from '../../packaging/omarchy-plugin/Timeline.mjs';
+test('popup clock advances through midnight in the configured zone and time format', () => {
+  const ms = Date.UTC(2026, 8, 8, 4, 59);
+  expect(currentClock(ms, '12h', -18000)).toBe('11:59pm');
+  expect(currentClock(ms + 60000, '12h', -18000)).toBe('12:00am');
+  expect(currentClock(ms + 60000, '24h', -18000)).toBe('00:00');
+});

--- a/ui/tests/widget-feed.spec.ts
+++ b/ui/tests/widget-feed.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from '@playwright/test';
+import { mkdtempSync, writeFileSync, symlinkSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+const helper = fileURLToPath(new URL('../../packaging/omarchy-plugin/read-feed.py', import.meta.url));
+
+test('feed reader rejects oversized, malformed, non-object, symlink and FIFO inputs', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'omacal-feed-'));
+  const path = join(dir, 'feed');
+  const read = (p = path) => spawnSync('/usr/bin/python3', [helper, p], { timeout: 3000, encoding: 'utf8' });
+  try {
+    for (const content of ['null', '[]', 'true', '2', '"hello"', '{', '{"events":[null]}', '{"events":[]}' + ' '.repeat(2 * 1024 * 1024 - 12)]) {
+      writeFileSync(path, content);
+      expect(read().status).not.toBe(0);
+    }
+    writeFileSync(path, '{"events":[]}');
+    symlinkSync(path, join(dir, 'link'));
+    expect(read(join(dir, 'link')).status).not.toBe(0);
+    expect(spawnSync('mkfifo', [join(dir, 'fifo')]).status).toBe(0);
+    const fifo = read(join(dir, 'fifo'));
+    expect(fifo.status).toBe(1);
+    expect(fifo.error).toBeUndefined();
+    writeFileSync(path, '{"events":[]}' + ' '.repeat(2 * 1024 * 1024 - 13));
+    expect(read().status).toBe(0);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('feed reader bounds and sanitizes text before the shell receives it', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'omacal-feed-'));
+  try {
+    const path = join(dir, 'feed');
+    writeFileSync(path, JSON.stringify({ events: [{ title: '<b>Design</b>\u202e\n' + 'x'.repeat(4000), start_ms: 1, end_ms: 2, all_day: false }] }));
+    const result = spawnSync('/usr/bin/python3', [helper, path], { timeout: 3000, encoding: 'utf8' });
+    expect(result.status).toBe(0);
+    const title = JSON.parse(result.stdout).events[0].title;
+    expect(title).toContain('<b>Design</b>');
+    expect(title).not.toMatch(/[\u202e\n]/);
+    expect(title.length).toBeLessThanOrEqual(2048);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('zero-duration events keep the feed available in every agenda list', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'omacal-instant-feed-'));
+  try {
+    const path = join(dir, 'feed');
+    const meeting = {title: 'Design review', start_ms: 1000, end_ms: 2000, all_day: false};
+    const instant = {title: 'Deadline', start_ms: 3000, end_ms: 3000, all_day: false};
+    const events = [meeting, instant];
+    const panel = {events, agenda_days: [{date_label: 'Sep 9', events}], day_view: false,
+      label: true, day_start_ms: 0, day_end_ms: 86400000, join_minutes: 5, clocks: {}, hours: []};
+    const read = (feed: unknown) => {
+      writeFileSync(path, JSON.stringify(feed));
+      return spawnSync('/usr/bin/python3', [helper, path], {timeout: 3000, encoding: 'utf8'});
+    };
+    const result = read({events, panel});
+    expect(result.status).toBe(0);
+    const feed = JSON.parse(result.stdout);
+    expect(feed.events).toEqual(events);
+    expect(feed.panel.events).toEqual(events);
+    expect(feed.panel.agenda_days[0].events).toEqual(events);
+
+    // Equal timestamps are allowed; reversed intervals still fail validation.
+    const reversed = {...instant, end_ms: instant.start_ms - 1};
+    for (const invalid of [
+      {events: [meeting, reversed], panel},
+      {events, panel: {...panel, events: [reversed]}},
+      {events, panel: {...panel, agenda_days: [{date_label: 'Sep 9', events: [reversed]}]}},
+    ]) expect(read(invalid).status).not.toBe(0);
+  } finally { rmSync(dir, {recursive: true, force: true}); }
+});
+
+test('agenda feed accepts five days and rejects invalid or oversized day groups', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'omacal-agenda-feed-'));
+  try {
+    const path = join(dir, 'feed');
+    const event = {title: '<b>Name</b>\u202e', start_ms: 1, end_ms: 2, all_day: false};
+    const day = {date_label: 'Sep 7', events: [event]};
+    const panel = {events: [], day_view: false, label: true, day_start_ms: 0, day_end_ms: 86400000, join_minutes: 5, clocks: {}, hours: []};
+    for (const days of [null, [null], Array(8).fill(day), [{...day, events: [null]}],
+      [{...day, events: Array(101).fill(event)}, {...day, events: Array(100).fill(event)}]]) {
+      writeFileSync(path, JSON.stringify({events: [], panel: {...panel, agenda_days: days}}));
+      expect(spawnSync('/usr/bin/python3', [helper, path]).status).not.toBe(0);
+    }
+    writeFileSync(path, JSON.stringify({events: [], panel: {...panel, agenda_days: Array(5).fill(day)}}));
+    const result = spawnSync('/usr/bin/python3', [helper, path], {encoding:'utf8'});
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).panel.agenda_days[4].events[0].title).toBe('<b>Name</b>');
+  } finally { rmSync(dir, {recursive:true, force:true}); }
+});

--- a/ui/tests/widget-model.spec.ts
+++ b/ui/tests/widget-model.spec.ts
@@ -14,8 +14,9 @@ const source = readFileSync(
 );
 // eslint-disable-next-line @typescript-eslint/no-implied-eval
 const Model = new Function(
-  `${source}; return { parseFeed, sections, isMultiDay, untilText, timeText };`,
+  `${source}; return { agendaSections, parseFeed, sections, isMultiDay, untilText, timeText };`,
 )() as {
+  agendaSections: (feed: { events: Ev[]; panel: { events: Ev[]; agenda_days?: { date_label: string; events: Ev[] }[] } }, now: number, cap: number) => { title: string; rows: Ev[] }[];
   parseFeed: (text: string) => unknown;
   sections: (
     events: Ev[] | null,
@@ -93,7 +94,7 @@ test.describe('the popup sections', () => {
       NOW,
       12,
     );
-    expect(titles(out)).toEqual(['ONGOING', 'ALL DAY', 'UPCOMING']);
+    expect(titles(out)).toEqual(['ALL DAY', 'ONGOING', 'UPCOMING']);
   });
 
   test('an all-day event does not count as today still having something', () => {
@@ -127,3 +128,18 @@ test.describe('the popup sections', () => {
     expect(out[0].rows.map((r) => r.title)).toEqual(['A']);
   });
 });
+
+test('all-day stays above earlier, ongoing and upcoming agenda rows', () => {
+  const events = [allDay('Holiday', 0, 1), timed('Finished', NOW - 2 * HOUR, NOW - HOUR),
+    timed('Current', NOW - HOUR, NOW + HOUR), timed('Next', NOW + 2 * HOUR, NOW + 3 * HOUR)];
+  expect(titles(Model.agendaSections({ events: events.filter(e => e.end_ms > NOW), panel: { events } }, NOW, 12)))
+    .toEqual(['ALL DAY', 'EARLIER TODAY', 'ONGOING', 'UPCOMING']);
+});
+
+ test('agenda includes every configured day and does not use the old twelve-event cap', () => {
+  const days = Array.from({length: 5}, (_, d) => ({ date_label: `Day ${d + 1}`,
+    events: Array.from({length: 8}, (_, i) => timed(`Event ${d}-${i}`, NOW + (d * 24 + i + 1) * HOUR, NOW + (d * 24 + i + 2) * HOUR)) }));
+  const out = Model.agendaSections({events: [], panel: {events: days[0].events, agenda_days: days}}, NOW, 12);
+  expect(out.map(s => s.title)).toEqual(['UPCOMING', 'TOMORROW', 'Day 3', 'Day 4', 'Day 5']);
+  expect(out.flatMap(s => s.rows)).toHaveLength(40);
+ });


### PR DESCRIPTION
Show the current or next meeting in the bar with a live countdown and a camera button between the logo and title. Join appears at the chosen lead time, including handing off to a back-to-back meeting before it starts. A red pulsing indicator means a matching meeting window is open during its scheduled time.

The agenda keeps earlier events, shows elapsed progress, follows the configured week length, and scrolls between a fixed header and footer. Add and Preferences are available in the popup; settings changes refresh immediately. Includes the macOS agenda popup.

The full-day timeline and view switcher have been split into #108 for separate review, as requested. The bounded feed reader stays here because the agenda uses it too.

Validated with Rust workspace tests, clippy, Svelte/TypeScript checks, 58 focused browser/model/feed tests, QML lint and plugin validation. The QML capture below runs the actual widget and installed Omarchy components in an isolated headless display with synthetic events; it is not a browser rendering.

![Actual Omarchy agenda widget](https://raw.githubusercontent.com/jondkinney/omacal/a79aeabc3cf0fd3519719a39480a83b103faa52a/review/20260910/omarchy-agenda.png)
