### PR TITLE
fix(reminders): a clicked reminder selects its meeting instead of opening it

### DIFF
--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -171,6 +171,9 @@
    * another press advances again instead of silently paging without bound. */
   let pendingEventMove = $state<-1 | 1 | null>(null);
   let pendingKeyboardDay = $state<number | null>(null);
+  /** An exact occurrence waiting for its day to load, rather than a direction
+   *  to move in — what a clicked reminder parks. Cleared with the other two. */
+  let pendingKeyboardEvent = $state<{ id: number; startMs: number } | null>(null);
 
   let status = $state<AppStatus | null>(null);
   let calendars = $state<Calendar[]>([]);
@@ -237,10 +240,39 @@
     const un = listen<string>('open-date', (e) => { anchorMs = ymdMs(e.payload); });
     return () => { un.then((f) => f()); };
   });
+  /** A clicked reminder lands on its meeting and **selects** it, opening
+   *  nothing.
+   *
+   *  `notify::Action::OpenEvent` already says the click "means 'show me',
+   *  never anything with side effects" — but it used to open the popover,
+   *  which is a panel with Yes/Maybe/No, Edit and Delete in it. Showing
+   *  somebody where a meeting is and putting its destructive controls under
+   *  their cursor are different favours (Plamen, 2026-09-08).
+   *
+   *  Selection rather than a highlight of its own: the keyboard cursor
+   *  already means "this is the event in question", already scrolls itself
+   *  into view, and is already the thing every other surface here defers to.
+   *  A second visual language for the same idea would be one to keep in
+   *  step forever.
+   *
+   *  Year and Big Year cannot draw a cursor, and anchoring them alone would
+   *  leave the click showing a grid of months with nothing marked — strictly
+   *  less than the popover it replaces. Those two land on the week instead,
+   *  which is the view that can answer "where is it". */
   $effect(() => {
     const un = listen<{ id: number; startMs: number; endMs: number }>('open-event', (e) => {
-      anchorMs = dayStart(e.payload.startMs);
-      void openOccurrence(e.payload.id, e.payload.startMs, e.payload.endMs, keyboardAnchor());
+      const dayStartMs = dayStart(e.payload.startMs);
+      anchorMs = dayStartMs;
+      if (!listable(view)) view = 'week';
+      keyboardActive = true;
+      // The day may not be loaded yet — the anchor above may have just moved
+      // the period. Park the occurrence the same way `loadKeyboardDay` parks
+      // a direction, and let the payload effect place the cursor once the
+      // day it belongs to actually arrives.
+      pendingKeyboardDay = dayStartMs;
+      pendingEventMove = null;
+      pendingKeyboardEvent = { id: e.payload.id, startMs: e.payload.startMs };
+      selectKeyboard(dayCursor(dayStartMs));
     });
     return () => { un.then((f) => f()); };
   });
@@ -556,6 +588,7 @@
     }
     pendingKeyboardDay = null;
     pendingEventMove = null;
+    pendingKeyboardEvent = null;
     selectKeyboard(moved.cursor);
   }
 
