### PR TITLE
feat(events): duplicate into an unsaved draft with a calendar chooser

### DIFF
--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -26,7 +26,7 @@
     type EventDetail, type Occurrence, type SendUpdates,
   } from './lib/eventdetail';
   import {
-    blankValue, blankValueAt, dateOf, pastedValue, previewGhost, timeOf, toEventInput,
+    blankValue, blankValueAt, dateOf, duplicatedValue, pastedValue, previewGhost, timeOf, toEventInput,
     type FormGhost,
     blankAllDayValue,
     valueFromDetail, type EventFormResult, type EventFormValue, type Scope,
@@ -1304,7 +1304,7 @@
    *  popover is already closed by then, and `occurrenceStartMs` is the one
    *  value an edit cannot be allowed to guess. */
   type FormRequest =
-    | { mode: 'create'; anchor: Rect; initial: EventFormValue }
+    | { mode: 'create'; anchor: Rect; initial: EventFormValue; chooseCalendar?: boolean }
     | { mode: 'edit'; anchor: Rect; initial: EventFormValue; id: number; occurrenceStartMs: number };
 
   let form = $state<FormRequest | null>(null);
@@ -1339,6 +1339,16 @@
     copiedEvent = valueFromDetail(
       occurrence.detail, occurrence.startMs, occurrence.endMs,
     );
+  }
+
+  function duplicateOccurrence(occurrence: Occurrence, anchor: Rect) {
+    const copied = valueFromDetail(occurrence.detail, occurrence.startMs, occurrence.endMs);
+    const calendarId = offerableCalendarId(copied.calendarId, calendars);
+    closeGridEvent();
+    form = {
+      mode: 'create', anchor, chooseCalendar: true,
+      initial: duplicatedValue(copied, blankValue(Date.now(), calendarId)),
+    };
   }
 
   // Where the mouse last was, for paste: Ctrl+V lands the copy on the day
@@ -2045,6 +2055,7 @@
                   oncreate={newEventAt} oncreateallday={newAllDayEventOver}
                   onedit={openEdit} ondelete={askDelete}
                   oncopy={copyOccurrence}
+                  onduplicate={createCalendarId === null ? null : duplicateOccurrence}
           onmove={moveOccurrence}
           ondraftmove={(span) => formEl?.applySpan(span)}
           onresponded={refreshAfterWrite} />
@@ -2118,6 +2129,7 @@
     onedit={() => openEdit(occurrence, rect)}
     ondelete={() => askDelete(occurrence, rect)}
     oncopy={() => copyOccurrence(occurrence)}
+    onduplicate={createCalendarId === null ? null : () => duplicateOccurrence(occurrence, rect)}
   />
 {/if}
 
@@ -2145,6 +2157,7 @@
     bind:this={formEl}
     anchor={form.anchor}
     initial={form.initial}
+    chooseCalendar={form.mode === 'create' && form.chooseCalendar === true}
     {calendars}
     onsave={saveForm}
     oncancel={() => (form = null)}

--- a/ui/src/lib/EventForm.svelte
+++ b/ui/src/lib/EventForm.svelte
@@ -71,6 +71,7 @@
     onsave,
     oncancel,
     onvaluechange,
+    chooseCalendar = false,
   }: {
     /** The rect to sit beside: the clicked block, or the clicked grid cell. */
     anchor: Rect;
@@ -88,6 +89,8 @@
      *  moves as the times are typed (2026-08-20, by request). Optional and
      *  advisory: nothing here waits on it, and the save path never reads it. */
     onvaluechange?: (v: EventFormValue) => void;
+    /** A duplicate starts by choosing where the new event should live. */
+    chooseCalendar?: boolean;
   } = $props();
 
   // A working copy. Every field the user can change lives here; the facts they
@@ -324,7 +327,9 @@
 
   /** Whether the calendar dot's list is open — bindable into the picker so
    *  the Escape guard below can subordinate the form to it. */
