### PR TITLE
fix(settings): the appearance copy and comments describe the code again

### DIFF
--- a/ui/src/lib/SettingsModal.svelte
+++ b/ui/src/lib/SettingsModal.svelte
@@ -840,7 +840,6 @@
             <span class="rownote" data-testid="tz-note">Restarting…</span>
           {/if}
         </div>
-
       </div>
       <p class="hint">
         Every time OmaCal shows reads in this zone — the grid, reminders, the
@@ -859,7 +858,6 @@
             onclick={applySecondZone}
           >Apply</button>
         </div>
-
       </div>
       <p class="hint">
         A second clock beside the first — on the Week and Day hour ruler, and
@@ -1092,8 +1090,10 @@
           </output>
         </div>
         <p class="hint">
-          0% is opaque; 50% is half transparent. Adjust in 0.1% steps. Inactive applies when another window has focus.
-          Your compositor may apply additional transparency.
+          0% is opaque; 50% is as clear as the canvas goes, in 0.1% steps.
+          Inactive applies when another window has focus. Omarchy blends
+          every window a little on its own, so there the app starts at 4% to
+          match, and the compositor's share stays on top.
         </p>
       </section>
       {/if}
@@ -1509,15 +1509,9 @@
      any component that restyles a select's padding owes the right side 22px. */
   select { padding-right: 22px; }
   input[type='number'] { width: 72px; }
-  /* Wide enough for "Australia/Lord_Howe"; scoped to the inline rows so the
-     CalDAV form below keeps its own column width. */
   input:focus, select:focus { outline: 1px solid var(--accent); outline-offset: -1px; }
 
   .caldot { width: 10px; height: 10px; border-radius: 3px; flex: none; }
-
-  /* The zone search results: plain rows under the box, in the flow rather
-     than floating — the modal scrolls, and a floating list inside a
-     scrolling body clips. Eight rows at most (the derivation caps it). */
 
   .check { display: flex; align-items: center; gap: 7px; font-size: 12.5px; cursor: pointer; }
 

--- a/ui/src/lib/appearance.ts
+++ b/ui/src/lib/appearance.ts
@@ -39,7 +39,9 @@ function applyBackground(preferences: AppearancePreferences, root: HTMLElement) 
 }
 
 /**
- * Applies absolute transparency: 0 is opaque and 100 is clear.
+ * Applies absolute transparency: 0 is opaque, and the cap for each surface
+ * is as clear as it goes — 50 for the canvas, 25 for event fills. Both are
+ * expressed in tenths of a percent, so Omarchy's own blend is reachable.
  *
  * Omacal opts out of Omarchy's whole-window opacity when these controls are
  * installed, then reproduces that former baseline in the stored defaults.


### PR DESCRIPTION
Follow-up to #83 and #85, both merged today. Four small corrections where the prose outlived the code it described — the kind of thing that reads as fact to the next person in the file.

**Two orphaned comments from #83.** That PR replaced the in-flow match lists with a portalled combobox, deleting both the `.tzlist` rules and `.inline input[type='text'] { width: 220px }`. Each rule's comment stayed. One of them now claimed the results sit *"in the flow rather than floating — the modal scrolls, and a floating list inside a scrolling body clips"*, which is the opposite of what `TimezoneSelect` does, and the opposite of the reason it does it. It also left two blank lines where the `{#if tzMatches}` blocks were.

**A stale docstring from #85.** `applyAppearance` still promised *"0 is opaque and 100 is clear"* after the sliders were narrowed to 0–50 for the canvas and 0–25 for event fills, in tenths of a percent.

**A hint that lost the only thing worth saying.** #85 replaced the Omarchy explanation with *"Your compositor may apply additional transparency"* — true of any compositor, and an answer to no question a user has. The sentence it replaced answered the one this control actually raises: **why does my slider start at 4 and not 0?** On an Omarchy-first app that baseline is the number worth naming, so it is back, beside the new 0.1%-step and inactive-window wording.

No behaviour change: comments, a docstring and one hint string.

Gate: `npm run check` 266 files / 0 errors, Playwright suite 1974 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GabzsFfyts4eNZMbTkhtkQ