@@ -636,10 +669,20 @@
 
     if (pendingKeyboardDay !== null) {
       if (!days.some((day) => day.startMs === pendingKeyboardDay)) return;
+      const pendingDay = pendingKeyboardDay;
       const eventDir = pendingEventMove;
+      const exact = pendingKeyboardEvent;
       pendingKeyboardDay = null;
       pendingEventMove = null;
-      if (eventDir !== null) {
+      pendingKeyboardEvent = null;
+      // A parked occurrence names its own destination, so it neither moves
+      // nor searches: place the cursor on it and let `selectKeyboard` reveal
+      // it. Taken before the direction arm because the two never coexist.
+      if (exact !== null) {
+        selectKeyboard({
+          dayStartMs: pendingDay, eventId: exact.id, eventStartMs: exact.startMs,
+        });
+      } else if (eventDir !== null) {
         const now = Date.now();
         const moved = moveEvent(
           days, keyboardCursor, eventDir, { nowMs: now },

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -8,7 +8,7 @@ import {
   CHORDS, EDIT_CHORDS, EVENT_SHORTCUT_LIST, SHORTCUT_LIST, SHORTCUT_TEXT,
 } from '../src/lib/shortcuts';
 import {
-  APP_MON, APP_NOW, weekLabel,
+  APP_MON, APP_NOW, KEYBOARD_FIRST_ID, weekLabel,
   APP_SOLO_SERIES_ID,
   APP_PRIMARY_CALENDAR_ID, APP_READER_CALENDAR_ID,
   APP_SERIES_DTSTART, APP_SERIES_OCCURRENCE,
@@ -210,19 +210,59 @@ test.describe('App', () => {
     await expect(page.locator('h1')).toHaveText('March 2024');
   });
 
-  /** The `open-event` entrance — a clicked reminder: land on the day *and*
-   *  open the popover on the occurrence, the same arrival a chosen search
-   *  hit gets. The occurrence sits 45 days out for the reason the Dentist
-   *  search fixture does: in the app's own January, a version that never
-   *  moved the anchor would pass. */
-  test('a clicked reminder lands on the occurrence and opens it', async ({ page }) => {
-    await page.goto(app());
-    await expect(page.locator('h1')).toHaveText('January 2024');
-    await page.evaluate(([id, start]) => window.__harness.emit('open-event', {
-      id, startMs: start, endMs: (start as number) + 3_600_000,
-    }), [APP_SOLO_SERIES_ID, APP_NOW + 45 * 24 * 3_600_000]);
-    await expect(page.locator('h1')).toHaveText('March 2024');
-    await expect(page.getByRole('dialog', { name: 'Gym' })).toBeVisible();
+  /** The `open-event` entrance — a clicked reminder: land on the occurrence
+   *  and **select** it, opening nothing.
+   *
+   *  It used to open the popover, which is a panel carrying Yes/Maybe/No,
+   *  Edit and Delete: showing somebody where a meeting is and putting its
+   *  destructive controls under their cursor are different favours (Plamen,
+   *  2026-09-08).
+   *
+   *  Three weeks out on purpose. The week is not loaded when the event
+   *  arrives, so a version that set the cursor synchronously would look for
+   *  the day among the *old* payload, find nothing and select nothing — the
+   *  parking is the half that carries this. `keyboard-navigation` because
+   *  its fixture draws each event in the day it actually starts in; the
+   *  `writable` week deliberately renders four events in Monday's column
+   *  whatever their `start_ms`, and no cursor could land on them.
+   */
+  test('a clicked reminder lands on the occurrence and selects it, opening nothing', async ({ page }) => {
+    await page.clock.setFixedTime(APP_MON + 8 * 3_600_000);
+    await page.goto(app('keyboard-navigation'));
+    await expect(page.locator('.vswitch button.active')).toBeVisible();
+    await expect(page.locator('[data-kbd-selected-event]')).toHaveCount(0);
+
+    const start = APP_MON + 21 * 24 * 3_600_000 + 9 * 3_600_000;
+    await page.evaluate(([id, s]) => window.__harness.emit('open-event', {
+      id, startMs: s, endMs: (s as number) + 3_600_000,
+    }), [KEYBOARD_FIRST_ID, start]);
+
+    // The anchor moved to the occurrence's own week...
+    await expect(page.locator('h1')).toHaveText('February 2024');
+    // ...and the occurrence itself is selected, not merely its day.
+    await expect(page.locator('[data-kbd-selected-event]')).toHaveCount(1);
+    await expect(page.locator('[data-kbd-selected-event]')).toContainText('Plan the launch');
+    // Nothing opened: not the popover it used to open, not anything else.
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+  });
+
+  /** Year draws no cursor, so anchoring it alone would leave the click showing
+   *  a grid of months with nothing marked — strictly less than the popover
+   *  this replaces. The click lands on a view that can answer "where is it". */
+  test('a reminder clicked from Year lands on a view that can show the selection', async ({ page }) => {
+    await page.clock.setFixedTime(APP_MON + 8 * 3_600_000);
+    await page.goto(app('keyboard-navigation'));
+    await page.getByRole('button', { name: 'Year', exact: true }).click();
+    await expect(page.locator('[data-kbd-selected-event]')).toHaveCount(0);
+
+    const start = APP_MON + 21 * 24 * 3_600_000 + 9 * 3_600_000;
+    await page.evaluate(([id, s]) => window.__harness.emit('open-event', {
+      id, startMs: s, endMs: (s as number) + 3_600_000,
+    }), [KEYBOARD_FIRST_ID, start]);
+
+    await expect(page.locator('[data-kbd-selected-event]')).toHaveCount(1);
+    await expect(page.locator('[data-kbd-selected-event]')).toContainText('Plan the launch');
+    await expect(page.getByRole('dialog')).toHaveCount(0);
   });
 
   /** The fresh-launch half of the same entrance: the date was parked on the


### PR DESCRIPTION
Clicking a reminder landed on the occurrence **and opened its popover** — the panel with Yes/Maybe/No, Edit and Delete in it. Showing somebody where a meeting is and putting its destructive controls under their cursor are different favours.

The backend already agreed in principle. `notify::Action::OpenEvent`:

> The click means "show me", never anything with side effects — a reminder is not a question the way an invitation is, so its click must not answer one.

It just took "show me" one step too far.

## Now

```
click reminder → window raised
               → view jumps to that day
               → occurrence selected, scrolled into view
               → nothing opens
```

**Selection rather than a highlight of its own.** The keyboard cursor already means "this is the event in question", already scrolls itself into view, and is already what every other surface defers to. A second visual language for the same idea would be one to keep in step forever.

**The occurrence is parked**, the way `loadKeyboardDay` parks a direction. The anchor has only just moved when the event arrives, so the target day is usually not loaded yet — a cursor set synchronously would search the *old* payload, find no such day, and select nothing.

**Year and Big Year land on the week.** Neither draws a cursor, so anchoring them alone would leave the click showing a grid of months with nothing marked — strictly less than the popover this replaces.

## The old spec could not have caught this

It asserted the popover opened. The popover fetches its own detail by id, so **it passed with the event absent from the grid entirely** — which is exactly the state the `default` fixture is in.

Two fixture facts that cost a while and are worth writing down:

- the `default` App scenario renders no events at all;
- the `writable` one deliberately draws its four events in **Monday's column whatever their `start_ms`**, so no cursor can ever land on them.

The specs therefore moved to `keyboard-navigation`, whose fixture draws each event in the day it actually starts in *and* serves any requested week — so the occurrence sits three weeks out and the anchor genuinely has to move.

## Verification

**Both halves are mutation-proven.** Dropping the parked occurrence reddens the pair; restoring the popover beside the selection reddens it too. So "selects it" and "opens nothing" are each independently held rather than one assertion carrying both.

Gate: clippy `-D warnings` clean, `npm run check` 268 files / 0 errors, Playwright **1986 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GabzsFfyts4eNZMbTkhtkQ