-  let calOpen = $state(false);
+  // A fresh form owns this initial choice; closing the list must stay closed.
+  // svelte-ignore state_referenced_locally
+  let calOpen = $state(chooseCalendar);
   // One per date field, so `escapeCloses` above can peel a chooser without
   // taking the form with it. See `CalendarPicker`'s `open` for the pattern.
   let startDateOpen = $state(false);
@@ -363,7 +368,11 @@
     // The first field, not the panel: this is a form, and the first thing
     // anybody does with it is type a title. `role="dialog"` + `aria-modal`
     // still oblige focus to start *inside*, which this satisfies.
-    titleEl?.focus();
+    if (chooseCalendar) {
+      const option = panelEl?.querySelector<HTMLElement>('[role="option"][aria-selected="true"]')
+        ?? panelEl?.querySelector<HTMLElement>('[role="option"]');
+      (option ?? titleEl)?.focus();
+    } else titleEl?.focus();
     return () => ro.disconnect();
   });
 

--- a/ui/src/lib/EventPopover.svelte
+++ b/ui/src/lib/EventPopover.svelte
@@ -26,6 +26,7 @@
     onedit,
     ondelete,
     oncopy,
+    onduplicate,
   }: {
     detail: EventDetail;
     anchor: Rect;
@@ -79,6 +80,9 @@
      *  in the shared component covers every view. Required, like `onedit`: a
      *  caller that omitted it would swallow the chord and copy nothing. */
     oncopy: () => void;
+    /** Opens an unsaved copy. Read-only sources are fine; null means there
+     * is no writable destination calendar available. */
+    onduplicate: (() => void) | null;
   } = $props();
 
   const segments = $derived(descriptionSegments(detail.description));
@@ -584,16 +588,18 @@
     </div>
   {/if}
 
-  <!-- Only when the backend says this account may write to the calendar the
+  <!-- Edit and Delete require the backend to say this account may write to the calendar the
        event is on (`can_edit`, from the same `access_role` column
        `create_impl`/`update_impl` check server-side). Offering either control
        on a subscribed holiday calendar would produce a Save — or worse, a
        Delete confirmation — the server could only refuse, after the user had
