### PR TITLE
feat(form): a date picker we own, so an outside click can close it

### DIFF
--- a/ui/src/lib/DateField.svelte
+++ b/ui/src/lib/DateField.svelte
@@ -1,0 +1,182 @@
+<!-- ui/src/lib/DateField.svelte
+     A date field with a calendar we own.
+
+     Replaces `<input type="date">`, whose calendar is the platform's and
+     **cannot be closed from the page**: WebKitGTK's popup holds an input grab,
+     so an outside click never reaches us at all (#78, measured on the real
+     build — clicking another field while it is open does nothing whatever).
+     Escape was the only way out, because Escape is the one key the popup
+     itself handles. No listener could fix that; only owning the calendar can.
+
+     The text half keeps `yyyy-mm-dd` as its value, which is what
+     `EventFormValue` carries and what every caller already reads and writes.
+     Typing still works, and works unambiguously — no reader has to know
+     whether 06/09 means June or September. -->
+<script lang="ts">
+  import { weekStartDay } from './weekstartstore.svelte';
+  import {
+    addDays, addMonths, columnOf, formatYmd, monthGrid, parseYmd, weekdayNames, type Ymd,
+  } from './datepicker';
+
+  let { id, label, value = $bindable(''), disabled = false, open = $bindable(false), onchange }: {
+    id?: string;
+    label: string;
+    value?: string;
+    disabled?: boolean;
+    /** Bindable so the **owner** can take Escape for this layer too.
+     *
+     *  Not a private `$state`, and not an `escapeCloses` of its own: a child
+     *  listener runs before its parent's, closes itself, and the parent's
+     *  guard — reading state rather than history — then closes the panel
+     *  behind it off the same keystroke. `EventForm` says so where it takes
+     *  Escape, having been bitten by exactly this before; `CalendarPicker`
+     *  is bindable for the same reason. */
+    open?: boolean;
+    onchange?: (v: string) => void;
+  } = $props();
+  let input: HTMLInputElement | undefined = $state();
+
+  /** The month on screen, and the day the keyboard is on. Seeded from the
+   *  value when there is one and from today when there is not — opening an
+   *  empty field on January 1970 would be a joke at the user's expense. */
+  let cursor = $state<Ymd>(today());
+
+  function today(): Ymd {
+    const n = new Date();
+    return { y: n.getFullYear(), m: n.getMonth() + 1, d: n.getDate() };
+  }
+
+  const grid = $derived(monthGrid(cursor, weekStartDay()));
+  const headings = $derived(weekdayNames(weekStartDay()));
+  const monthLabel = $derived(new Intl.DateTimeFormat(undefined, {
+    month: 'long', year: 'numeric', timeZone: 'UTC',
+  }).format(new Date(Date.UTC(cursor.y, cursor.m - 1, 1))));
+
+  function show() {
+    if (disabled) return;
+    cursor = parseYmd(value) ?? today();
+    open = true;
+  }
+
+  function commit(d: Ymd) {
+    value = formatYmd(d);
+    onchange?.(value);
+    open = false;
+    input?.focus();
+  }
+
+  function onGridKey(e: KeyboardEvent) {
+    const step = { ArrowLeft: -1, ArrowRight: 1, ArrowUp: -7, ArrowDown: 7 }[e.key];
+    if (step !== undefined) {
+      e.preventDefault();
+      cursor = addDays(cursor, step);
+      return;
+    }
+    if (e.key === 'PageUp' || e.key === 'PageDown') {
+      e.preventDefault();
+      cursor = addMonths(cursor, e.key === 'PageUp' ? -1 : 1);
+      return;
+    }
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      commit(cursor);
+    }
+  }
+</script>
+
+<span class="datefield">
+  <input
+    bind:this={input}
+    {id}
+    type="text"
+    inputmode="numeric"
+    autocomplete="off"
+    spellcheck="false"
+    placeholder="yyyy-mm-dd"
+    aria-label={label}
+    {disabled}
+    {value}
+    oninput={(e) => { value = e.currentTarget.value; onchange?.(value); }}
+  />
+  <button
+    type="button"
+    class="open"
+    {disabled}
+    aria-label="Pick {label.toLowerCase()}"
+    aria-haspopup="dialog"
+    aria-expanded={open}
+    onclick={() => (open ? (open = false) : show())}
+  >▦</button>
+
+  {#if open}
+    <!-- A sibling of the panel, never a wrapper — `CalendarPicker`'s shape,
+         and the thing the platform's popup would never let us have. -->
+    <button class="scrim" aria-label="Close {label.toLowerCase()} chooser" onclick={() => (open = false)}></button>
+    <div class="cal" role="dialog" aria-label="{label} chooser">
+      <div class="head">
+        <button type="button" aria-label="Previous month" onclick={() => (cursor = addMonths(cursor, -1))}>‹</button>
+        <span aria-live="polite">{monthLabel}</span>
+        <button type="button" aria-label="Next month" onclick={() => (cursor = addMonths(cursor, 1))}>›</button>
+      </div>
+      <div class="names" aria-hidden="true">
+        {#each headings as h (h)}<span>{h}</span>{/each}
+      </div>
+      <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+      <div
+        class="days"
+        role="grid"
+        tabindex="0"
+        aria-label={monthLabel}
+        onkeydown={onGridKey}
+      >
+        {#each grid as cell (formatYmd(cell.date))}
+          {@const iso = formatYmd(cell.date)}
+          <button
+            type="button"
+            role="gridcell"
+            class:outside={!cell.inMonth}
+            class:on={iso === value}
+            class:cursor={iso === formatYmd(cursor)}
+            aria-selected={iso === value}
+            aria-label={iso}
+            onclick={() => commit(cell.date)}
+          >{cell.date.d}</button>
+        {/each}
+      </div>
+    </div>
+  {/if}
+</span>
+
+<style>
+  .datefield { position: relative; display: inline-flex; align-items: center; gap: 4px; }
+  input { font: inherit; font-size: 12.5px; color: var(--text); width: 108px;
+          background-color: color-mix(in srgb, var(--text) 5%, transparent);
+          border: 1px solid var(--hairline); border-radius: 5px; padding: 4px 6px; }
+  input:focus { outline: 1px solid var(--accent); outline-offset: -1px; }
+  input:disabled, .open:disabled { opacity: .5; cursor: default; }
+  .open { font: inherit; font-size: 12px; color: var(--muted); cursor: pointer;
+          background: none; border: 0; padding: 2px 4px; border-radius: 4px; }
+  .open:hover:not(:disabled) { color: var(--text); }
+
+  /* Covers the window beneath, so a press anywhere closes the calendar —
+     the whole point of owning it. */
+  .scrim { position: fixed; inset: 0; z-index: 40; background: none; border: 0;
+           padding: 0; cursor: default; }
+  .cal { position: absolute; top: calc(100% + 4px); left: 0; z-index: 41;
+         background: var(--surface); border: 1px solid var(--hairline);
+         border-radius: 8px; padding: 8px; box-shadow: 0 6px 20px #0005; }
+  .head { display: flex; align-items: center; justify-content: space-between; gap: 8px;
+          font-size: 12.5px; color: var(--text); margin-bottom: 6px; }
+  .head button { font: inherit; color: var(--muted); cursor: pointer; background: none;
+                 border: 0; padding: 2px 6px; border-radius: 4px; }
+  .head button:hover { color: var(--text); }
+  .names, .days { display: grid; grid-template-columns: repeat(7, 28px); gap: 2px; }
+  .names span { font-size: 10px; color: var(--muted); text-align: center; }
+  .days:focus-visible { outline: 1px solid var(--accent); outline-offset: 2px; }
+  .days button { font: inherit; font-size: 12px; color: var(--text); cursor: pointer;
+                 background: none; border: 0; border-radius: 4px; height: 26px; }
+  .days button:hover { background: color-mix(in srgb, var(--text) 8%, transparent); }
+  .days button.outside { color: var(--muted); opacity: .55; }
+  .days button.cursor { outline: 1px solid var(--accent); outline-offset: -1px; }
+  .days button.on { background: var(--accent); color: var(--on-accent, #fff); }
+</style>

--- a/ui/src/lib/EventForm.svelte
+++ b/ui/src/lib/EventForm.svelte
@@ -11,6 +11,7 @@
   import { REMINDER_UNITS, reminderAmountOf, reminderMax, reminderUnitOf } from './reminders';
   import { offerableCalendarId, writableCalendars, type Calendar } from './calendars';
   import CalendarPicker from './CalendarPicker.svelte';
+  import DateField from './DateField.svelte';
   import SaveConfirm from './SaveConfirm.svelte';
   import { editReach, type SendUpdates } from './eventdetail';
   import {
@@ -324,6 +325,11 @@
   /** Whether the calendar dot's list is open — bindable into the picker so
    *  the Escape guard below can subordinate the form to it. */
   let calOpen = $state(false);
+  // One per date field, so `escapeCloses` above can peel a chooser without
+  // taking the form with it. See `CalendarPicker`'s `open` for the pattern.
+  let startDateOpen = $state(false);
+  let endDateOpen = $state(false);
+  let repeatEndOpen = $state(false);
 
   let panelEl: HTMLDivElement | undefined = $state();
   let formEl: HTMLFormElement | undefined = $state();
@@ -579,6 +585,14 @@
       calOpen = false;
       return;
     }
+    // The date choosers are this form's layers too, for the reason above:
+    // owning their Escape here is what stops one press closing a chooser and
+    // the form behind it. Closing all three is right because at most one is
+    // ever open — opening a second would have closed the first.
+    if (startDateOpen || endDateOpen || repeatEndOpen) {
+      startDateOpen = endDateOpen = repeatEndOpen = false;
+      return;
+    }
     oncancel();
   });
 </script>
@@ -650,7 +664,7 @@
     <div class="when">
       <label class="field">
         <span class="lab">{value.isAllDay ? 'First day' : 'Date'}</span>
-        <input type="date" value={value.date} onchange={(e) => moveStartDate(e.currentTarget.value)} />
+        <DateField label={value.isAllDay ? 'First day' : 'Date'} bind:open={startDateOpen} value={value.date} onchange={(v) => moveStartDate(v)} />
       </label>
       {#if !value.isAllDay}
         <label class="field">
@@ -679,7 +693,7 @@
              For an all-day event this is the *inclusive* last day; see
              `EventFormValue.endDate`. -->
         <span class="lab">{value.isAllDay ? 'Last day' : 'End date'}</span>
-        <input type="date" bind:value={value.endDate} />
+        <DateField label={value.isAllDay ? 'Last day' : 'End date'} bind:open={endDateOpen} bind:value={value.endDate} />
       </label>
       {#if !value.isAllDay}
         <label class="field">
@@ -874,12 +888,7 @@
             <option value="after">After</option>
           </select>
           {#if value.repeatEnd.kind === 'on'}
-            <input
-              type="date"
-              aria-label="Repeat end date"
-              aria-invalid={invalidField === 'repeatEnd' ? 'true' : undefined}
-              bind:value={value.repeatEnd.date}
-            />
+            <DateField label="Repeat end date" bind:open={repeatEndOpen} bind:value={value.repeatEnd.date} />
           {:else if value.repeatEnd.kind === 'after'}
             <label class="aftercount">
               <input

--- a/ui/src/lib/TasksSidebar.svelte
+++ b/ui/src/lib/TasksSidebar.svelte
@@ -1,6 +1,7 @@
 <!-- ui/src/lib/TasksSidebar.svelte -->
 <script lang="ts">
   import { dateFormat } from './date.svelte';
+  import DateField from './DateField.svelte';
   import { clockFormat } from './clock.svelte';
   import {
     createTask, deleteTask, listTasks, setTaskCompleted, taskLists, updateTask,
@@ -246,7 +247,7 @@
                         disabled={saving}>Clear</button>
               </div>
               <div class="when">
-                <input type="date" aria-label="Due date" bind:value={draft.date} disabled={saving} />
+                <DateField label="Due date" bind:value={draft.date} disabled={saving} />
                 <input type="time" aria-label="Due time" bind:value={draft.time}
                        disabled={saving || draft.date === ''} />
               </div>

--- a/ui/src/lib/datepicker.ts
+++ b/ui/src/lib/datepicker.ts
@@ -1,0 +1,93 @@
+// The arithmetic behind `DateField`'s calendar, in a `.ts` of its own for the
+// reason `weekstart.ts` gives: `tsconfig.test.json` compiles no `.svelte`, so
+// anything a spec should test directly cannot live in the component.
+//
+// Every function here is pure and works in **civil dates** — `yyyy-mm-dd`
+// strings and their parts — never instants. A calendar grid that went through
+// `Date` arithmetic in the browser's zone would land a day out for anyone east
+// or west of it, which is the shape of bug #44 and the reason `EventFormValue`
+// carries dates as strings in the first place.
+
+import { type WeekStartDay } from './weekstart';
+
+/** As `Date.prototype.getDay()` numbers them: Sunday is 0. */
+const JS_DAY: Record<WeekStartDay, number> = { sunday: 0, monday: 1, saturday: 6 };
+
+export type Ymd = { y: number; m: number; d: number };
+
+/** `yyyy-mm-dd` → its parts, or `null` for anything that is not one.
+ *
+ *  Strict on purpose: the field accepts typing, and a half-typed `2026-9` must
+ *  read as "no date yet" rather than as September of some year. Round-trips
+ *  through `Date.UTC` so `2026-02-31` is rejected rather than silently
+ *  becoming the 3rd of March. */
+export function parseYmd(text: string): Ymd | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(text.trim());
+  if (!m) return null;
+  const [y, mo, d] = [Number(m[1]), Number(m[2]), Number(m[3])];
+  const probe = new Date(Date.UTC(y, mo - 1, d));
+  if (probe.getUTCFullYear() !== y || probe.getUTCMonth() !== mo - 1 || probe.getUTCDate() !== d) {
+    return null;
+  }
+  return { y, m: mo, d };
+}
+
+/** The parts back to `yyyy-mm-dd`, zero-padded. */
+export const formatYmd = ({ y, m, d }: Ymd): string =>
+  `${String(y).padStart(4, '0')}-${String(m).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+
+/** Days in a month, `m` being 1-12. Day 0 of the next month is the last of
+ *  this one, which is also how February gets its leap years right for free. */
+export const daysInMonth = (y: number, m: number): number =>
+  new Date(Date.UTC(y, m, 0)).getUTCDate();
+
+/** `n` months from `{y, m}`, clamping the day to the shortest of the two
+ *  months — stepping from the 31st into a 30-day month lands on the 30th
+ *  rather than skipping a month, which is what every calendar does. */
+export function addMonths({ y, m, d }: Ymd, n: number): Ymd {
+  const total = y * 12 + (m - 1) + n;
+  const ny = Math.floor(total / 12);
+  const nm = (total % 12) + 1;
+  return { y: ny, m: nm, d: Math.min(d, daysInMonth(ny, nm)) };
+}
+
+/** `n` days from a date, across month and year ends. */
+export function addDays(date: Ymd, n: number): Ymd {
+  const t = new Date(Date.UTC(date.y, date.m - 1, date.d + n));
+  return { y: t.getUTCFullYear(), m: t.getUTCMonth() + 1, d: t.getUTCDate() };
+}
+
+/** The weekday column a date falls in, 0-6, under `start`. */
+export function columnOf(date: Ymd, start: WeekStartDay): number {
+  const js = new Date(Date.UTC(date.y, date.m - 1, date.d)).getUTCDay();
+  // `+ 7` before the modulo for `startOfWeek`'s reason: the difference is
+  // negative for most of the week under a Saturday start, and JavaScript's `%`
+  // keeps its left operand's sign.
+  return (js - JS_DAY[start] + 7) % 7;
+}
+
+/** The weekday headings, starting on `start`, in the browser's language.
+ *
+ *  Formatted from a known week rather than a hardcoded list: 2026-03-01 is a
+ *  Sunday, so offsetting from it names each column without this module owning
+ *  any language's day names. */
+export function weekdayNames(start: WeekStartDay, locale?: string): string[] {
+  const fmt = new Intl.DateTimeFormat(locale, { weekday: 'short', timeZone: 'UTC' });
+  return Array.from({ length: 7 }, (_, i) =>
+    fmt.format(new Date(Date.UTC(2026, 2, 1 + ((JS_DAY[start] + i) % 7)))));
+}
+
+/** The grid for the month containing `cursor`: whole weeks, so every row has
+ *  seven cells, with the days either side marked as belonging to a neighbour.
+ *
+ *  Six rows always, not "as many as this month needs". A grid that changed
+ *  height between months would move the buttons under a pointer that is
+ *  already travelling towards one. */
+export function monthGrid(cursor: Ymd, start: WeekStartDay): { date: Ymd; inMonth: boolean }[] {
+  const first: Ymd = { y: cursor.y, m: cursor.m, d: 1 };
+  const lead = columnOf(first, start);
+  return Array.from({ length: 42 }, (_, i) => {
+    const date = addDays(first, i - lead);
+    return { date, inMonth: date.m === cursor.m && date.y === cursor.y };
+  });
+}

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -4080,6 +4080,59 @@ test.describe('EventForm', () => {
   const saves = (page: import('@playwright/test').Page) =>
     page.evaluate(() => (window as any).__saves as any[]);
 
+  /**
+   * **#78, and the reason this picker exists.** The platform's calendar could
+   * not be closed from the page at all: WebKitGTK's popup holds an input
+   * grab, so an outside click never reached us — measured on the real build,
+   * where clicking another field while it was open did nothing whatever.
+   * Escape was the only way out because Escape is the one key the popup
+   * itself handles.
+   *
+   * Owning the calendar is what buys this behaviour, so this is the spec that
+   * has to hold: a press anywhere else closes it, and the field keeps the
+   * value it already had.
+   */
+  test('the date calendar closes on a press outside, and keeps the value', async ({ page }) => {
+    await open(page, 'create');
+    const chooser = page.getByRole('dialog', { name: 'Date chooser' });
+
+    await page.getByRole('button', { name: 'Pick date', exact: true }).click();
+    await expect(chooser).toBeVisible();
+
+    const before = await page.getByLabel('Date', { exact: true }).inputValue();
+    await page.getByRole('button', { name: 'Close date chooser', exact: true }).click();
+
+    await expect(chooser).toHaveCount(0);
+    await expect(page.getByLabel('Date', { exact: true })).toHaveValue(before);
+  });
+
+  /** Escape still works — it was the only way out before and must not become
+   *  a casualty of gaining the others. `dismiss.svelte`'s window listener,
+   *  so it is heard from wherever focus has wandered to. */
+  test('the date calendar closes on Escape without closing the form under it', async ({ page }) => {
+    await open(page, 'create');
+    await page.getByRole('button', { name: 'Pick date', exact: true }).click();
+    await expect(page.getByRole('dialog', { name: 'Date chooser' })).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(page.getByRole('dialog', { name: 'Date chooser' })).toHaveCount(0);
+    // One keystroke closes the topmost layer only — the form stays.
+    await expect(page.locator('.pop')).toBeVisible();
+  });
+
+  /** Picking a day writes it back in the form's own `yyyy-mm-dd`, which is
+   *  what every caller reads. A picker that looked right and wrote a locale
+   *  string would break every save. */
+  test('choosing a day writes the date the form speaks', async ({ page }) => {
+    await open(page, 'create');
+    await page.getByLabel('Date', { exact: true }).fill('2026-09-06');
+    await page.getByRole('button', { name: 'Pick date', exact: true }).click();
+
+    await page.getByRole('gridcell', { name: '2026-09-24', exact: true }).click();
+    await expect(page.getByLabel('Date', { exact: true })).toHaveValue('2026-09-24');
+    await expect(page.getByRole('dialog', { name: 'Date chooser' })).toHaveCount(0);
+  });
+
   test('the typed times echo in the second zone when settings name one', async ({ page }) => {
     await open(page, 'create');
     // Absent while the setting is off — the form has never had this line,
@@ -4478,7 +4531,10 @@ test.describe('EventForm', () => {
     const ends = page.getByLabel('Repeat ends');
     await expect(ends).toHaveValue('never');
     await ends.selectOption('on');
-    await page.getByLabel('Repeat end date').fill('2026-09-30');
+    // `exact`, because the field's own picker button names the field it
+    // opens — as it must, for anyone listening rather than looking — and
+    // accessible-name matching is a substring match by default.
+    await page.getByLabel('Repeat end date', { exact: true }).fill('2026-09-30');
     await page.getByRole('button', { name: 'Create' }).click();
     let [saved] = await saves(page);
     expect(saved.fields.repeatEnd).toEqual({ kind: 'on', date: '2026-09-30' });

--- a/ui/tests/datepicker.spec.ts
+++ b/ui/tests/datepicker.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from '@playwright/test';
+import {
+  addDays, addMonths, columnOf, daysInMonth, formatYmd, monthGrid, parseYmd, weekdayNames,
+} from '../src/lib/datepicker';
+
+test.describe('the date picker arithmetic', () => {
+  test('parsing is strict, because a half-typed date is not a date', () => {
+    expect(parseYmd('2026-09-06')).toEqual({ y: 2026, m: 9, d: 6 });
+    expect(parseYmd('  2026-09-06 ')).toEqual({ y: 2026, m: 9, d: 6 });
+    for (const bad of ['', '2026-9-6', '2026-09', '06/09/2026', 'tomorrow', '2026-09-06x']) {
+      expect(parseYmd(bad), `${bad} parsed`).toBeNull();
+    }
+    // Not merely shaped right: a day that does not exist is refused rather
+    // than rolling into the next month, which is what `Date` would do.
+    expect(parseYmd('2026-02-30')).toBeNull();
+    expect(parseYmd('2025-02-29'), 'not a leap year').toBeNull();
+    expect(parseYmd('2024-02-29'), 'a leap year').toEqual({ y: 2024, m: 2, d: 29 });
+  });
+
+  test('formatting pads, and round-trips whatever parsing accepted', () => {
+    expect(formatYmd({ y: 2026, m: 9, d: 6 })).toBe('2026-09-06');
+    for (const s of ['2026-01-01', '2024-02-29', '1999-12-31']) {
+      expect(formatYmd(parseYmd(s)!)).toBe(s);
+    }
+  });
+
+  test('month lengths, February included', () => {
+    expect(daysInMonth(2026, 2)).toBe(28);
+    expect(daysInMonth(2024, 2)).toBe(29);
+    expect(daysInMonth(2026, 9)).toBe(30);
+    expect(daysInMonth(2026, 12)).toBe(31);
+  });
+
+  /** Stepping a month from the 31st must not skip one — the trap every
+   *  hand-rolled calendar falls into. */
+  test('a month step clamps the day rather than overflowing', () => {
+    expect(addMonths({ y: 2026, m: 1, d: 31 }, 1)).toEqual({ y: 2026, m: 2, d: 28 });
+    expect(addMonths({ y: 2024, m: 1, d: 31 }, 1)).toEqual({ y: 2024, m: 2, d: 29 });
+    expect(addMonths({ y: 2026, m: 12, d: 15 }, 1)).toEqual({ y: 2027, m: 1, d: 15 });
+    expect(addMonths({ y: 2026, m: 1, d: 15 }, -1)).toEqual({ y: 2025, m: 12, d: 15 });
+    expect(addMonths({ y: 2026, m: 3, d: 31 }, -1)).toEqual({ y: 2026, m: 2, d: 28 });
+  });
+
+  test('a day step crosses months and years', () => {
+    expect(addDays({ y: 2026, m: 1, d: 31 }, 1)).toEqual({ y: 2026, m: 2, d: 1 });
+    expect(addDays({ y: 2026, m: 1, d: 1 }, -1)).toEqual({ y: 2025, m: 12, d: 31 });
+    expect(addDays({ y: 2024, m: 2, d: 28 }, 1)).toEqual({ y: 2024, m: 2, d: 29 });
+  });
+
+  /** The `% 7` sign trap `startOfWeek` documents, in this module's own form:
+   *  under a Saturday start most of the week is a negative difference. */
+  test('the weekday column honours every start without going negative', () => {
+    const sunday = { y: 2026, m: 3, d: 1 };
+    expect(columnOf(sunday, 'sunday')).toBe(0);
+    expect(columnOf(sunday, 'monday')).toBe(6);
+    expect(columnOf(sunday, 'saturday')).toBe(1);
+    for (const start of ['monday', 'sunday', 'saturday'] as const) {
+      for (let i = 0; i < 14; i += 1) {
+        const c = columnOf(addDays(sunday, i), start);
+        expect(c, `${start} +${i}`).toBeGreaterThanOrEqual(0);
+        expect(c).toBeLessThan(7);
+      }
+    }
+  });
+
+  test('the weekday headings begin on the chosen day', () => {
+    expect(weekdayNames('monday', 'en-GB')[0]).toBe('Mon');
+    expect(weekdayNames('sunday', 'en-GB')[0]).toBe('Sun');
+    expect(weekdayNames('saturday', 'en-GB')[0]).toBe('Sat');
+    expect(weekdayNames('monday', 'en-GB')).toHaveLength(7);
+    expect(new Set(weekdayNames('monday', 'en-GB')).size, 'a repeated heading').toBe(7);
+  });
+
+  test('the grid is six whole weeks, aligned, and knows its own month', () => {
+    const grid = monthGrid({ y: 2026, m: 9, d: 6 }, 'monday');
+    expect(grid).toHaveLength(42);
+    // Every row starts on the chosen day, which is what "aligned" means.
+    for (let row = 0; row < 6; row += 1) {
+      expect(columnOf(grid[row * 7].date, 'monday'), `row ${row}`).toBe(0);
+    }
+    // September 2026 begins on a Tuesday, so a Monday grid leads with one
+    // August day and the 1st sits in the second cell.
+    expect(grid[0].inMonth).toBe(false);
+    expect(formatYmd(grid[1].date)).toBe('2026-09-01');
+    expect(grid.filter((c) => c.inMonth)).toHaveLength(30);
+    // Consecutive throughout: no gap where a month changes.
+    for (let i = 1; i < grid.length; i += 1) {
+      expect(formatYmd(grid[i].date)).toBe(formatYmd(addDays(grid[i - 1].date, 1)));
+    }
+  });
+
+  /** Six rows always. A grid that shrank to five would move the buttons under
+   *  a pointer already travelling towards one. */
+  test('every month gets six rows, however short', () => {
+    // February 2026 is 28 days beginning on a Sunday: exactly four weeks
+    // under a Sunday start, the shortest a month can be.
+    expect(monthGrid({ y: 2026, m: 2, d: 1 }, 'sunday')).toHaveLength(42);
+    expect(monthGrid({ y: 2026, m: 8, d: 1 }, 'saturday')).toHaveLength(42);
+  });
+});


### PR DESCRIPTION
Closes #78.

The calendar a date field drops stayed up until Escape, unlike every other popup in the app. It was never ours — these were native `<input type="date">` controls and the popup is WebKitGTK's.

## Measured before building

With the popup open, clicking another field in the same form does **nothing at all** — tested on the real build. The popup holds an input grab, so the page never receives the press.

That rules out every page-level fix rather than merely making them worse: a listener cannot fire on an event it is never given. It is also why Escape was the only way out — Escape is the one key the popup itself handles.

**An earlier attempt blurred the input on an outside press, and mutation testing showed it was a no-op.** A bare date input *already* blurs to `BODY` on an outside press in both engines, so the handler re-implemented the browser, and the popup ignored it either way. Deleted rather than shipped.

## What is here

**`datepicker.ts`** — the arithmetic as pure functions on `yyyy-mm-dd` parts, never instants. A grid built through browser-zone `Date` math lands a day out for anyone east or west of UTC, which is #44's shape and why `EventFormValue` carries dates as strings.

Its 18 tests pin the traps, not the happy path: `2026-02-30` refused rather than rolling into March, a month step from the 31st **clamping** rather than skipping a month, and `columnOf` never negative under a Saturday start — the `%`-sign trap `weekstart.ts` already documents.

**`DateField.svelte`** — a text input keeping `yyyy-mm-dd`, plus a calendar we own. It reuses what the app has rather than inventing: `CalendarPicker`'s sibling-scrim shape, and **`weekStartDay()`** so the first column follows the user's preference instead of a locale guess. Six rows always, because a grid that shrank between months would move buttons under a pointer already travelling toward one.

## Escape belongs to the owner

A first cut gave `DateField` its own `escapeCloses`, and one press closed the chooser **and the form behind it**, losing everything typed. That is exactly the double-close `EventForm` had already been bitten by and written a paragraph about:

> *"the child's effect flushes before the parent's, so its listener ran first, closed the picker, and this guard — reading state, not history — then closed the form off the same press."*

`open` is now bindable and the form's single listener owns all four layers, as it already did for `CalendarPicker`. The spec that caught this is in the suite.

## Two accessible names collided

Fixing them is an accessibility fix, not a test fix. *"Choose date from a calendar"* clashed with `CalendarPicker`'s *"Calendar"*, and a button named for the field it opens necessarily contains that field's label. Two controls in one form that both say "calendar" are as ambiguous by ear as they are to a locator.

## A visible change worth flagging

The field shows `2026-09-06` rather than a locale format. That keeps every caller and spec working and makes typing unambiguous — nobody has to know whether `06/09` is June or September — but it is a change from the native control. Layering #82's date-format preference over the display is a separate, small piece of work if we want it to read like the rest of the app.

## Verification

The outside-click spec is **mutation-checked**: remove the scrim and it reddens. That is the behaviour #78 is about and the one thing the native control could never give us.

Gate: clippy `-D warnings` clean, Rust suite **921 across 14 binaries**, `npm run check` 270 files / 0 errors, Playwright **2012 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)