### PR TITLE
fix(form): the date opens its calendar, and the grid stops shrinking past legible

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -24,7 +24,7 @@ pub const HOUR_HEIGHT_DEFAULT: i64 = 70;
 /// hour labels still a line apart; 160 is six hours to a tall pane. Mirrored
 /// in `ui/src/lib/zoom.ts`, which clamps the gesture before it ever asks —
 /// this pair is the floor and ceiling the row is held to regardless.
-pub const HOUR_HEIGHT_MIN: i64 = 30;
+pub const HOUR_HEIGHT_MIN: i64 = 48;
 pub const HOUR_HEIGHT_MAX: i64 = 160;
 const FALLBACK_KEY: &str = "fallback_reminder_minutes";
 const DEFAULT_CALENDAR_KEY: &str = "default_calendar_id";
@@ -654,10 +654,17 @@ pub(crate) async fn read_settings_with(pool: &SqlitePool, baseline: u8) -> AppSe
         // The mark unless the row says otherwise, for `list_mode`'s reason:
         // a hand-edited value must land on what the app has always drawn.
         show_date: read(pool, SHOW_DATE_KEY).await.map(|v| v == "1").unwrap_or(false),
+        // **Clamped, not discarded.** A number outside the range is still an
+        // answer to "how tall do you like your hours" — when the floor rose
+        // from 30 to 48, discarding sent everyone who had zoomed out past it
+        // back to the default 70, which is further from what they chose than
+        // the floor is. Only an unparseable or absent value takes the
+        // default. (A hand-edited value still lands on something the app
+        // draws, which is what the rule above this one is for.)
         hour_height: read(pool, HOUR_HEIGHT_KEY)
             .await
             .and_then(|v| v.parse::<i64>().ok())
-            .filter(|px| (HOUR_HEIGHT_MIN..=HOUR_HEIGHT_MAX).contains(px))
+            .map(|px| px.clamp(HOUR_HEIGHT_MIN, HOUR_HEIGHT_MAX))
             .unwrap_or(HOUR_HEIGHT_DEFAULT),
         // **Shipped as 60 and 10, not empty** (fallback spec §3): the gap
         // this fills is real meetings going silent on receive-only shared
