### PR TITLE
fix(restart): wait for helpers to be reaped before returning

### DIFF
--- a/src-tauri/src/restart.rs
+++ b/src-tauri/src/restart.rs
@@ -220,8 +220,7 @@ pub(crate) fn stop_webkit_helpers() {
     // below is for).
     let deadline = std::time::Instant::now() + std::time::Duration::from_millis(1500);
     loop {
-        reap(&first);
-        if first.iter().all(|&pid| !alive(pid)) || std::time::Instant::now() >= deadline {
+        if reap(&first) || std::time::Instant::now() >= deadline {
             break;
         }
         std::thread::sleep(std::time::Duration::from_millis(20));
@@ -234,10 +233,15 @@ pub(crate) fn stop_webkit_helpers() {
             libc::kill(pid as libc::pid_t, libc::SIGKILL);
         }
     }
+    // The live-process sweep excludes zombies. Keep the original children
+    // in the reap set too: one may have exited as the first deadline elapsed.
+    let mut pending = first.clone();
+    pending.extend(left.iter().copied());
+    pending.sort_unstable();
+    pending.dedup();
     let deadline = std::time::Instant::now() + std::time::Duration::from_millis(300);
     loop {
-        reap(&left);
-        if left.iter().all(|&pid| !alive(pid)) || std::time::Instant::now() >= deadline {
+        if reap(&pending) || std::time::Instant::now() >= deadline {
             break;
         }
         std::thread::sleep(std::time::Duration::from_millis(10));
@@ -245,23 +249,21 @@ pub(crate) fn stop_webkit_helpers() {
     tracing::info!(stopped = first.len(), killed = left.len(), "webkit helpers stopped before the restart");
 }
 
-/// Whether `pid` is still a running process: present in `/proc` and not a
-/// zombie. A reaped process has no entry at all.
-fn alive(pid: u32) -> bool {
-    std::fs::read_to_string(format!("/proc/{pid}/stat"))
-        .ok()
-        .and_then(|stat| parse_stat(&stat))
-        .is_some_and(|(_, _, state, _)| state != 'Z' && state != 'X')
-}
-
-/// Collects whichever of `pids` have exited, without blocking on the rest.
-fn reap(pids: &[u32]) {
+/// Collects exited children and reports whether every child has been reaped.
+/// A child can exit just after WNOHANG returns zero. Checking its liveness
+/// separately would then see a zombie and stop waiting before collecting it.
+fn reap(pids: &[u32]) -> bool {
+    let mut done = true;
     for &pid in pids {
         let mut status = 0;
-        unsafe {
-            libc::waitpid(pid as libc::pid_t, &mut status, libc::WNOHANG);
-        }
+        let result = unsafe {
+            libc::waitpid(pid as libc::pid_t, &mut status, libc::WNOHANG)
+        };
+        // Another owner (e.g. WebKit) may already have collected this child.
+        done &= result == pid as libc::pid_t
+            || (result == -1 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ECHILD));
     }
+    done
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Cherry-picks `810c33df` out of #81, unchanged and with @jondkinney's authorship intact, so `main` stops flaking regardless of when that PR's calendar-labels half is reviewed. The commit touches `restart.rs` and nothing else, and it is independent of the feature it happens to be sitting behind.

## Why now

`main`'s own CI run for the #83 merge ([34199540361](https://github.com/x3me/omacal/actions/runs/34199540361)) went red on `rust` while both UI jobs passed:

```
restart::tests::a_child_named_like_a_webkit_helper_is_stopped_and_an_ordinary_one_is_not
panicked at src-tauri/src/restart.rs:403: and reaped, not left as a zombie
```

**#83 changed no Rust at all**, so it cannot have caused that — the test is flaky. @jondkinney hit the same failure independently on #81's CI and wrote this fix for it.

## The race

`stop_webkit_helpers` SIGTERMs each helper, then loops:

```rust
reap(&first);
if first.iter().all(|&pid| !alive(pid)) || past_deadline { break; }
```

`reap` calls `waitpid(pid, WNOHANG)` and **discards the result**. `alive` reads `/proc/<pid>/stat` and returns false for state `'Z'`.

So if a child exits in the gap between those two — `waitpid` returns 0 having collected nothing, and microseconds later `alive` sees a zombie and reports "not alive" — the loop breaks having reaped nobody. The child stays a zombie. `webkit_helpers` excludes zombies (its own unit test asserts exactly that: `!is_webkit_helper_of(me, 204, me, 'Z', "WebKitWebProces")`), so the second sweep's `left` is empty and never collects it either. The assertion that `/proc/<pid>` is gone then fails.

The fix removes the two-step entirely: `reap` now reports completion from `waitpid`'s own result — the pid returned, or `ECHILD` when another owner already collected the child — so there is no window between deciding and observing. It also adds `first` to the second sweep's pending set, covering a child that exits just as the first deadline elapses.

## Scope, stated honestly

**This is a CI-stability fix, not a user-visible one.** The early break only ever happens on a *zombie*, which has already released its files and so cannot hold the AppImage mount that motivated #63. A still-running child keeps `alive` true and the loop continues correctly. The cost of the bug is a red `main` at random, which is quite enough reason to land it.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo test --workspace` — 914 passed across 14 binaries.
- **The flake did not reproduce on this machine**, before or after: 300 sequential runs under 8-way CPU load and 200 concurrent runs of the failing test on the *unfixed* build both came back clean. The window is the few microseconds between one syscall and one file read, entered once per 20 ms iteration, so it needs a loaded CI runner. A green loop on the fixed build therefore proves nothing on its own and is not offered as proof — the evidence here is the two independent CI failures plus the race being visible in the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GabzsFfyts4eNZMbTkhtkQ