-       already decided to go through with it. -->
-  {#if detail.can_edit}
+       already decided to go through with it. Duplicate only needs a writable
+       destination; its source calendar can be read-only. -->
+  {#if detail.can_edit || onduplicate}
     <div class="own">
-      <button onclick={onedit}>Edit</button>
-      <button onclick={ondelete}>Delete</button>
+      {#if detail.can_edit}<button onclick={onedit}>Edit</button>{/if}
+      {#if onduplicate}<button onclick={onduplicate}>Duplicate</button>{/if}
+      {#if detail.can_edit}<button onclick={ondelete}>Delete</button>{/if}
     </div>
   {/if}
 

--- a/ui/src/lib/WeekGrid.svelte
+++ b/ui/src/lib/WeekGrid.svelte
@@ -27,7 +27,7 @@
   import { cursorNamesEvent, type KeyboardCursor } from './keyboardnav';
   import { dateOf } from './eventform';
 
-  let { week, weather = null, weatherStale = false, onweather = null, tasks = null, ontaskmove = null, ontasktoggle = null, formPreview = null, createColor = null, revealNowRequest = 0, keyboardCursor = null, onpan = null, hourPx = $bindable(HOUR_PX_DEFAULT), visibleStartMs = null, visibleDays = null, onerror = null, oncreate, oncreateallday, onedit, ondelete, oncopy, onmove, ondraftmove = null, onresponded }: {
+  let { week, weather = null, weatherStale = false, onweather = null, tasks = null, ontaskmove = null, ontasktoggle = null, formPreview = null, createColor = null, revealNowRequest = 0, keyboardCursor = null, onpan = null, hourPx = $bindable(HOUR_PX_DEFAULT), visibleStartMs = null, visibleDays = null, onerror = null, oncreate, oncreateallday, onedit, ondelete, oncopy, onduplicate, onmove, ondraftmove = null, onresponded }: {
     /** Padded since 2026-09-03: `visibleDays` from `visibleStartMs` are what
      *  is on screen, and the days either side are the track's to slide into
      *  under a finger (`weekwindow.ts`). Both null — a standalone mount, a
@@ -116,6 +116,7 @@
      *  what Ctrl+V pastes. Not through `relay` — a copy leaves the popover
      *  open, the way every selection survives being copied. */
     oncopy: (occurrence: Occurrence) => void;
+    onduplicate: ((occurrence: Occurrence, rect: Rect) => void) | null;
     /** A completed drag, handed up rather than written here: the grid decides
      *  *which occurrence* moved and *where to*, and `App` owns every write —
      *  the same split `oncreate`/`onedit`/`ondelete` already use. `WeekGrid`
@@ -1658,6 +1659,7 @@
     onedit={() => relay(onedit, occurrence, rect)}
     ondelete={() => relay(ondelete, occurrence, rect)}
     oncopy={() => oncopy(occurrence)}
+    onduplicate={onduplicate ? () => relay(onduplicate!, occurrence, rect) : null}
   />
 {/if}
 

--- a/ui/src/lib/eventform.ts
+++ b/ui/src/lib/eventform.ts
@@ -377,10 +377,9 @@ export const sameGuests = (a: Guest[], b: Guest[]): boolean => {
 /**
  * **How many people this save could mail.**
  *
- * Everyone on the resulting list, plus everyone removed from it, minus the
- * signed-in user. One rule, and deliberately with no `isEdit` branch in it: a
- * create is the case where `initial.guests` is empty and `selfEmail` is null,
- * which this arithmetic already handles.
+ * Everyone on the resulting list, plus (for an edit) everyone removed from
+ * it, minus the signed-in user. A pasted or duplicated draft can start with
+ * guests, but nobody has been invited until that draft is created.
  *
  * The **union** matters, not just the resulting list. A removal saved with
  * notify on sends that person a cancellation (guest-list spec §3), so they are
@@ -402,7 +401,10 @@ export const sameGuests = (a: Guest[], b: Guest[]): boolean => {
 export function mailableGuests(value: EventFormValue, initial: EventFormValue): number {
   const self = value.selfEmail;
   const mailable = new Set<string>();
-  for (const g of [...value.guests, ...initial.guests]) {
+  // Removing a guest from an unsaved duplicate cannot cancel an invitation:
+  // there is no server-side event yet. Only edits need to count removed guests.
+  const previous = value.isEdit ? initial.guests : [];
+  for (const g of [...value.guests, ...previous]) {
     if (self !== null && sameAddress(g.email, self)) continue;
     // Keyed by the *compared* form, so one person spelled two ways is one
     // entry — the same normalisation `sameAddress` applies, which is what
@@ -1029,6 +1031,19 @@ export function pastedValue(copied: EventFormValue, blank: EventFormValue): Even
     endDate: shiftedEndDate(copied.date, blank.date, copied.endDate),
     sourceStartMs: null,
     sourceEndMs: null,
+  };
+}
+
+/** A duplicate is a new draft of this occurrence, on its original dates.
+ * Reuse paste's guest and recurrence rules, but keep the exact instants (also
+ * through a repeated DST hour). A structured meeting belongs to the source
+ * event; carry its URL as a manual link rather than requesting a new room. */
+export function duplicatedValue(copied: EventFormValue, blank: EventFormValue): EventFormValue {
+  return {
+    ...pastedValue(copied, { ...blank, date: copied.date }),
+    sourceStartMs: copied.sourceStartMs,
+    sourceEndMs: copied.sourceEndMs,
+    videoCall: copied.videoCall ? { ...copied.videoCall, source: 'new' } : null,
   };
 }
 

--- a/ui/tests/duplicate-event.spec.ts
+++ b/ui/tests/duplicate-event.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect, type Page } from '@playwright/test';
+import {
+  APP_WRITE_CALENDARS, APP_GUESTS_ID, APP_SERIES_OCCURRENCE,
+  POPOVER_DETAILS,
+} from './fixtures';
+
+const form = (page: Page) => page.getByRole('dialog', { name: 'New event', exact: true });
+const calls = (page: Page, cmd: string) => page.evaluate((name) =>
+  window.__harness.calls.filter((c) => c.cmd === name).map((c) => c.args as any), cmd);
+
+async function setup(page: Page, readOnly = false) {
+  const calendars = [...APP_WRITE_CALENDARS, {
+    ...APP_WRITE_CALENDARS[2], id: 20, account_id: 2,
+    account_email: 'personal@example.com', summary: 'Home',
+  }];
+  const detail = {
+    ...POPOVER_DETAILS[APP_GUESTS_ID], can_edit: !readOnly,
+    location: 'Room 4', description: 'Bring the project notes.',
+    conference_uri: 'https://meet.google.com/abc-defg-hij',
+  };
+  await page.addInitScript(({ calendars, detail }) => {
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      set(ipc) {
+        const invoke = ipc.invoke;
+        ipc.invoke = (cmd: string, args: any, ...rest: any[]) => {
+          if (cmd === 'get_calendars') return Promise.resolve(calendars);
+          if ((cmd === 'event_detail' || cmd === 'refresh_event') && args.id === detail.id)
+            return Promise.resolve(detail);
+          return invoke(cmd, args, ...rest);
+        };
+        Object.defineProperty(window, '__TAURI_INTERNALS__', { value: ipc, configurable: true });
+      },
+    });
+  }, { calendars, detail });
+  await page.goto('/tests/harness/index.html?c=App&f=writable');
+  await expect(page.locator('.ev').filter({ hasText: 'Client call' })).toBeVisible();
+}
+
+test('duplicate opens an unsaved draft with the calendar picker, then creates on another account', async ({ page }) => {
+  await setup(page);
+  await page.locator('.ev').filter({ hasText: 'Client call' }).click();
+  await page.getByRole('button', { name: 'Duplicate', exact: true }).click();
+  await expect(form(page)).toBeVisible();
+  const picker = form(page).getByRole('listbox', { name: 'Calendar', exact: true });
+  await expect(picker).toBeVisible();
+  await expect(picker.getByRole('option', { selected: true })).toBeFocused();
+  await expect(picker.getByRole('option', { name: 'Holidays in Bulgaria' })).toHaveCount(0);
+  expect(await calls(page, 'create_event')).toEqual([]);
+  expect(await calls(page, 'update_event')).toEqual([]);
+  await picker.getByRole('option', { name: 'Home', exact: true }).click();
+  await form(page).getByRole('button', { name: 'Create', exact: true }).click();
+  await page.getByRole('button', { name: 'Create without notifying', exact: true }).click();
+  await expect(form(page)).toHaveCount(0);
+  const [created] = await calls(page, 'create_event');
+  expect(created.calendarId).toBe(20);
+  expect(created.fields.summary).toBe('Client call');
+  expect(created.fields.description).toBe('Bring the project notes.');
+  expect(created.fields.location).toContain('Room 4');
+  expect(created.fields.location).toContain('https://meet.google.com/abc-defg-hij');
+  expect(created.fields.guests).toEqual([{ email: 'ana@x.com', optional: false }]);
+  expect(created.sendUpdates).toBe('none');
+  expect(await calls(page, 'update_event')).toEqual([]);
+});
+
+test('duplicate keeps the clicked recurring occurrence and Escape cancels without writing', async ({ page }) => {
+  await setup(page);
+  await page.locator('.ev').filter({ hasText: 'Standup' }).click();
+  await page.getByRole('button', { name: 'Duplicate', exact: true }).click();
+  await expect(form(page).getByRole('listbox')).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(form(page)).toBeVisible();
+  await expect(form(page).getByRole('listbox')).toHaveCount(0);
+  await expect(form(page).getByLabel('Date', { exact: true })).toHaveValue(new Date(APP_SERIES_OCCURRENCE).toISOString().slice(0, 10));
+  await expect(form(page).getByLabel('Start', { exact: true })).toHaveValue('09:00');
+  await expect(form(page).getByLabel('End', { exact: true })).toHaveValue('09:30');
+  await expect(form(page).getByLabel('Repeat', { exact: true })).toHaveValue('never');
+  await page.keyboard.press('Escape');
+  await expect(form(page)).toHaveCount(0);
+  expect(await calls(page, 'create_event')).toEqual([]);
+  expect(await calls(page, 'update_event')).toEqual([]);
+});
+
+test('duplicate is available for read-only source events and guests can be removed before saving', async ({ page }) => {
+  await setup(page, true);
+  await page.locator('.ev').filter({ hasText: 'Client call' }).click();
+  await expect(page.getByRole('button', { name: 'Edit', exact: true })).toHaveCount(0);
+  await page.getByRole('button', { name: 'Duplicate', exact: true }).click();
+  await form(page).getByRole('option', { name: 'Home', exact: true }).click();
+  await form(page).getByRole('button', { name: 'Remove ana@x.com', exact: true }).click();
+  await form(page).getByRole('button', { name: 'Create', exact: true }).click();
+  await expect(form(page)).toHaveCount(0);
+  const [created] = await calls(page, 'create_event');
+  expect(created.calendarId).toBe(20);
+  expect(created.fields.guests ?? []).toEqual([]);
+});
+
+test('duplicate preserves the all-day occurrence dates', async ({ page }) => {
+  await setup(page);
+  await page.locator('.chip').filter({ hasText: 'Diwali' }).click();
+  await page.getByRole('button', { name: 'Duplicate', exact: true }).click();
+  await form(page).getByRole('option', { name: 'Home', exact: true }).click();
+  await expect(form(page).getByLabel('All day', { exact: true })).toBeChecked();
+  await expect(form(page).getByLabel('First day', { exact: true })).toHaveValue('2024-01-31');
+  await expect(form(page).getByLabel('Last day', { exact: true })).toHaveValue('2024-01-31');
+});
+
+test('duplicate works from the shared list popover without replacing the copy buffer', async ({ page }) => {
+  await setup(page);
+  await page.locator('.ev').filter({ hasText: 'Standup' }).click();
+  await page.keyboard.press('Control+c');
+  await page.keyboard.press('Escape');
+  await page.keyboard.press('f');
+  await page.getByRole('button', { name: /Client call/ }).click();
+  await page.getByRole('button', { name: 'Duplicate', exact: true }).click();
+  await expect(form(page).getByRole('listbox')).toBeVisible();
+  await page.keyboard.press('Escape');
+  await page.keyboard.press('Escape');
+  await page.keyboard.press('Control+v');
+  await expect(form(page).getByLabel('Title', { exact: true })).toHaveValue('Standup');
+});

--- a/ui/tests/harness/mount.svelte.ts
+++ b/ui/tests/harness/mount.svelte.ts
@@ -242,6 +242,7 @@ if (name === 'App') {
             (window as any).__lastDelete = { occurrence, rect };
           },
           // Ctrl+C in the popover. No rect — a copy points at nothing.
+          onduplicate: null,
           oncopy: (occurrence: unknown) => {
             (window as any).__lastCopy = { occurrence };
           },
@@ -374,6 +375,7 @@ if (name === 'App') {
           ondelete: () => {
             (window as any).__lastDelete = { deleted: true };
           },
+          onduplicate: null,
           oncopy: () => {
             (window as any).__lastCopy = { copied: true };
           },


### PR DESCRIPTION
Adds Duplicate beside Edit and Delete in event details. It opens an unsaved draft with the calendar picker already open, so you can choose the destination and adjust guests before creating the copy. The source event stays untouched, and recurring events copy only the selected occurrence.

Guest editing keeps the existing provider capabilities; this does not add CalDAV attendee support.

Validated with Svelte/TypeScript checks and all 10 duplication cases in Chromium and WebKit, including cancellation without writes, read-only sources, recurring/all-day dates, and guest retention. The regression cases were also proven red before the implementation.

Actual app UI, captured in Chromium with synthetic calendars and an otherwise empty workspace:

![Duplicate draft with calendar picker](https://raw.githubusercontent.com/jondkinney/omacal/b80316919d61cf484161263a5c3971a8a3d7a8b5/review/20260910/duplicate-draft.png)
