### PR TITLE
feat(settings): a default view setting, including a "Last view" that follows navigation

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1287,7 +1287,7 @@ fn single_instance_plugin() -> tauri::plugin::TauriPlugin<tauri::Wry> {
                         tracing::warn!(%e, "could not open the meeting link");
                     }
                 }
-                tray::TrayAction::Open => tray::show_main_window(app),
+                tray::TrayAction::Open => tray::open_plain(app),
             }
         },
     );
@@ -1693,6 +1693,8 @@ pub fn run() {
             settings::set_date_format,
             settings::set_temperature_unit,
             settings::set_default_view,
+            settings::set_default_view_follows_last,
+            settings::set_last_view,
             settings::set_week_start,
             settings::set_week_starts_today,
             settings::set_week_view_days,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1692,6 +1692,7 @@ pub fn run() {
             settings::set_time_format,
             settings::set_date_format,
             settings::set_temperature_unit,
+            settings::set_default_view,
             settings::set_week_start,
             settings::set_week_starts_today,
             settings::set_week_view_days,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -60,6 +60,7 @@ pub(crate) fn appearance_baseline(omarchy: bool) -> u8 {
     }
 }
 const TIME_FORMAT_KEY: &str = "time_format";
+const DEFAULT_VIEW_KEY: &str = "default_view";
 const WEEK_START_KEY: &str = "week_start";
 const WEEK_STARTS_TODAY_KEY: &str = "week_starts_today";
 const WEEK_VIEW_DAYS_KEY: &str = "week_view_days";
@@ -119,6 +120,39 @@ impl TimeFormat {
         match self {
             TimeFormat::H24 => "24h",
             TimeFormat::H12 => "12h",
+        }
+    }
+}
+
+/// Which of the five view-switcher slots OmaCal opens on.
+///
+/// An enum for [`TimeFormat`]'s reason: the set is closed and mirrors the
+/// switcher's own five buttons exactly, so [`set_default_view`] needs no
+/// refusal path — a sixth value cannot be sent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DefaultView {
+    #[serde(rename = "day")]
+    Day,
+    #[serde(rename = "week")]
+    Week,
+    #[serde(rename = "month")]
+    Month,
+    #[serde(rename = "year")]
+    Year,
+    #[serde(rename = "bigyear")]
+    BigYear,
+}
+
+impl DefaultView {
+    /// The stored spelling, which is also the wire spelling — the switcher's
+    /// own `View` union in `views.ts`.
+    fn as_str(self) -> &'static str {
+        match self {
+            DefaultView::Day => "day",
+            DefaultView::Week => "week",
+            DefaultView::Month => "month",
+            DefaultView::Year => "year",
+            DefaultView::BigYear => "bigyear",
         }
     }
 }
@@ -520,6 +554,11 @@ pub struct AppSettings {
     /// Which desktop this build is running on, so the settings copy can name
     /// it. Read-only: a fact about the host, never a stored preference.
     pub desktop: String,
+    /// Which of the five view-switcher slots OmaCal opens on. **Week by
+    /// default** — the view every existing install already opens to; this
+    /// setting only makes the choice visible and changeable rather than
+    /// changing what a fresh install does.
+    pub default_view: DefaultView,
     /// The day a week begins on, honoured by the Week grid's own anchor, the
     /// month grid's leading blanks, the Year view's twelve small grids, and
     /// Big Year's 392-day ribbon. When `week_starts_today` is on, this still
@@ -721,6 +760,16 @@ pub(crate) async fn read_settings_with(pool: &SqlitePool, baseline: u8) -> AppSe
             .await
             .map(|v| if v == "12h" { TimeFormat::H12 } else { TimeFormat::H24 })
             .unwrap_or(TimeFormat::H24),
+        // Week is the view every existing install already opens on; absent,
+        // garbage, or a spelling only a future version writes all land there
+        // rather than on a switcher slot nobody chose.
+        default_view: match read(pool, DEFAULT_VIEW_KEY).await.as_deref() {
+            Some("day") => DefaultView::Day,
+            Some("month") => DefaultView::Month,
+            Some("year") => DefaultView::Year,
+            Some("bigyear") => DefaultView::BigYear,
+            _ => DefaultView::Week,
+        },
         // Same polarity rule as its two neighbours: only the two spellings
         // this version writes move the setting, and everything else — absent,
         // hand-edited, or written by a version that learned a fourth day —
@@ -1449,6 +1498,20 @@ async fn set_week_view_days_impl(pool: &SqlitePool, days: u8) -> anyhow::Result<
     Ok(read_settings(pool).await)
 }
 
+/// Stores which view OmaCal opens on. Like [`set_time_format`] nothing is
+/// refused: [`DefaultView`] has five variants and the switcher offers all
+/// five, so there is no sixth value for a caller to send.
+#[tauri::command]
+pub async fn set_default_view(
+    state: tauri::State<'_, AppState>,
+    view: DefaultView,
+) -> Result<AppSettings, String> {
+    write(&state.pool, DEFAULT_VIEW_KEY, view.as_str())
+        .await
+        .map_err(|e| crate::errors::user_facing(&e))?;
+    Ok(read_settings(&state.pool).await)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1499,6 +1562,11 @@ mod tests {
             s.time_format,
             TimeFormat::H24,
             "the clock the app has always drawn, so no installed copy changes under its user"
+        );
+        assert_eq!(
+            s.default_view,
+            DefaultView::Week,
+            "the view every existing install already opens on"
         );
         assert_eq!(
             s.week_start,
@@ -1956,6 +2024,30 @@ mod tests {
         }
         write(&p, "date_format", "garbage").await.unwrap();
         assert_eq!(read_settings(&p).await.date_format, DateFormat::Locale);
+    }
+
+    /// All five round-trip, and an unrecognised row reads as Week — the same
+    /// polarity rule [`the_week_start_round_trips_and_falls_back_to_monday`]
+    /// takes, and the same view every install already opened on before this
+    /// setting existed.
+    #[tokio::test]
+    async fn the_default_view_round_trips_and_falls_back_to_week() {
+        let p = pool().await;
+        for view in [
+            DefaultView::Day, DefaultView::Month, DefaultView::Year,
+            DefaultView::BigYear, DefaultView::Week,
+        ] {
+            write(&p, DEFAULT_VIEW_KEY, view.as_str()).await.unwrap();
+            assert_eq!(read_settings(&p).await.default_view, view);
+        }
+        for stored in ["", "Week", "WEEK", "quarter", "🗓"] {
+            write(&p, DEFAULT_VIEW_KEY, stored).await.unwrap();
+            assert_eq!(
+                read_settings(&p).await.default_view,
+                DefaultView::Week,
+                "{stored:?} is not a spelling this version writes",
+            );
+        }
     }
 
     /// All three round-trip, and an unrecognised row reads as Monday — the

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -61,6 +61,8 @@ pub(crate) fn appearance_baseline(omarchy: bool) -> u8 {
 }
 const TIME_FORMAT_KEY: &str = "time_format";
 const DEFAULT_VIEW_KEY: &str = "default_view";
+const DEFAULT_VIEW_FOLLOWS_LAST_KEY: &str = "default_view_follows_last";
+const LAST_VIEW_KEY: &str = "last_view";
 const WEEK_START_KEY: &str = "week_start";
 const WEEK_STARTS_TODAY_KEY: &str = "week_starts_today";
 const WEEK_VIEW_DAYS_KEY: &str = "week_view_days";
@@ -154,6 +156,19 @@ impl DefaultView {
             DefaultView::Year => "year",
             DefaultView::BigYear => "bigyear",
         }
+    }
+}
+
+/// [`AppSettings::default_view`] and [`AppSettings::last_view`]'s shared
+/// fallback: absent, garbage, or a spelling only a future version writes
+/// lands on Week rather than an error.
+fn parse_default_view(stored: Option<&str>) -> DefaultView {
+    match stored {
+        Some("day") => DefaultView::Day,
+        Some("month") => DefaultView::Month,
+        Some("year") => DefaultView::Year,
+        Some("bigyear") => DefaultView::BigYear,
+        _ => DefaultView::Week,
     }
 }
 
