### PR TITLE
fix(google): send a length with the bodyless move request

### DIFF
--- a/crates/omacal-google/src/client.rs
+++ b/crates/omacal-google/src/client.rs
@@ -361,6 +361,23 @@ impl CalendarClient {
             ))
             .bearer_auth(&self.access_token)
             .query(&[("destination", destination), ("sendUpdates", send_updates)])
+            // **A bodyless POST still needs a length.** Everything this call
+            // says is in the query string, so there is no body — and reqwest
+            // omits `Content-Length` entirely rather than sending zero, which
+            // Google's endpoint answers with `411 Length Required`. Every
+            // move failed on it, for everyone, from the day the feature
+            // shipped: the request never reached the calendar logic at all.
+            //
+            // It took this long to find because `user_facing` discarded the
+            // status before anyone could read it — the move looked like a
+            // permissions or organizer problem for an evening (2026-09-08).
+            //
+            // The header explicitly, and **not** `.body("")`: reqwest drops a
+            // zero-length body entirely and sends no length with it, which is
+            // the shape that fails. Verified against a mock that printed the
+            // headers it received — `{authorization, accept, host}`, nothing
+            // more — rather than assumed.
+            .header(reqwest::header::CONTENT_LENGTH, "0")
             .send()
             .await
             .map_err(|e| ApiError::Transport(e.to_string()))?;
@@ -807,3 +824,4 @@ mod tests {
         ));
     }
 }
+

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -9496,6 +9496,12 @@ mod tests {
             .and(wiremock::matchers::path("/calendars/cal%40x.com/events/master1/move"))
             .and(wiremock::matchers::query_param("destination", "other@x.com"))
             .and(wiremock::matchers::query_param("sendUpdates", "all"))
+            // The move carries no body, and a bodyless POST still needs a
+            // length: without one Google answers `411 Length Required` and
+            // the move never happens. wiremock accepts a request with no
+            // `Content-Length` quite happily, which is exactly why this test
+            // passed for as long as the feature was broken (2026-09-08).
+            .and(wiremock::matchers::header_exists("content-length"))
             .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "id": "master1", "status": "confirmed",
                 "start": {"dateTime": "2026-08-03T09:00:00Z"},


### PR DESCRIPTION
**Every calendar move has failed since the feature shipped, for everyone.**

```
error=http error: 411 Length Required
```

Google's `events.move` is a POST whose entire content is in the query string. **reqwest drops a zero-length body entirely** — sending no `Content-Length` header at all rather than `0` — and Google's endpoint refuses that with 411. The request never reached any calendar logic.

## Verified, not assumed

A mock that printed the headers it actually received:

```
before:  {authorization, accept, host}
after:   {authorization, content-length: 0, accept, host}
```

Note that **`.body("")` does not fix it** — that was the first attempt, and the probe showed the header still absent. Hence the explicit header rather than an empty body.

## The test that should have caught it

`a_move_sends_the_master_to_the_destination_and_re_files_the_local_rows` passed for the entire time the feature was broken. It matched method, path and query params — and **wiremock accepts a bodyless POST quite happily**, so nothing about the missing header ever surfaced.

The assertion therefore goes into that test rather than a new one beside it:

```rust
.and(wiremock::matchers::header_exists("content-length"))
```

Mutation-checked: remove the header from the client and that test reddens.

## How it stayed hidden

The failure reached the user as *"Sync failed. See the application log for details."* — `user_facing` having discarded the status before anyone could read it, and the log being empty by construction. It looked like a permissions or organizer problem for an evening; four separate theories were wrong.

#92 made the status readable. The answer then took one line, which is the argument for that change better than the change's own description made it.

Gate: clippy `-D warnings` clean, workspace suite **921 passed across 14 binaries**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)