@@ -2158,7 +2165,25 @@ mod tests {
         let p = pool().await;
         write(&p, HOUR_HEIGHT_KEY, "112").await.unwrap();
         assert_eq!(read_settings(&p).await.hour_height, 112);
-        for bad in ["2000", "12", "tall", ""] {
+
+        // **A number out of range is clamped, not thrown away.** It is still
+        // an answer to "how tall do you like your hours", and the nearest
+        // height the app will draw is closer to it than the default is.
+        for (stored, want) in [("2000", HOUR_HEIGHT_MAX), ("12", HOUR_HEIGHT_MIN)] {
+            write(&p, HOUR_HEIGHT_KEY, stored).await.unwrap();
+            assert_eq!(read_settings(&p).await.hour_height, want, "stored {stored:?}");
+        }
+
+        // The case this rule exists for: the floor rose from 30 to 48 when
+        // half-hour events turned out to be unreadable below it. Anyone who
+        // had zoomed out past the new floor lands **on** it rather than
+        // snapping back to a default they never chose.
+        write(&p, HOUR_HEIGHT_KEY, "30").await.unwrap();
+        assert_eq!(read_settings(&p).await.hour_height, HOUR_HEIGHT_MIN);
+        assert_ne!(read_settings(&p).await.hour_height, HOUR_HEIGHT_DEFAULT);
+
+        // Only something that is not a height at all takes the default.
+        for bad in ["tall", ""] {
             write(&p, HOUR_HEIGHT_KEY, bad).await.unwrap();
             assert_eq!(read_settings(&p).await.hour_height, HOUR_HEIGHT_DEFAULT, "stored {bad:?}");
         }

--- a/ui/src/lib/DateField.svelte
+++ b/ui/src/lib/DateField.svelte
@@ -97,6 +97,7 @@
     {disabled}
     {value}
     oninput={(e) => { value = e.currentTarget.value; onchange?.(value); }}
+    onclick={() => { if (!open) show(); }}
   />
   <button
     type="button"
@@ -106,7 +107,19 @@
     aria-haspopup="dialog"
     aria-expanded={open}
     onclick={() => (open ? (open = false) : show())}
-  >▦</button>
+  >
+    <!-- Drawn rather than a glyph: `▦` was a filled square at this size and
+         read as decoration, and the font that has a calendar character is
+         not one we ship. `currentColor` so it follows the theme like every
+         other icon here. -->
+    <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true" focusable="false">
+      <rect x="1.5" y="3" width="13" height="11.5" rx="1.5" fill="none"
+            stroke="currentColor" stroke-width="1.4" />
+      <path d="M1.5 6.5h13" stroke="currentColor" stroke-width="1.4" />
+      <path d="M5 1.5v3M11 1.5v3" stroke="currentColor" stroke-width="1.4"
+            stroke-linecap="round" />
+    </svg>
+  </button>
 
   {#if open}
     <!-- A sibling of the panel, never a wrapper — `CalendarPicker`'s shape,
@@ -154,9 +167,15 @@
           border: 1px solid var(--hairline); border-radius: 5px; padding: 4px 6px; }
   input:focus { outline: 1px solid var(--accent); outline-offset: -1px; }
   input:disabled, .open:disabled { opacity: .5; cursor: default; }
-  .open { font: inherit; font-size: 12px; color: var(--muted); cursor: pointer;
-          background: none; border: 0; padding: 2px 4px; border-radius: 4px; }
-  .open:hover:not(:disabled) { color: var(--text); }
+  /* `--text` at rest, not `--muted`: at 14px this is the only sign the field
+     has a calendar behind it, and muted read as disabled against the field's
+     own border (reported 2026-09-09, "not very visible"). */
+  .open { display: inline-flex; align-items: center; color: var(--text);
+          cursor: pointer; background: none; border: 0; padding: 2px 3px;
+          border-radius: 4px; opacity: .8; }
+  .open:hover:not(:disabled) { opacity: 1;
+          background: color-mix(in srgb, var(--text) 10%, transparent); }
+  .open:focus-visible { outline: 1px solid var(--accent); outline-offset: -1px; }
 
   /* Covers the window beneath, so a press anywhere closes the calendar —
      the whole point of owning it. */

--- a/ui/src/lib/DateField.svelte
+++ b/ui/src/lib/DateField.svelte
@@ -97,8 +97,16 @@
     {disabled}
     {value}
     oninput={(e) => { value = e.currentTarget.value; onchange?.(value); }}
-    onclick={() => { if (!open) show(); }}
+    onpointerdown={() => { if (!open) show(); }}
+    
   />
+  <!-- **`pointerdown`, not `click`.** A press that lands on the calendar —
+       a day, or the scrim — closes it on mouseup, and the popover unmounts
+       while the click is still resolving. The browser then targets whatever
+       is underneath, which is this input, and a `click` handler here would
+       reopen the calendar the press had just dismissed. WebKit retargets
+       where Chromium does not, so it failed on CI alone (2026-09-09).
+       A press that began elsewhere is not a press on the field. -->
   <button
     type="button"
     class="open"

--- a/ui/src/lib/zoom.ts
+++ b/ui/src/lib/zoom.ts
@@ -11,11 +11,24 @@
 /** The grid's own 70 (see `WeekGrid.svelte`'s `.col`): what nobody has
  *  zoomed, and what `Ctrl+0` goes back to. */
 export const HOUR_PX_DEFAULT = 70;
-/** The reach. 30 puts a whole day in a laptop pane with the hour labels
- *  still a line apart; 160 is six hours to a tall pane. Mirrors
+/** The reach. 160 is six hours to a tall pane. Mirrors
  *  `settings::HOUR_HEIGHT_MIN`/`MAX`, which hold the stored row to the same
- *  pair regardless of what the page asks for. */
-export const HOUR_PX_MIN = 30;
+ *  pair regardless of what the page asks for.
+ *
+ *  **The floor is what an event needs, not what the ruler needs.** It was 30,
+ *  chosen so a whole day fit a laptop pane with the hour labels still a line
+ *  apart — which is true, and about the wrong thing. A block is `2px` of
+ *  padding either side of an 11.5px title at 1.3 line-height, so it wants
+ *  ~19px to show one line; a half-hour event is half the hour, so 38px was
+ *  already the edge, and its second line — the location, the Zoom — could
+ *  never fit. Reported at 39px (2026-09-09): "I can shrink it so much that
+ *  it becomes ugly".
+ *
+ *  48 gives a half-hour event 24px, a clean title line with room around it,
+ *  and an hour-long one 48px, enough for the title and the line under it.
+ *  Below that the grid stops being a calendar and becomes a diagram of one —
+ *  which is what Month is for. */
+export const HOUR_PX_MIN = 48;
 export const HOUR_PX_MAX = 160;
 
 /** Not rounded here: a trackpad's 1-2px wheel ticks move the height by a

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -4106,6 +4106,36 @@ test.describe('EventForm', () => {
     await expect(page.getByLabel('Date', { exact: true })).toHaveValue(before);
   });
 
+  /** Clicking the field opens the calendar, which is what the platform
+   *  control did and what a hand expects (reported 2026-09-09). Typing still
+   *  works with it open — the calendar sits below the field, not over it —
+   *  so the two ways of naming a date do not fight.
+   *
+   *  On **click**, deliberately not on focus: Tab through the form would
+   *  otherwise pop a calendar open at every date field on its way past. */
+  test('clicking the date field opens the calendar, and typing still works', async ({ page }) => {
+    await open(page, 'create');
+    const field = page.getByLabel('Date', { exact: true });
+    const chooser = page.getByRole('dialog', { name: 'Date chooser' });
+
+    await expect(chooser).toHaveCount(0);
+    await field.click();
+    await expect(chooser).toBeVisible();
+
+    await field.fill('2026-09-24');
+    await expect(field).toHaveValue('2026-09-24');
+    await expect(chooser, 'typing closed the calendar').toBeVisible();
+  });
+
+  /** Tab does not open anything. The form has three date fields and reaching
+   *  the third would otherwise leave two calendars behind it. */
+  test('tabbing onto a date field leaves its calendar shut', async ({ page }) => {
+    await open(page, 'create');
+    await page.getByLabel('Title', { exact: true }).focus();
+    await page.keyboard.press('Tab');
+    await expect(page.getByRole('dialog', { name: 'Date chooser' })).toHaveCount(0);
+  });
+
   /** Escape still works — it was the only way out before and must not become
    *  a casualty of gaining the others. `dismiss.svelte`'s window listener,
    *  so it is heard from wherever focus has wandered to. */

--- a/ui/tests/zoom.spec.ts
+++ b/ui/tests/zoom.spec.ts
@@ -26,7 +26,11 @@ test.describe('hour zoom arithmetic', () => {
 
   test('a pinch scales the height it began at, never the one it is passing through', () => {
     expect(hourPxAfterPinch(70, 1.5)).toBe(105);
-    expect(hourPxAfterPinch(70, 0.5)).toBe(35);
+    // Scaling the height it began at, in range: half of 120 is 60.
+    expect(hourPxAfterPinch(120, 0.5)).toBe(60);
+    // And held at the ends. Half of 70 is 35, which the floor no longer
+    // allows — below 48 a half-hour event cannot show its title line.
+    expect(hourPxAfterPinch(70, 0.5)).toBe(HOUR_PX_MIN);
     expect(hourPxAfterPinch(70, 4)).toBe(HOUR_PX_MAX);
   });
 


### PR DESCRIPTION
Two things reported off the released build.

## Clicking the date opens the calendar

As the platform control did. On **click** rather than on focus — the form has three date fields, and Tab would otherwise leave a calendar open behind every one it passed. There is a spec for that.

Typing still works with it open: the calendar sits below the field rather than over it, so the two ways of naming a date do not fight.

## The icon is drawn rather than spelled

`▦` renders as a filled square at 14px and reads as decoration. *"Not very visible"* was the report, and it was right.

Now a small inline SVG in `currentColor`, at `--text` rather than `--muted` — muted against the field's own border had read as **disabled**. It gains a hover background and a focus ring it never had.

## The hour floor rises from 30 to 48

Derived, not chosen by feel:

| | |
|---|---|
| a block | `2px` padding + `11.5px × 1.3` title ≈ **19px** for one line |
| a half-hour event | half the hour, so **38px was already the edge** |
| its second line | the location, the Zoom — **never fit at all** |
| reported at | **39px** — "I can shrink it so much that it becomes ugly" |

At 48 a half-hour event gets 24px, a clean title with room around it, and an hour-long one gets 48px, enough for the title and the line beneath.

The old floor was justified as *"a whole day in a laptop pane with the hour labels still a line apart"*. True, and about the wrong thing — **chosen for the ruler rather than for what the ruler measures.** Below this the grid stops being a calendar and becomes a diagram of one, which is what Month is for.

## The half that would have bitten

A stored height outside the range was **discarded and reset to the default**. Raising the floor would therefore have thrown everyone zoomed below 48 all the way to 70 — *further* from what they chose than the floor is.

It clamps now, so an existing 30 lands on 48. Only a value that is not a height at all takes the default, and the migration has its own assertion.

## Tests

Two existing tests failed and were **right to** — both asserted the old behaviour. The pinch spec now proves scaling and the floor separately (`120 × 0.5 = 60` in range, `70 × 0.5` held at the floor) rather than resting on a raw result that happened to sit inside the old range.

The click-to-open spec is mutation-checked: remove the handler and it reddens.

Gate: clippy `-D warnings` clean, Rust **927 across 14 binaries**, `npm run check` 270 files / 0 errors, Playwright **2014 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)