@@ -554,11 +569,22 @@ pub struct AppSettings {
     /// Which desktop this build is running on, so the settings copy can name
     /// it. Read-only: a fact about the host, never a stored preference.
     pub desktop: String,
-    /// Which of the five view-switcher slots OmaCal opens on. **Week by
-    /// default** — the view every existing install already opens to; this
-    /// setting only makes the choice visible and changeable rather than
-    /// changing what a fresh install does.
+    /// Which of the five view-switcher slots OmaCal opens on, when
+    /// [`Self::default_view_follows_last`] is off. **Week by default** — the
+    /// view every existing install already opens to; this setting only
+    /// makes the choice visible and changeable rather than changing what a
+    /// fresh install does.
     pub default_view: DefaultView,
+    /// Whether OmaCal ignores `default_view` and opens on
+    /// [`Self::last_view`] instead — `week_starts_today`'s shape for
+    /// `week_start`: a flag beside the fixed choice rather than a sixth
+    /// `DefaultView` variant, which would let `last_view` itself name "last".
+    pub default_view_follows_last: bool,
+    /// The view the switcher was most recently on, tracked on every switch
+    /// regardless of `default_view_follows_last`, so turning that mode on
+    /// opens on a real memory rather than a blank one. Week until anything
+    /// has been recorded.
+    pub last_view: DefaultView,
     /// The day a week begins on, honoured by the Week grid's own anchor, the
     /// month grid's leading blanks, the Year view's twelve small grids, and
     /// Big Year's 392-day ribbon. When `week_starts_today` is on, this still
@@ -763,13 +789,17 @@ pub(crate) async fn read_settings_with(pool: &SqlitePool, baseline: u8) -> AppSe
         // Week is the view every existing install already opens on; absent,
         // garbage, or a spelling only a future version writes all land there
         // rather than on a switcher slot nobody chose.
-        default_view: match read(pool, DEFAULT_VIEW_KEY).await.as_deref() {
-            Some("day") => DefaultView::Day,
-            Some("month") => DefaultView::Month,
-            Some("year") => DefaultView::Year,
-            Some("bigyear") => DefaultView::BigYear,
-            _ => DefaultView::Week,
-        },
+        default_view: parse_default_view(read(pool, DEFAULT_VIEW_KEY).await.as_deref()),
+        // Opt-in, `week_starts_today`'s reason and polarity: absent, garbage
+        // and a future spelling all keep the fixed `default_view` in force.
+        default_view_follows_last: read(pool, DEFAULT_VIEW_FOLLOWS_LAST_KEY)
+            .await
+            .map(|v| v == "1")
+            .unwrap_or(false),
+        // Same fallback as `default_view`, for the same reason: nothing has
+        // been recorded yet reads as the view every install already opens
+        // on, not as an error.
+        last_view: parse_default_view(read(pool, LAST_VIEW_KEY).await.as_deref()),
         // Same polarity rule as its two neighbours: only the two spellings
         // this version writes move the setting, and everything else — absent,
         // hand-edited, or written by a version that learned a fourth day —
@@ -1498,18 +1528,65 @@ async fn set_week_view_days_impl(pool: &SqlitePool, days: u8) -> anyhow::Result<
     Ok(read_settings(pool).await)
 }
 
-/// Stores which view OmaCal opens on. Like [`set_time_format`] nothing is
-/// refused: [`DefaultView`] has five variants and the switcher offers all
-/// five, so there is no sixth value for a caller to send.
+/// Stores a fixed view and leaves "Last view" mode — [`set_week_start`]'s
+/// shape, atomic for the same reason: a crash between two writes must never
+/// leave the mode on with a choice the user just picked to replace it.
 #[tauri::command]
 pub async fn set_default_view(
     state: tauri::State<'_, AppState>,
     view: DefaultView,
 ) -> Result<AppSettings, String> {
-    write(&state.pool, DEFAULT_VIEW_KEY, view.as_str())
+    set_default_view_impl(&state.pool, view)
+        .await
+        .map_err(|e| crate::errors::user_facing(&e))
+}
+
+async fn set_default_view_impl(pool: &SqlitePool, view: DefaultView) -> anyhow::Result<AppSettings> {
+    let mut tx = pool.begin().await?;
+    for (key, value) in [(DEFAULT_VIEW_KEY, view.as_str()), (DEFAULT_VIEW_FOLLOWS_LAST_KEY, "0")] {
+        sqlx::query(
+            "INSERT INTO settings (key, value) VALUES (?1, ?2)
+             ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+        )
+        .bind(key)
+        .bind(value)
+        .execute(&mut *tx)
+        .await?;
+    }
+    tx.commit().await?;
+    Ok(read_settings(pool).await)
+}
+
+/// Turns "Last view" mode on or off — [`set_week_starts_today`]'s shape:
+/// `default_view` is set aside, not discarded, and is what's used again once
+/// this is turned back off.
+#[tauri::command]
+pub async fn set_default_view_follows_last(
+    state: tauri::State<'_, AppState>,
+    on: bool,
+) -> Result<AppSettings, String> {
+    write(&state.pool, DEFAULT_VIEW_FOLLOWS_LAST_KEY, if on { "1" } else { "0" })
         .await
         .map_err(|e| crate::errors::user_facing(&e))?;
     Ok(read_settings(&state.pool).await)
+}
+
+/// Stores the view the switcher was most recently on, called on every
+/// switch regardless of mode — see [`AppSettings::last_view`]. Nothing to
+/// refuse, [`set_default_view`]'s reason.
+#[tauri::command]
+pub async fn set_last_view(
+    state: tauri::State<'_, AppState>,
+    view: DefaultView,
+) -> Result<AppSettings, String> {
+    set_last_view_impl(&state.pool, view)
+        .await
+        .map_err(|e| crate::errors::user_facing(&e))
+}
+
+async fn set_last_view_impl(pool: &SqlitePool, view: DefaultView) -> anyhow::Result<AppSettings> {
+    write(pool, LAST_VIEW_KEY, view.as_str()).await?;
+    Ok(read_settings(pool).await)
 }
 
 #[cfg(test)]
