### PR TITLE
fix(calendars): separate integrations that share an email

### DIFF
--- a/ui/src/lib/CalendarList.svelte
+++ b/ui/src/lib/CalendarList.svelte
@@ -162,9 +162,9 @@
   `two calendars with the same name in one account both render`.
 -->
 <div class="list" class:spacious>
-  {#each groups as [email, cals]}
-    <div class="acct">{email}</div>
-    {#each cals as c (c.id)}
+  {#each groups as group (group.id)}
+    <div class="acct">{group.label}</div>
+    {#each group.calendars as c (c.id)}
       <div class="row" class:off={!c.sync_enabled}>
         <label>
           <input

--- a/ui/src/lib/CalendarPicker.svelte
+++ b/ui/src/lib/CalendarPicker.svelte
@@ -1,6 +1,6 @@
 <!-- ui/src/lib/CalendarPicker.svelte -->
 <script lang="ts">
-  import type { Calendar } from './calendars';
+  import { byAccount, type Calendar } from './calendars';
 
   let {
     calendars,
@@ -24,18 +24,7 @@
 
   const chosen = $derived(calendars.find((c) => c.id === value) ?? null);
 
-  /** Account groups in first-seen order. A `Map` keeps insertion order, so
-   *  the list reads in the same order the accounts were connected — the same
-   *  order every other account-grouped surface uses. */
-  const groups = $derived.by(() => {
-    const m = new Map<string, Calendar[]>();
-    for (const c of calendars) {
-      const g = m.get(c.account_email);
-      if (g) g.push(c);
-      else m.set(c.account_email, [c]);
-    }
-    return [...m.entries()];
-  });
+  const groups = $derived(byAccount(calendars));
 
   /** The muted account headings earn their place only when there is more
    *  than one account to tell apart — the single-account rule the old
@@ -73,9 +62,9 @@
          scrim in this app has, and for the same reason. -->
     <button class="scrim" aria-label="Close calendar list" onclick={() => (open = false)}></button>
     <div class="list" role="listbox" aria-label="Calendar">
-      {#each groups as [email, cals] (email)}
-        {#if showHeadings}<span class="acct">{email}</span>{/if}
-        {#each cals as c (c.id)}
+      {#each groups as group (group.id)}
+        {#if showHeadings}<span class="acct" title={group.label}>{group.label}</span>{/if}
+        {#each group.calendars as c (c.id)}
           <button
             type="button"
             role="option"

--- a/ui/src/lib/calendars.ts
+++ b/ui/src/lib/calendars.ts
@@ -90,15 +90,20 @@ export const setCalendarSync = (id: number, on: boolean) =>
 export const setCalendarColor = (id: number, hex: string | null) =>
   invoke<void>('set_calendar_color', { id, hex });
 
-/** Calendars grouped by account, preserving the order the backend returned. */
-export function byAccount(cals: Calendar[]): Array<[string, Calendar[]]> {
-  const groups = new Map<string, Calendar[]>();
+/** Account identity is independent of its email: Google and CalDAV (or two
+ * CalDAV connections) may share an address. Keep first-seen account order. */
+export function byAccount(cals: Calendar[]): Array<{ id: number; label: string; calendars: Calendar[] }> {
+  const groups = new Map<number, { id: number; label: string; calendars: Calendar[] }>();
   for (const c of cals) {
-    const g = groups.get(c.account_email) ?? [];
-    g.push(c);
-    groups.set(c.account_email, g);
+    const g = groups.get(c.account_id);
+    if (g) g.calendars.push(c);
+    else {
+      const provider = c.provider === 'google' ? 'Google' : c.provider === 'caldav' ? 'CalDAV' : c.provider;
+      groups.set(c.account_id, { id: c.account_id,
+        label: `${provider} · ${c.account_email}`, calendars: [c] });
+    }
   }
-  return [...groups.entries()];
+  return [...groups.values()];
 }
 
 export const setCalendarLabel = (id: number, label: string | null): Promise<void> =>

--- a/ui/tests/calendar-account-groups.spec.ts
+++ b/ui/tests/calendar-account-groups.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+import { FORM_NOW } from './fixtures';
+
+const headings = ['Google · shared@example.com', 'CalDAV · shared@example.com', 'CalDAV · shared@example.com'];
+
+for (const host of ['settings', 'popover']) {
+  test(`${host} separates account identities sharing an email and names their integrations`, async ({ page }) => {
+    await page.goto(`/tests/harness/index.html?c=${host === 'settings' ? 'Header' : 'CalendarPopover'}&f=shared-email-accounts`);
+    if (host === 'settings') {
+      await page.getByRole('button', { name: 'Menu', exact: true }).click();
+      await page.getByRole('button', { name: 'Settings…' }).click();
+      await page.getByRole('tab', { name: 'Calendars', exact: true }).click();
+    } else {
+      await page.getByRole('button', { name: /Calendars/ }).click();
+    }
+    await expect(page.locator('.acct')).toHaveText(headings);
+    // The backend can interleave calendars when sorting their names. Each
+    // account must keep its own rows together, including repeated names.
+    const groups = await page.locator('.acct').evaluateAll(els => els.map(el => {
+      const names: string[] = [];
+      for (let row = el.nextElementSibling; row && !row.classList.contains('acct'); row = row.nextElementSibling) {
+        if (row.classList.contains('row')) names.push(row.querySelector('.name')!.textContent!);
+      }
+      return names;
+    }));
+    expect(groups).toEqual([['Personal', 'Work'], ['Personal'], ['Personal']]);
+    // An action on the second account's identically named calendar still
+    // addresses that calendar alone.
+    await page.locator('.list > .row').nth(2).getByRole('checkbox').uncheck();
+    const calls = await page.evaluate(() => (window as any).__harness.calls.filter((c: any) => c.cmd === 'set_calendar_selected'));
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args).toEqual({ id: 201, on: false });
+  });
+}
+
+test('the event calendar picker separates integrations and selects the intended same-name calendar', async ({ page }) => {
+  await page.clock.setFixedTime(FORM_NOW);
+  await page.goto('/tests/harness/index.html?c=EventForm&f=shared-email-accounts');
+  await page.getByLabel('Title', { exact: true }).fill('Account grouping test');
+  await page.getByRole('button', { name: 'Calendar', exact: true }).click();
+  const list = page.getByRole('listbox', { name: 'Calendar', exact: true });
+  await expect(list.locator('.acct')).toHaveText(headings);
+  await expect(list.locator('.name')).toHaveText(['Personal', 'Work', 'Personal', 'Personal']);
+  await list.getByRole('option', { name: 'Personal', exact: true }).last().click();
+  await page.getByRole('button', { name: 'Create', exact: true }).click();
+  const saves = await page.evaluate(() => (window as any).__saves);
+  expect(saves).toHaveLength(1);
+  expect(saves[0].calendarId).toBe(301);
+});

--- a/ui/tests/components.spec.ts
+++ b/ui/tests/components.spec.ts
@@ -1776,7 +1776,7 @@ test.describe('Header', () => {
     await page.goto(show('Header', 'connected'));
     const modal = await openSettings(page, 'Calendars');
 
-    await expect(modal.locator('.acct')).toHaveText(['me@x.com']);
+    await expect(modal.locator('.acct')).toHaveText(['Google · me@x.com']);
     await expect(modal.getByRole('tabpanel').locator('.row')).toHaveCount(3);
     await expect(modal.locator('.name')).toHaveText(['Personal', 'Team', 'Holidays in Bulgaria']);
   });
@@ -2076,7 +2076,7 @@ test.describe('CalendarPopover', () => {
     await page.goto(show('same-summary-one-account'));
     await page.getByRole('button', { name: /Calendars/ }).click();
 
-    await expect(page.locator('.acct')).toHaveText(['me@x.com']);
+    await expect(page.locator('.acct')).toHaveText(['Google · me@x.com']);
     await expect(page.locator('.name')).toHaveText(['UK Holidays', 'UK Holidays']);
   });
 

--- a/ui/tests/fixtures.ts
+++ b/ui/tests/fixtures.ts
@@ -443,6 +443,16 @@ const cal = (o: Partial<Calendar> & { id: number; account_email: string; summary
   ...o,
 });
 
+/** Same address and repeated names across Google and two distinct CalDAV
+ * connections. Interleaved input must still form three account groups. */
+const SAME_EMAIL_CALENDARS = [
+  cal({ id: 101, account_id: 10, account_email: 'shared@example.com', summary: 'Personal' }),
+  cal({ id: 201, account_id: 20, account_email: 'shared@example.com', summary: 'Personal', provider: 'caldav', color_hex: '#20b080' }),
+  cal({ id: 102, account_id: 10, account_email: 'shared@example.com', summary: 'Work' }),
+  cal({ id: 301, account_id: 30, account_email: 'shared@example.com', summary: 'Personal', provider: 'caldav', color_hex: '#e2a03f' }),
+];
+
+
 /** A fixture instant as the `yyyy-mm-dd` its calendar keeps it on.
  *
  *  Every all-day fixture here sits at **UTC** midnight, so the calendar these
@@ -2259,6 +2269,10 @@ export const FIXTURES: Record<string, Record<string, any>> = {
     },
   },
   Header: {
+    'shared-email-accounts': {
+      ...header({ accounts: ['shared@example.com'], last_sync_ms: FIVE_MIN_AGO, demo: false, overlay_titlebar: false }),
+      calendars: SAME_EMAIL_CALENDARS,
+    },
     disconnected: header({ accounts: [], last_sync_ms: null, demo: false, overlay_titlebar: false }),
     // **With calendars**, unlike every other fixture in this block, which
     // predate the picker living behind the hamburger and left the list empty.
@@ -2494,6 +2508,7 @@ export const FIXTURES: Record<string, Record<string, any>> = {
     },
   },
   CalendarPopover: {
+    'shared-email-accounts': { calendars: SAME_EMAIL_CALENDARS, onchange: noop },
     /**
      * **Two calendars with the same name in one account** — the shape that
      * actually trips `each_key_duplicate`, which is not quite the one the
@@ -2950,6 +2965,9 @@ export const FIXTURES: Record<string, Record<string, any>> = {
   // callback props rather than Tauri commands, so they are captured on the
   // window exactly as `MonthGrid`'s `onopen` is (see harness/mount.svelte.ts).
   EventForm: {
+    'shared-email-accounts': {
+      anchor: ANCHOR, initial: blankValue(FORM_NOW, 101), calendars: SAME_EMAIL_CALENDARS,
+    },
     // Built from `Date.now()` on purpose. The "next half hour" default belongs
     // to `blankValue`, and a fixture that pinned the instant itself could not
     // tell a form that applies the default from one that was handed the answer.


### PR DESCRIPTION
Google and CalDAV accounts with the same email were being grouped together, making same-named calendars hard to distinguish. Group calendars by account identity and show the integration in each heading. Settings, the calendar popover, and the event calendar picker all use the same grouping.

Svelte/TypeScript checks and all six account-grouping cases pass in Chromium and WebKit. The regression was proven red against email-based grouping and checks that selection/visibility updates reach the intended calendar ID.

Actual Settings UI with synthetic accounts and no calendar events:

![Separate Google and CalDAV calendar groups](https://raw.githubusercontent.com/jondkinney/omacal/b80316919d61cf484161263a5c3971a8a3d7a8b5/review/20260910/calendar-account-groups.png)