@@ -1568,6 +1645,8 @@ mod tests {
             DefaultView::Week,
             "the view every existing install already opens on"
         );
+        assert!(!s.default_view_follows_last, "fixed by default, not \"last\"");
+        assert_eq!(s.last_view, DefaultView::Week, "nothing recorded yet");
         assert_eq!(
             s.week_start,
             WeekStart::Monday,
@@ -2048,6 +2127,66 @@ mod tests {
                 "{stored:?} is not a spelling this version writes",
             );
         }
+    }
+
+    /// `last_view` takes the same five spellings and the same fallback as
+    /// `default_view` — proven separately because the two rows are read by
+    /// the same helper and a copy-paste could point one at the other's key
+    /// without either test noticing.
+    #[tokio::test]
+    async fn the_last_view_round_trips_and_falls_back_to_week() {
+        let p = pool().await;
+        for view in [DefaultView::Month, DefaultView::BigYear, DefaultView::Day] {
+            let s = set_last_view_impl(&p, view).await.unwrap();
+            assert_eq!(s.last_view, view);
+            assert_eq!(read_settings(&p).await.last_view, view);
+        }
+        for stored in ["", "Week", "garbage"] {
+            write(&p, LAST_VIEW_KEY, stored).await.unwrap();
+            assert_eq!(
+                read_settings(&p).await.last_view,
+                DefaultView::Week,
+                "{stored:?} is not a spelling this version writes",
+            );
+        }
+    }
+
+    /// [`choosing_a_fixed_week_start_leaves_rolling_mode_atomically`]'s exact
+    /// shape: picking a fixed default view while "Last view" mode is on
+    /// turns that mode off in the same write, and turning it back on
+    /// restores the `last_view` recorded independently of either.
+    #[tokio::test]
+    async fn choosing_a_fixed_default_view_leaves_last_view_mode_atomically() {
+        let p = pool().await;
+        write(&p, DEFAULT_VIEW_FOLLOWS_LAST_KEY, "1").await.unwrap();
+        set_last_view_impl(&p, DefaultView::Year).await.unwrap();
+
+        let s = set_default_view_impl(&p, DefaultView::Month).await.unwrap();
+        assert_eq!(s.default_view, DefaultView::Month);
+        assert!(!s.default_view_follows_last);
+        assert_eq!(read(&p, DEFAULT_VIEW_KEY).await.as_deref(), Some("month"));
+        assert_eq!(read(&p, DEFAULT_VIEW_FOLLOWS_LAST_KEY).await.as_deref(), Some("0"));
+
+        // Turning the mode back on does not disturb the fixed choice or the
+        // memory of what "last" meant.
+        write(&p, DEFAULT_VIEW_FOLLOWS_LAST_KEY, "1").await.unwrap();
+        let s = read_settings(&p).await;
+        assert!(s.default_view_follows_last);
+        assert_eq!(s.default_view, DefaultView::Month);
+        assert_eq!(s.last_view, DefaultView::Year);
+    }
+
+    /// Both directions, `the_time_format_round_trips_both_ways`'s reason.
+    #[tokio::test]
+    async fn default_view_follows_last_round_trips_both_ways() {
+        let p = pool().await;
+        assert!(!read_settings(&p).await.default_view_follows_last, "off until chosen");
+
+        write(&p, DEFAULT_VIEW_FOLLOWS_LAST_KEY, "1").await.unwrap();
+        assert!(read_settings(&p).await.default_view_follows_last);
+
+        write(&p, DEFAULT_VIEW_FOLLOWS_LAST_KEY, "0").await.unwrap();
+        assert!(!read_settings(&p).await.default_view_follows_last);
     }
 
     /// All three round-trip, and an unrecognised row reads as Monday — the

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -583,7 +583,7 @@ pub(crate) fn build(app: &AppHandle) -> tauri::Result<()> {
         .show_menu_on_left_click(true)
         .icon(tauri::include_image!("icons/tray.png"))
         .on_menu_event(|app, event| match action_for(event.id.as_ref()) {
-            Some(TrayAction::Open) => show_main_window(app),
+            Some(TrayAction::Open) => open_plain(app),
             // Unreachable from a menu — `action_for` never returns it, the
             // menu has no dated entry — but honoured rather than ignored,
             // because a match arm that discards an action is how a future
@@ -767,6 +767,22 @@ pub(crate) const OPEN_DATE_EVENT: &str = "open-date";
 /// What a double-clicked `.ics` emits: the path, which is what the import
 /// preview already takes from a dropped file.
 pub(crate) const OPEN_FILE_EVENT: &str = "open-file";
+
+/// What a *plain* open emits — [`TrayAction::Open`]'s two sites (the tray
+/// menu and a bare CLI relaunch), neither of which names a destination.
+/// Closing only ever hides the window, never tears the webview down, so
+/// without this the default-view setting would apply once at cold start and
+/// never again. [`open_at`] and [`open_file`] deliberately don't emit it —
+/// they already say where to land, which is not this setting's decision.
+pub(crate) const APP_OPENED_EVENT: &str = "app-opened";
+
+/// [`show_main_window`], then say so — unlike [`open_at`]/[`open_file`],
+/// which say *where*.
+pub(crate) fn open_plain(app: &AppHandle) {
+    use tauri::Emitter;
+    show_main_window(app);
+    let _ = app.emit(APP_OPENED_EVENT, ());
+}
 
 /// [`show_main_window`], then tell the webview where to land. Untested like
 /// its first half; everything it decides was decided by `parse_date`.

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -728,6 +728,11 @@
   /** Live range previews supersede the asynchronous startup settings read in
    *  the same way the filmstrip and rolling-week controls do. */
   let appearanceChoices = 0;
+  /** `listModeChoices`'s reason, for `view` itself: a switcher click or number
+   *  key made while the startup `get_settings` read is still in flight must
+   *  not be undone once that slow read lands — bumped by `pick`, the one
+   *  chokepoint every way of changing `view` already goes through. */
+  let viewChoices = 0;
 
   /** The stored default for new events, or `null` for the old rule. Seeded
    *  below and kept fresh by `SettingsModal`'s `onsettingschange` — without
@@ -759,6 +764,11 @@
     const before = listModeChoices;
     const weekBefore = weekViewChoices;
     const appearanceBefore = appearanceChoices;
+    // Untracked: `pick` runs on every view switch, including the number
+    // keys, and this effect must not refetch settings on each one — the
+    // guard only needs `viewChoices`' *value* at the moment of this snapshot,
+    // not a subscription to it.
+    const viewBefore = untrack(() => viewChoices);
     getSettings()
       .then((s) => {
         defaultCalendarId = s.defaultCalendarId;
@@ -769,6 +779,10 @@
         setTemperatureUnit(s.temperatureUnit);
         if (appearanceChoices === appearanceBefore) applyAppearance(s);
         if (weekViewChoices === weekBefore) applyWeekSettings(s, false);
+        // Plain assignment, not `pick`: this is the silent startup seed, and
+        // `pick`'s job — bumping `viewChoices` itself — would make this read
+        // permanently "since superseded" for every later rerun of this effect.
+        if (viewChoices === viewBefore) view = s.defaultView;
         // Only if nobody has zoomed in the meantime: a pinch made while the
         // read was in flight is the newer fact, and it is about to be stored.
         if (hourPx === persistedHourPx) { hourPx = s.hourHeight; persistedHourPx = s.hourHeight; }
@@ -1081,6 +1095,9 @@
   // through, so neither path can diverge from the other. All five slots are
   // live (spec §10) — nothing left to turn away here.
   function pick(v: View) {
+    // `listModeChoices`'s reason: a settings read still in flight when this
+    // runs must not later overwrite whatever the switcher just chose.
+    viewChoices += 1;
     // Spec §5 and the DoD: the anchor survives every switch, and Year is a
     // switch like any other. `yearNum` starts on the real current year, so
     // without this an anchor on 28 Dec 2022 opened Year on the current year

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -39,7 +39,9 @@
   import {
     dayCursor, eventAtCursor, moveDay, moveEvent, type KeyboardCursor,
   } from './lib/keyboardnav';
-  import { getSettings, setHourHeight, setListMode, type AppSettings, type WeekViewDays } from './lib/settings';
+  import {
+    getSettings, setHourHeight, setLastView, setListMode, type AppSettings, type WeekViewDays,
+  } from './lib/settings';
   import { HOUR_PX_DEFAULT, hourPxStepped } from './lib/zoom';
   import { padFor, sliceWeek, visibleIndex, windowHeld } from './lib/weekwindow';
   import { setClockFormat } from './lib/clock.svelte';
@@ -227,6 +229,19 @@
   // this refetch is the half that actually draws it.
   $effect(() => {
     const un = listen('update-notice', () => { void refreshStatus(); });
+    return () => { un.then((f) => f()); };
+  });
+
+  // `tray::open_plain`'s own reason: closing the window only hides it, and
+  // hiding never remounts this component, so without this signal a default
+  // chosen in Settings would apply once at cold start and never again.
+  // Through `pick`, not a bare assignment, for its Year reseed and its
+  // `viewChoices` stamp. Deliberately not wired to `open-date` or a clicked
+  // reminder — both name an actual destination, unlike a plain reopen.
+  $effect(() => {
+    const un = listen('app-opened', () => {
+      void getSettings().then((s) => pick(effectiveDefaultView(s))).catch(() => {});
+    });
     return () => { un.then((f) => f()); };
   });
 
@@ -752,6 +767,13 @@
    *  setting: it is a thing you look at, not a thing you configure. */
   let helpOpen = $state(false);
 
+  /** The view a fresh seed of `view` should land on — `lastView` under
+   *  "Last view" mode, `defaultView` otherwise. One place for the question,
+   *  since the mount effect and the `app-opened` listener both ask it. */
+  function effectiveDefaultView(s: AppSettings): View {
+    return s.defaultViewFollowsLast ? s.lastView : s.defaultView;
+  }
+
   function applyWeekSettings(s: AppSettings, jumpOnEntry: boolean) {
     const enteringRolling = !weekStartsToday && s.weekStartsToday;
     setWeekStartDay(s.weekStart);
@@ -782,7 +804,7 @@
         // Plain assignment, not `pick`: this is the silent startup seed, and
         // `pick`'s job — bumping `viewChoices` itself — would make this read
         // permanently "since superseded" for every later rerun of this effect.
-        if (viewChoices === viewBefore) view = s.defaultView;
+        if (viewChoices === viewBefore) view = effectiveDefaultView(s);
         // Only if nobody has zoomed in the meantime: a pinch made while the
         // read was in flight is the newer fact, and it is about to be stored.
         if (hourPx === persistedHourPx) { hourPx = s.hourHeight; persistedHourPx = s.hourHeight; }
@@ -1113,6 +1135,9 @@
     // declaration, and `step` below.
     if (v === 'year') yearNum = new Date(anchorMs).getFullYear();
     view = v;
+    // Recorded on every switch, not only under "Last view" mode, so turning
+    // that mode on later opens on a real memory rather than a blank one.
+    void setLastView(v);
   }
 
   // `H`/`L` — and the header's own `‹`/`›`, which are the same motion by

--- a/ui/src/lib/SettingsModal.svelte
+++ b/ui/src/lib/SettingsModal.svelte
@@ -17,7 +17,7 @@
   import { listAccounts, signOut, type Account } from './accounts';
   import {
     getSettings, listTimezones, minutesOf, msOfMinutes, setAppearancePreferences,
-    setDefaultCalendar,
+    setDefaultCalendar, setDefaultView, DEFAULT_VIEW_OPTIONS,
     setDefaultEventDuration, setStartOnLogin, START_ON_LOGIN_OPTIONS,
     setDisplayTimezone, setFallbackReminders, setNotificationsEnabled,
     setAppearance, APPEARANCE_OPTIONS,
@@ -27,6 +27,7 @@
     type AppSettings, type Appearance, type StartOnLogin, type WeekViewDays,
     type WindowFrame, WINDOW_FRAME_OPTIONS, setWindowFrame,
   } from './settings';
+  import type { View } from './views';
   import { formatClock, type TimeFormat } from './timefmt';
   import type { TemperatureUnit } from './temperature';
   import type { WeekStartDay } from './weekstart';
@@ -253,6 +254,22 @@
       } else {
         settings = await setWeekStart(choice.id as WeekStartDay);
       }
+      onsettingschange?.(settings);
+    } catch (e) {
+      note = { text: String(e), kind: 'error' };
+    }
+  }
+
+  /** Stores which view OmaCal opens on next — `defaultCalendarId`'s shape,
+   *  not `saveTimeFormat`'s: the view currently on screen is whatever the
+   *  user navigated to, and this setting has no opinion about that. Jumping
+   *  the calendar behind the modal to match would mean touching any
+   *  *unrelated* setting while browsing a different view yanks you back to
+   *  the default — the same trap a `defaultCalendarId` that repainted the
+   *  header would be. */
+  async function saveDefaultView(view: View) {
+    try {
+      settings = await setDefaultView(view);
       onsettingschange?.(settings);
     } catch (e) {
       note = { text: String(e), kind: 'error' };
@@ -976,6 +993,27 @@
           effect at once.
         </p>
       {/if}
+
+      <div class="row">
+        <label class="lab" for="default-view">Open OmaCal on</label>
+        <div class="inline">
+          <select
+            id="default-view"
+            disabled={!settings}
+            value={settings?.defaultView ?? 'week'}
+            onchange={(e) =>
+              saveDefaultView((e.currentTarget as HTMLSelectElement).value as View)}
+          >
+            {#each DEFAULT_VIEW_OPTIONS as [id, label] (id)}
+              <option value={id}>{label}</option>
+            {/each}
+          </select>
+        </div>
+      </div>
+      <p class="hint">
+        Which of the five views OmaCal opens next time — the calendar behind
+        this modal keeps showing whatever you last navigated to.
+      </p>
 
       <div class="row">
         <label class="lab" for="week-view">Week view</label>

--- a/ui/src/lib/SettingsModal.svelte
+++ b/ui/src/lib/SettingsModal.svelte
@@ -17,7 +17,8 @@
   import { listAccounts, signOut, type Account } from './accounts';
   import {
     getSettings, listTimezones, minutesOf, msOfMinutes, setAppearancePreferences,
-    setDefaultCalendar, setDefaultView, DEFAULT_VIEW_OPTIONS,
+    setDefaultCalendar, setDefaultView, setDefaultViewFollowsLast, DEFAULT_VIEW_OPTIONS,
+    type DefaultViewChoice,
     setDefaultEventDuration, setStartOnLogin, START_ON_LOGIN_OPTIONS,
     setDisplayTimezone, setFallbackReminders, setNotificationsEnabled,
     setAppearance, APPEARANCE_OPTIONS,
@@ -27,7 +28,6 @@
     type AppSettings, type Appearance, type StartOnLogin, type WeekViewDays,
     type WindowFrame, WINDOW_FRAME_OPTIONS, setWindowFrame,
   } from './settings';
-  import type { View } from './views';
   import { formatClock, type TimeFormat } from './timefmt';
   import type { TemperatureUnit } from './temperature';
   import type { WeekStartDay } from './weekstart';
@@ -262,14 +262,17 @@
 
   /** Stores which view OmaCal opens on next — `defaultCalendarId`'s shape,
    *  not `saveTimeFormat`'s: the view currently on screen is whatever the
-   *  user navigated to, and this setting has no opinion about that. Jumping
-   *  the calendar behind the modal to match would mean touching any
-   *  *unrelated* setting while browsing a different view yanks you back to
-   *  the default — the same trap a `defaultCalendarId` that repainted the
-   *  header would be. */
-  async function saveDefaultView(view: View) {
+   *  user navigated to, and this setting has no opinion about that.
+   *
+   *  One control, two backend writes — `saveWeekView`'s own shape: "Last
+   *  view" is `defaultViewFollowsLast` turned on, and every other row is a
+   *  fixed `defaultView` (which itself turns that flag back off, atomically,
+   *  on the backend). */
+  async function saveDefaultView(choice: DefaultViewChoice) {
     try {
-      settings = await setDefaultView(view);
+      settings = choice === 'last'
+        ? await setDefaultViewFollowsLast(true)
+        : await setDefaultView(choice);
       onsettingschange?.(settings);
     } catch (e) {
       note = { text: String(e), kind: 'error' };
@@ -1000,9 +1003,9 @@
           <select
             id="default-view"
             disabled={!settings}
-            value={settings?.defaultView ?? 'week'}
+            value={settings?.defaultViewFollowsLast ? 'last' : (settings?.defaultView ?? 'week')}
             onchange={(e) =>
-              saveDefaultView((e.currentTarget as HTMLSelectElement).value as View)}
+              saveDefaultView((e.currentTarget as HTMLSelectElement).value as DefaultViewChoice)}
           >
             {#each DEFAULT_VIEW_OPTIONS as [id, label] (id)}
               <option value={id}>{label}</option>
@@ -1011,8 +1014,8 @@
         </div>
       </div>
       <p class="hint">
-        Which of the five views OmaCal opens next time — the calendar behind
-        this modal keeps showing whatever you last navigated to.
+        Which of the five views OmaCal opens next time. Last view reopens
+        wherever you left off instead of a fixed one.
       </p>
 
       <div class="row">

--- a/ui/src/lib/settings.ts
+++ b/ui/src/lib/settings.ts
@@ -5,6 +5,18 @@ import type { TemperatureUnit } from './temperature';
 import type { TimeFormat } from './timefmt';
 import type { WeekStartDay } from './weekstart';
 import type { EventCornerStyle } from './appearance';
+import type { View } from './views';
+
+/** The five switcher slots, in the order the select offers them —
+ *  `ViewSwitcher`'s own `SLOTS` labels, so the settings row and the switcher
+ *  itself cannot describe the same view two different ways. */
+export const DEFAULT_VIEW_OPTIONS: ReadonlyArray<[View, string]> = [
+  ['day', 'Day'],
+  ['week', 'Week'],
+  ['month', 'Month'],
+  ['year', 'Year'],
+  ['bigyear', 'Big Year'],
+];
 
 /** Total columns in the rolling Week view, including today. */
 export type WeekViewDays = 3 | 5 | 7;
@@ -114,6 +126,10 @@ export type AppSettings = {
   /** Which desktop this build runs on, so the copy can name it. A fact about
    *  the host, not a stored preference — there is no setter. */
   desktop: 'macos' | 'omarchy' | 'linux';
+  /** Which of the five view-switcher slots OmaCal opens on. `'week'` by
+   *  default — the view every existing install already opened to before
+   *  this setting existed. */
+  defaultView: View;
   /** The day a week begins on. Read by the grids through the
    *  `weekstartstore.svelte.ts` rune, for the same reason `timeFormat` is. */
   weekStart: WeekStartDay;
@@ -241,6 +257,11 @@ export const setTemperatureUnit = (unit: TemperatureUnit) =>
  *  down — see the note on `set_time_format`. */
 export const setTimeFormat = (format: TimeFormat) =>
   invoke<AppSettings>('set_time_format', { format });
+
+/** Stores which view OmaCal opens on. Nothing is refused: the select offers
+ *  exactly the five variants `settings::DefaultView` has. */
+export const setDefaultView = (view: View) =>
+  invoke<AppSettings>('set_default_view', { view });
 
 /** Stores the day a week begins on. Nothing is refused: the select offers
  *  exactly the three variants `settings::WeekStart` has. */

--- a/ui/src/lib/settings.ts
+++ b/ui/src/lib/settings.ts
@@ -7,15 +7,23 @@ import type { WeekStartDay } from './weekstart';
 import type { EventCornerStyle } from './appearance';
 import type { View } from './views';
 
+/** A `View`, plus `'last'` — "wherever the switcher was most recently,"
+ *  which is `defaultViewFollowsLast`, not a sixth `View` value: `View` also
+ *  names what `lastView` holds, and that can never be "last". */
+export type DefaultViewChoice = View | 'last';
+
 /** The five switcher slots, in the order the select offers them —
  *  `ViewSwitcher`'s own `SLOTS` labels, so the settings row and the switcher
- *  itself cannot describe the same view two different ways. */
-export const DEFAULT_VIEW_OPTIONS: ReadonlyArray<[View, string]> = [
+ *  itself cannot describe the same view two different ways — plus "Last
+ *  view", the row this modal derives rather than stores directly; see
+ *  `SettingsModal`'s `saveDefaultView`. */
+export const DEFAULT_VIEW_OPTIONS: ReadonlyArray<[DefaultViewChoice, string]> = [
   ['day', 'Day'],
   ['week', 'Week'],
   ['month', 'Month'],
   ['year', 'Year'],
   ['bigyear', 'Big Year'],
+  ['last', 'Last view'],
 ];
 
 /** Total columns in the rolling Week view, including today. */
@@ -126,10 +134,17 @@ export type AppSettings = {
   /** Which desktop this build runs on, so the copy can name it. A fact about
    *  the host, not a stored preference — there is no setter. */
   desktop: 'macos' | 'omarchy' | 'linux';
-  /** Which of the five view-switcher slots OmaCal opens on. `'week'` by
-   *  default — the view every existing install already opened to before
-   *  this setting existed. */
+  /** Which of the five view-switcher slots OmaCal opens on, when
+   *  `defaultViewFollowsLast` is off. `'week'` by default — the view every
+   *  existing install already opened to before this setting existed. */
   defaultView: View;
+  /** Whether OmaCal ignores `defaultView` and opens on `lastView` instead —
+   *  `weekStartsToday`'s shape for `weekStart`. */
+  defaultViewFollowsLast: boolean;
+  /** The view the switcher was most recently on, tracked regardless of
+   *  `defaultViewFollowsLast` so turning that mode on opens on a real
+   *  memory. `'week'` until anything has been recorded. */
+  lastView: View;
   /** The day a week begins on. Read by the grids through the
    *  `weekstartstore.svelte.ts` rune, for the same reason `timeFormat` is. */
   weekStart: WeekStartDay;
@@ -258,10 +273,22 @@ export const setTemperatureUnit = (unit: TemperatureUnit) =>
 export const setTimeFormat = (format: TimeFormat) =>
   invoke<AppSettings>('set_time_format', { format });
 
-/** Stores which view OmaCal opens on. Nothing is refused: the select offers
- *  exactly the five variants `settings::DefaultView` has. */
+/** Stores a fixed view for OmaCal to open on and leaves "Last view" mode —
+ *  `set_week_start`'s shape: the backend clears `defaultViewFollowsLast` in
+ *  the same write. Nothing is refused: the select offers exactly the five
+ *  variants `settings::DefaultView` has. */
 export const setDefaultView = (view: View) =>
   invoke<AppSettings>('set_default_view', { view });
+
+/** Turns "Last view" mode on or off, preserving whichever `defaultView` was
+ *  in force before — `setWeekStartsToday`'s shape for `setWeekStart`. */
+export const setDefaultViewFollowsLast = (on: boolean) =>
+  invoke<AppSettings>('set_default_view_follows_last', { on });
+
+/** Stores the view the switcher was most recently on, called by `App`'s
+ *  `pick` on every switch regardless of mode. */
+export const setLastView = (view: View) =>
+  invoke<AppSettings>('set_last_view', { view });
 
 /** Stores the day a week begins on. Nothing is refused: the select offers
  *  exactly the three variants `settings::WeekStart` has. */

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -2136,6 +2136,65 @@ test.describe('App', () => {
   });
 
   /**
+   * The default-view row itself: its five options match the switcher's own
+   * slots, so a choice cannot silently describe a view that isn't one of
+   * the five, the choice reaches the command, and it defaults to Week — the
+   * view every install already opened on before this setting existed.
+   */
+  test('the default view can be chosen, and still defaults to Week', async ({ page }) => {
+    await writable(page);
+    await page.getByRole('button', { name: 'Menu' }).click();
+    await page.getByRole('button', { name: 'Settings…' }).click();
+    const modal = page.getByRole('dialog', { name: 'Settings' });
+    await modal.getByRole('tab', { name: 'Appearance' }).click();
+    const select = modal.locator('#default-view');
+    await expect(select).toHaveValue('week');
+    await expect(select.locator('option')).toHaveText([
+      'Day', 'Week', 'Month', 'Year', 'Big Year',
+    ]);
+
+    await select.selectOption('month');
+    const [args] = await callsTo(page, 'set_default_view');
+    expect(args).toEqual({ view: 'month' });
+
+    // Reopened, the select shows what was stored rather than its own default.
+    await page.keyboard.press('Escape');
+    await expect(modal).toHaveCount(0);
+    await page.getByRole('button', { name: 'Menu' }).click();
+    await page.getByRole('button', { name: 'Settings…' }).click();
+    await modal.getByRole('tab', { name: 'Appearance' }).click();
+    await expect(modal.locator('#default-view')).toHaveValue('month');
+  });
+
+  /**
+   * `defaultCalendarId`'s own test pins the shape this one repeats: chosen
+   * in Settings and stored **without a restart**, but a *default*, not a
+   * live jump — the calendar behind the modal keeps showing whatever the
+   * user actually navigated to, exactly as a chosen default calendar waits
+   * for the next `n` rather than repainting the header. Only a fresh launch
+   * — proxied here by a reload, the same stand-in
+   * `the chosen first day survives a reload` uses — picks the new default up.
+   */
+  test('a default view chosen in Settings is what a reload opens on, not this session', async ({ page }) => {
+    await writable(page);
+    await expect(page.locator('.vswitch button.active')).toHaveText('Week');
+
+    await page.getByRole('button', { name: 'Menu' }).click();
+    await page.getByRole('button', { name: 'Settings…' }).click();
+    const modal = page.getByRole('dialog', { name: 'Settings' });
+    await modal.getByRole('tab', { name: 'Appearance' }).click();
+    await modal.locator('#default-view').selectOption('month');
+    await page.keyboard.press('Escape');
+    await expect(modal).toHaveCount(0);
+
+    // Unchanged this session: a default for next time, not a live jump.
+    await expect(page.locator('.vswitch button.active')).toHaveText('Week');
+
+    await page.reload();
+    await expect(page.locator('.vswitch button.active')).toHaveText('Month');
+  });
+
+  /**
    * A draft can be placed by hand, the way a saved event can (2026-09-02, by
    * request: "when I create a new meeting I want to be able to move it
    * visually also").
@@ -3234,6 +3293,30 @@ test.describe('App', () => {
     await expect(toggle(page)).toHaveAttribute('aria-pressed', 'true');
     // …and the write that keystroke made is what survives to the next launch.
     expect(await callsTo(page, 'set_list_mode')).toEqual([{ on: true }]);
+  });
+
+  /**
+   * `viewChoices`'s reason, `a choice made while the stored one is still
+   * loading is not undone by it` for the view switcher: the number keys work
+   * the instant `<svelte:window>` is listening, well before the startup
+   * `get_settings` read — which seeds `view` from the stored default — has
+   * landed. Without the same supersession stamp, that stale read would put
+   * the calendar back on Week the moment it resolved.
+   */
+  test('a view picked while the stored default is still loading is not undone by it', async ({ page }) => {
+    await page.addInitScript(() => { (window as any).__holdSettings = true; });
+    await page.goto(app());
+    await expect(page.locator('.vswitch button')).toHaveCount(5);
+
+    await page.keyboard.press('3'); // Month
+    await expect(page.locator('.vswitch button.active')).toHaveText('Month');
+
+    // Now the parked answer lands, saying "Week" — the stored default as of
+    // the question it was asked, stale by one keystroke.
+    await page.evaluate(() => window.__harness.releaseSettings());
+    await expect(
+      page.locator('.vswitch button.active'), 'the stale read undid the keystroke',
+    ).toHaveText('Month');
   });
 
   test('the choice follows the user across views', async ({ page }) => {

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -2150,7 +2150,7 @@ test.describe('App', () => {
     const select = modal.locator('#default-view');
     await expect(select).toHaveValue('week');
     await expect(select.locator('option')).toHaveText([
-      'Day', 'Week', 'Month', 'Year', 'Big Year',
+      'Day', 'Week', 'Month', 'Year', 'Big Year', 'Last view',
     ]);
 
     await select.selectOption('month');
@@ -2192,6 +2192,120 @@ test.describe('App', () => {
 
     await page.reload();
     await expect(page.locator('.vswitch button.active')).toHaveText('Month');
+  });
+
+  /**
+   * `tray::open_plain`'s reason: closing the window only hides it, and
+   * hiding never remounts `App`, so nothing re-read `defaultView` on the way
+   * back — reported after the setting shipped, working on a full restart but
+   * never on the ordinary close-to-tray-then-reopen cycle.
+   */
+  test('reopening OmaCal (tray menu, bare CLI relaunch) applies the default view', async ({ page }) => {
+    await writable(page);
+    await page.keyboard.press('3'); // Month — away from the stored default
+    await expect(page.locator('.vswitch button.active')).toHaveText('Month');
+
+    await page.evaluate(() => window.__harness.emit('app-opened', null));
+    await expect(page.locator('.vswitch button.active')).toHaveText('Week');
+  });
+
+  /**
+   * The boundary `app-opened` deliberately does not cross: a dated launch or
+   * a clicked reminder already name a destination (`open-date`/`open-event`,
+   * spec comment in `App.svelte`), and the view on screen is not that
+   * destination's decision to make — only a *plain* reopen, with none of its
+   * own, defers to the stored default.
+   */
+  test('a dated reopen leaves the view alone, unlike a plain one', async ({ page }) => {
+    await writable(page);
+    await page.keyboard.press('3'); // Month
+    await expect(page.locator('.vswitch button.active')).toHaveText('Month');
+
+    await page.evaluate(() => window.__harness.emit('open-date', '2024-03-14'));
+    await expect(page.locator('.vswitch button.active')).toHaveText('Month');
+  });
+
+  /**
+   * The sixth row on the same one-question control `saveWeekView` already
+   * uses for Week view: "Last view" is `defaultViewFollowsLast` turned on,
+   * every other row is a fixed `defaultView` — and picking one of those
+   * turns the flag back off atomically, the same round trip
+   * `choosing Sunday rotates the Month header immediately`'s neighbours pin
+   * for `weekStartsToday`.
+   */
+  test('choosing Last view, then a fixed view again, moves the flag both ways', async ({ page }) => {
+    await writable(page);
+    await page.getByRole('button', { name: 'Menu' }).click();
+    await page.getByRole('button', { name: 'Settings…' }).click();
+    const modal = page.getByRole('dialog', { name: 'Settings' });
+    await modal.getByRole('tab', { name: 'Appearance' }).click();
+    const select = modal.locator('#default-view');
+
+    await select.selectOption('last');
+    let [args] = await callsTo(page, 'set_default_view_follows_last');
+    expect(args).toEqual({ on: true });
+
+    await select.selectOption('day');
+    [args] = await callsTo(page, 'set_default_view');
+    expect(args).toEqual({ view: 'day' });
+
+    // Reopened, the select reports the fixed choice, not "Last view" —
+    // the same atomic clear `set_default_view` makes on the backend.
+    await page.keyboard.press('Escape');
+    await expect(modal).toHaveCount(0);
+    await page.getByRole('button', { name: 'Menu' }).click();
+    await page.getByRole('button', { name: 'Settings…' }).click();
+    await modal.getByRole('tab', { name: 'Appearance' }).click();
+    await expect(modal.locator('#default-view')).toHaveValue('day');
+  });
+
+  /**
+   * The point of the setting, end to end: with "Last view" chosen, wherever
+   * the switcher was last left is where a reload — a fresh launch's own
+   * stand-in, `the chosen first day survives a reload`'s reason — opens.
+   * `pick` records the view on every switch (`set_last_view`), regardless of
+   * whether this mode is even on, precisely so turning it on has a real
+   * memory to open on rather than a blank one.
+   */
+  test('Last view reopens wherever the switcher was left, across a reload', async ({ page }) => {
+    await writable(page);
+    await page.getByRole('button', { name: 'Menu' }).click();
+    await page.getByRole('button', { name: 'Settings…' }).click();
+    const modal = page.getByRole('dialog', { name: 'Settings' });
+    await modal.getByRole('tab', { name: 'Appearance' }).click();
+    await modal.locator('#default-view').selectOption('last');
+    await page.keyboard.press('Escape');
+    await expect(modal).toHaveCount(0);
+
+    await page.keyboard.press('4'); // Year
+    await expect(page.locator('.vswitch button.active')).toHaveText('Year');
+
+    await page.reload();
+    await expect(page.locator('.vswitch button.active')).toHaveText('Year');
+  });
+
+  /**
+   * `reopening OmaCal (tray menu, bare CLI relaunch) applies the default
+   * view`'s own scenario, under "Last view" instead of a fixed default: the
+   * `app-opened` signal still applies whatever `App` currently holds as the
+   * effective default, which under this mode is `lastView`, not `defaultView`.
+   */
+  test('reopening under Last view lands back on the view last picked, not the fixed default', async ({ page }) => {
+    await writable(page);
+    await page.getByRole('button', { name: 'Menu' }).click();
+    await page.getByRole('button', { name: 'Settings…' }).click();
+    const modal = page.getByRole('dialog', { name: 'Settings' });
+    await modal.getByRole('tab', { name: 'Appearance' }).click();
+    await modal.locator('#default-view').selectOption('last');
+    await page.keyboard.press('Escape');
+    await expect(modal).toHaveCount(0);
+
+    await page.keyboard.press('3'); // Month
+    await page.keyboard.press('1'); // Day — the most recent pick
+    await expect(page.locator('.vswitch button.active')).toHaveText('Day');
+
+    await page.evaluate(() => window.__harness.emit('app-opened', null));
+    await expect(page.locator('.vswitch button.active')).toHaveText('Day');
   });
 
   /**

--- a/ui/tests/harness/tauri.ts
+++ b/ui/tests/harness/tauri.ts
@@ -580,6 +580,8 @@ type StubSettings = {
   dateFormat: import('../../src/lib/datefmt').DateFormat;
   desktop: 'macos' | 'omarchy' | 'linux';
   defaultView: View;
+  defaultViewFollowsLast: boolean;
+  lastView: View;
   weekStart: WeekStartDay;
   weekStartsToday: boolean;
   weekViewDays: WeekViewDays;
@@ -634,6 +636,10 @@ const DEFAULT_SETTINGS: StubSettings = {
   // The view every existing install already opens on, so every App spec
   // that predates this setting keeps describing the same screen.
   defaultView: 'week',
+  // Off until chosen — a fixed default, not "wherever I left off".
+  defaultViewFollowsLast: false,
+  // Nothing recorded yet reads as the same view the fixed default does.
+  lastView: 'week',
   // The week omacal has always drawn, so every golden holds.
   weekStart: 'monday',
   weekStartsToday: false,
@@ -945,7 +951,15 @@ export function installTauriStub(scenario: string): Harness {
         settings = saveSettings({ ...settings, hourHeight: args.px as number });
         return { ...settings };
       case 'set_default_view':
-        settings = saveSettings({ ...settings, defaultView: args.view as View });
+        settings = saveSettings({
+          ...settings, defaultView: args.view as View, defaultViewFollowsLast: false,
+        });
+        return { ...settings };
+      case 'set_default_view_follows_last':
+        settings = saveSettings({ ...settings, defaultViewFollowsLast: args.on as boolean });
+        return { ...settings };
+      case 'set_last_view':
+        settings = saveSettings({ ...settings, lastView: args.view as View });
         return { ...settings };
       case 'set_week_start':
         settings = saveSettings({

--- a/ui/tests/harness/tauri.ts
+++ b/ui/tests/harness/tauri.ts
@@ -16,6 +16,7 @@ import type { EventDetail } from '../../src/lib/eventdetail';
 import type { TimeFormat } from '../../src/lib/timefmt';
 import type { WeekStartDay } from '../../src/lib/weekstart';
 import type { Appearance, StartOnLogin, WeekViewDays, WindowFrame } from '../../src/lib/settings';
+import type { View } from '../../src/lib/views';
 import type { EventCornerStyle } from '../../src/lib/appearance';
 import type { TemperatureUnit } from '../../src/lib/temperature';
 import { sliceWeek } from '../../src/lib/weekwindow';
@@ -578,6 +579,7 @@ type StubSettings = {
   timeFormat: TimeFormat;
   dateFormat: import('../../src/lib/datefmt').DateFormat;
   desktop: 'macos' | 'omarchy' | 'linux';
+  defaultView: View;
   weekStart: WeekStartDay;
   weekStartsToday: boolean;
   weekViewDays: WeekViewDays;
@@ -629,6 +631,9 @@ const DEFAULT_SETTINGS: StubSettings = {
   timeFormat: '24h',
   dateFormat: 'locale',
   desktop: 'linux',
+  // The view every existing install already opens on, so every App spec
+  // that predates this setting keeps describing the same screen.
+  defaultView: 'week',
   // The week omacal has always drawn, so every golden holds.
   weekStart: 'monday',
   weekStartsToday: false,
@@ -938,6 +943,9 @@ export function installTauriStub(scenario: string): Harness {
         // The backend clamps; the stub stores what it was told, so a spec
         // reads back exactly the value the app asked to keep.
         settings = saveSettings({ ...settings, hourHeight: args.px as number });
+        return { ...settings };
+      case 'set_default_view':
+        settings = saveSettings({ ...settings, defaultView: args.view as View });
         return { ...settings };
       case 'set_week_start':
         settings = saveSettings({


### PR DESCRIPTION
## Summary

- Adds a "Open OmaCal on" row to Settings → Appearance: pick Day, Week, Month, Year, Big Year, or **Last view** (reopens wherever the switcher was last left).
- New Rust: `settings::DefaultView` (5 variants — no 6th "last" variant, since `last_view` itself can never mean "last") plus `default_view`, `default_view_follows_last`, `last_view` fields, mirroring the existing `week_start`/`week_starts_today` shape exactly (including `set_default_view`'s atomic clear of `default_view_follows_last`, same as `set_week_start`).
- Fixes a real bug found while testing: closing the window only ever hides it (`quitOnClose` off, the default), and hiding never remounts the webview — so the setting applied once at cold start and never again on the ordinary "close to tray, reopen from the menu or CLI" cycle. `tray::open_plain` now emits an `app-opened` event from the two sites that mean a plain reopen with no destination of their own (tray menu's Open item, bare CLI relaunch); `App` re-applies the default on that signal. Deliberately **not** wired into `open_at`/`open_file`/a clicked reminder — those already name where to land.
- The setting is a *default*, not a live jump: choosing it in Settings doesn't yank the calendar behind the modal to a different view mid-session (same shape as `defaultCalendarId`). Takes effect next launch, or immediately when the app is next opened/reopened.

## Test plan

- [x] `cargo test --workspace --no-fail-fast` — 650 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `npm --prefix ui run check` — clean
- [x] `npx playwright test --project=chromium --ignore-snapshots` — 235 passed
- [x] New tests proven red against deliberately broken code before trusting them (testing-standard.md): the atomic-clear test against a `set_default_view_impl` missing its second write, the reopen test against the `app-opened` listener removed, and the Last-view reopen/reload tests against `effectiveDefaultView` pinned to `defaultView` alone.
- [x] Manually verified end-to-end against a local build (`cargo tauri build`) installed over a real running instance: Settings row renders correctly, choosing a view persists across reload, and closing/reopening via the tray now picks up the stored default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)