### PR TITLE
feat(calendar): create events over existing ones with Alt-drag

### DIFF
--- a/ui/src/lib/EventBlock.svelte
+++ b/ui/src/lib/EventBlock.svelte
@@ -14,6 +14,7 @@
     preview = null,
     liveSpan = null,
     keyboardSelected = false,
+    createMode = false,
   }: {
     event: UiEvent;
     placed: Placed;
@@ -44,6 +45,8 @@
     /** Named by App's vim-style cursor. This is visual selection, not DOM
      * focus; opening it moves focus into the detail dialog. */
     keyboardSelected?: boolean;
+    /** Alt-hover or an active creation sweep: this block is background. */
+    createMode?: boolean;
   } = $props();
 
   // What the card *says*: the drag's tentative span while one is in flight,
@@ -129,6 +132,7 @@
   class:nobodycoming={event.all_guests_declined}
   class:dragging={preview !== null}
   class:keyboard={keyboardSelected}
+  class:create-mode={createMode}
   data-kbd-selected-event={keyboardSelected ? '' : undefined}
   data-event-id={event.id}
   data-event-start-ms={event.start_ms}
@@ -155,7 +159,7 @@
        still lands on the button and `edgeAt` still decides. Hidden while
        this block is the one being dragged, when the only honest cursor is
        the grid's own `grabbing`. -->
-  {#if grips && !preview}
+  {#if grips && !preview && !createMode}
     <span class="grip" style="top:0; height:{RESIZE_EDGE_PX}px" aria-hidden="true"></span>
     <span class="grip" style="bottom:0; height:{RESIZE_EDGE_PX}px" aria-hidden="true"></span>
   {/if}
@@ -174,7 +178,7 @@
   {#if showMeta && meta}<em>{meta}</em>{/if}
   <!-- aria-hidden: the button's own label already says all of this, so the
        tooltip is presentation for the pointer, not a second announcement. -->
-  {#if tip && !preview}
+  {#if tip && !preview && !createMode}
     <span class="tip" class:below={!tip.above} aria-hidden="true"
           style="left:{tip.x}px; top:{tip.y}px;">
       <b class="tt">{event.title}</b>
@@ -204,7 +208,7 @@
      than as hidden. The bar appears only on hover, so a block at rest is
      unchanged and the committed baselines — which never hover — still hold
      these to invisibility. */
-  .ev:hover { cursor: grab; }
+  .ev:hover:not(.create-mode) { cursor: grab; }
   .grip { position: absolute; left: 0; right: 0; cursor: ns-resize; }
   /* Centred in the band rather than filling it: the bar says "here", the
      band is what actually answers, and a filled 6px block would read as a
@@ -258,10 +262,13 @@
      higher-column neighbours. `.ev.dragging` below got this right from day
      one; this rule had been losing the same fight invisibly until a dense
      iCloud week made it obvious. */
-  .ev:hover { left: 3px !important; width: calc(100% - 6px) !important; z-index: 20 !important;
+  .ev:hover:not(.create-mode) { left: 3px !important; width: calc(100% - 6px) !important; z-index: 20 !important;
               box-shadow: inset 2px 0 0 0 var(--spine),
                           0 -1px 0 0 var(--bg), 0 1px 0 0 var(--bg),
                           0 4px 14px rgba(0, 0, 0, .5); }
+  /* Keep every saved event below the creation preview, regardless of its
+     overlap column or keyboard selection. Alt must also override edge grips. */
+  .ev.create-mode { cursor: crosshair; z-index: 1 !important; }
 
   /* 11.5/10.5, up from 10/9 (2026-08-14): at 10px the grid read as decoration
      on a 14" screen, and Google's own week view sits at ~12px. The density

--- a/ui/src/lib/WeekGrid.svelte
+++ b/ui/src/lib/WeekGrid.svelte
@@ -7,7 +7,7 @@
   import WeatherGlyph from './WeatherGlyph.svelte';
   import { dateKey, type DayWeather } from './weather';
   import type { TaskChip } from './taskchips';
-  import { gutterLabel, zoneAbbrev, zoneGutterLabel } from './timefmt';
+  import { formatClock, gutterLabel, zoneAbbrev, zoneGutterLabel } from './timefmt';
   import { tick, untrack } from 'svelte';
   import { HOUR_PX_DEFAULT, hourPxAfterPinch, hourPxAfterWheel, scrollTopKeeping } from './zoom';
   import { onPinch, type Pinch } from './pinch';
@@ -702,6 +702,13 @@
     const col = target.closest('.col');
     if (!col) return;
     const colBox = col.getBoundingClientRect();
+    // Decide once at pointer-down. Releasing Alt during the sweep must not
+    // turn a new event into a move/resize of the event underneath it.
+    if (e.altKey) {
+      e.preventDefault();
+      startSweep(day, renderedDays.findIndex((d) => d.start_ms === day.start_ms), e, colBox);
+      return;
+    }
     const box = target.getBoundingClientRect();
 
     drag = {
@@ -1045,6 +1052,7 @@
     fromFrac: number;
     /** The last pointer position, for the rect the form opens beside — the
      *  same "next to where the user pointed" rule `startCreate` follows. */
+    clientX: number;
     clientY: number;
     /** Past the threshold. Below it this is still a click. */
     sweeping: boolean;
@@ -1052,11 +1060,39 @@
     ask: import('./drag').SweepAsk | null;
   };
   let sweep = $state<Sweep | null>(null);
+  let altHeld = $state(false);
+  // The gesture is chosen at pointer-down; pressing Alt during a move must
+  // not advertise creation, and releasing it during a sweep must not end it.
+  const createMode = $derived(sweep !== null || (altHeld && drag === null));
+  const trackAlt = (e: KeyboardEvent | PointerEvent) => { altHeld = e.altKey; };
 
-  function startSweep(day: { start_ms: number; end_ms: number }, dayIndex: number, e: PointerEvent) {
+  let viewportWidth = $state(0);
+  let viewportHeight = $state(0);
+  let feedbackWidth = $state(0);
+  let feedbackHeight = $state(0);
+  const sweepFeedback = $derived.by(() => {
+    const ask = sweep?.ask;
+    if (!ask) return null;
+    if (ask.kind === 'allDay') {
+      const days = renderedDays.filter((d) => d.start_ms >= ask.firstDayMs && d.start_ms <= ask.lastDayMs).length;
+      return { duration: `${days} ${days === 1 ? 'day' : 'days'}`, range: 'All day' };
+    }
+    // Read the snapped span that will open in the form, including reverse
+    // drags and boundary clamping, rather than measuring the pointer again.
+    const minutes = Math.round((ask.endMs - ask.startMs) / 60_000);
+    const hours = Math.floor(minutes / 60);
+    const rest = minutes % 60;
+    const duration = hours ? `${hours}h${rest ? ` ${rest}m` : ''}` : `${minutes} min`;
+    const range = `${formatClock(ask.startMs, clockFormat())} – ${formatClock(ask.endMs, clockFormat())}`;
+    return { duration, range };
+  });
+
+  function startSweep(
+    day: { start_ms: number; end_ms: number }, dayIndex: number, e: PointerEvent,
+    box = (e.currentTarget as HTMLElement).getBoundingClientRect(),
+  ) {
     // Primary button only, for the same reason `startDrag` says so.
     if (e.button !== 0) return;
-    const box = (e.currentTarget as HTMLElement).getBoundingClientRect();
     sweep = {
       dayStartMs: day.start_ms,
       dayMs: day.end_ms - day.start_ms,
@@ -1067,6 +1103,7 @@
       originX: e.clientX,
       originY: e.clientY,
       fromFrac: box.height === 0 ? 0 : (e.clientY - box.top) / box.height,
+      clientX: e.clientX,
       clientY: e.clientY,
       sweeping: false,
       ask: null,
@@ -1075,6 +1112,8 @@
     window.addEventListener('pointermove', onSweepMove);
     window.addEventListener('pointerup', onSweepEnd);
     window.addEventListener('keydown', onSweepKey);
+    window.addEventListener('pointercancel', cancelSweep);
+    window.addEventListener('blur', cancelSweep);
   }
 
   function onSweepMove(e: PointerEvent) {
@@ -1086,6 +1125,7 @@
     // still creates at the half hour it landed in.
     if (!sweep.sweeping && !beganDrag(dx, dy)) return;
     sweep.sweeping = true;
+    sweep.clientX = e.clientX;
     sweep.clientY = e.clientY;
 
     // The far end is the near end **plus how far the hand travelled**, never a
@@ -1136,6 +1176,11 @@
     // Cancelled: no form is asked for, and the release that follows must not be
     // read as the end of a sweep.
     e.stopPropagation();
+    cancelSweep();
+  }
+
+  function cancelSweep() {
+    if (!sweep) return;
     draggedNotClicked = sweep.sweeping;
     endSweep();
   }
@@ -1155,6 +1200,8 @@
     window.removeEventListener('pointermove', onSweepMove);
     window.removeEventListener('pointerup', onSweepEnd);
     window.removeEventListener('keydown', onSweepKey);
+    window.removeEventListener('pointercancel', cancelSweep);
+    window.removeEventListener('blur', cancelSweep);
   }
 
   /**
@@ -1396,6 +1443,10 @@
   }
 </script>
 
+<svelte:window onkeydown={trackAlt} onkeyup={trackAlt} onpointermove={trackAlt}
+  onblur={() => { altHeld = false; }}
+  bind:innerWidth={viewportWidth} bind:innerHeight={viewportHeight} />
+
 <div class="grid" style="--cols:{renderedDays.length}; --visible:{visible}; --vis:{renderVis}; --pan:{panDays}; --gutter:{gutterWidth()}" onwheel={wheelPan}>
   <div class="gutter head">
     {#if secondZone()}
@@ -1510,7 +1561,7 @@
   onopen={openPopover}
 />
 
-<div class="grid body quiet-scroll" style="--cols:{renderedDays.length}; --visible:{visible}; --vis:{renderVis}; --pan:{panDays}; --gutter:{gutterWidth()}; --hour-px:{Math.round(hourPx)}px" bind:this={bodyEl} data-testid="week-body" onwheel={wheelPan}>
+<div class="grid body quiet-scroll" class:creating={createMode} style="--cols:{renderedDays.length}; --visible:{visible}; --vis:{renderVis}; --pan:{panDays}; --gutter:{gutterWidth()}; --hour-px:{Math.round(hourPx)}px" bind:this={bodyEl} data-testid="week-body" onwheel={wheelPan}>
   <div class="gutter">
     {#each HOURS as h}
       {#if secondZone()}
@@ -1574,9 +1625,8 @@
         <div class="rule" style="top:{hourFrac(day, h) * 100}%"></div>
       {/each}
 
-      <!-- After the rules so it reads above them, before the blocks so it never
-           covers a real event, and transparent to the pointer so the sweep it
-           is drawing cannot be interrupted by its own ghost. -->
+      <!-- Raised above saved events, including the one under the pointer.
+           Pointer-transparent so the preview cannot interrupt its own sweep. -->
       {#if ghost}
         {@const edge = sweepEdges(day)}
         <div class="sweep" class:cl={edge.cl} class:cr={edge.cr} style={ghost}></div>
@@ -1607,6 +1657,7 @@
         <EventBlock
           event={day.events[p.idx]}
           placed={p}
+          {createMode}
           onopen={openPopover}
           ongrab={(ev, e) => startDrag(ev, day, e)}
           preview={previewFor(day.events[p.idx])}
@@ -1627,6 +1678,17 @@
   {/each}
   </div></div>
 </div>
+
+{#if sweep && sweepFeedback}
+  <div class="sweep-feedback" role="status" aria-label="New event duration"
+    bind:clientWidth={feedbackWidth} bind:clientHeight={feedbackHeight}
+    style:left="{Math.max(8, Math.min(sweep.clientX + 16, viewportWidth - feedbackWidth - 8))}px"
+    style:top="{Math.max(8, sweep.clientY + 16 + feedbackHeight > viewportHeight - 8
+      ? sweep.clientY - feedbackHeight - 16 : sweep.clientY + 16)}px">
+    <strong>{sweepFeedback.duration}</strong>
+    <span>{sweepFeedback.range}</span>
+  </div>
+{/if}
 
 {#if selectedId !== null && selectedStartMs !== null && anchor && detail}
   <!-- `id`/`startMs` are captured *now*, at this render, not read back off
@@ -1662,6 +1724,7 @@
 {/if}
 
 <style>
+  .creating .newhere { cursor: crosshair; }
   /* `--gutter` from `secondzone.svelte`'s one exported width: 44px alone,
      wider when the second clock takes the outer lane. A var rather than two
      hardcodings because the head row here, the body row below and the
@@ -1858,7 +1921,14 @@
            border-radius: var(--event-card-radius, 6px);
            background: color-mix(in srgb, var(--ghost, var(--accent)) 14%, var(--bg));
            box-shadow: inset 2px 0 0 0 var(--ghost, var(--accent));
-           pointer-events: none; z-index: 4; }
+           pointer-events: none; z-index: 60; }
+  .sweep-feedback { position: fixed; z-index: 70; pointer-events: none;
+                    display: flex; flex-direction: column; gap: 3px;
+                    padding: 7px 10px; border-radius: 6px;
+                    border: 1px solid var(--accent); background: var(--surface);
+                    color: var(--text); box-shadow: 0 3px 12px rgba(0, 0, 0, .3);
+                    max-width: calc(100vw - 16px); font-size: 12px; }
+  .sweep-feedback strong { font-size: 13px; }
   /* A multi-day ribbon: square off the edges that continue, and drop the
      spine on every segment but the first, so N columns read as one bar and
      not as N separate events. A continuing edge sits at **0** — the column's

--- a/ui/src/lib/shortcuts.ts
+++ b/ui/src/lib/shortcuts.ts
@@ -138,6 +138,7 @@ export const SHORTCUT_TEXT: Record<ShortcutId, string> = {
  */
 export const MOD_LABEL =
   typeof navigator !== 'undefined' && /Mac/.test(navigator.platform) ? '⌘' : 'Ctrl';
+const ALT_LABEL = MOD_LABEL === '⌘' ? 'Option' : 'Alt';
 
 export const CHORDS: { label: string; text: string; hint?: string }[] = [
   { label: `${MOD_LABEL} ,`, text: 'Open settings' },
@@ -149,6 +150,8 @@ export const CHORDS: { label: string; text: string; hint?: string }[] = [
     hint: 'Day and Week — a trackpad pinch or Ctrl+scroll over the grid does the same' },
   { label: `${MOD_LABEL} -`, text: 'Shorter hours' },
   { label: `${MOD_LABEL} 0`, text: 'Hours back to their usual height' },
+  { label: `${ALT_LABEL} drag`, text: 'Create over an existing event',
+    hint: 'Day and Week — hold the key before dragging to select a new time range' },
 ];
 
 /** A form chord rather than a bare key: it bubbles from any field to the form

--- a/ui/tests/alt-drag-create.spec.ts
+++ b/ui/tests/alt-drag-create.spec.ts
@@ -1,0 +1,135 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function start(page: Page) {
+  await page.goto('/tests/harness/index.html?c=App&f=writable');
+  const event = page.locator('.ev').filter({ hasText: 'Board prep' });
+  await event.scrollIntoViewIfNeeded();
+  const eventBox = (await event.boundingBox())!;
+  const col = await event.evaluate((el) => {
+    const col = el.closest<HTMLElement>('.col')!;
+    const r = col.getBoundingClientRect();
+    return { x: r.x, y: r.y, width: r.width, height: r.height };
+  });
+  // Start on the resize edge to prove Alt overrides resizing as well as moving.
+  const x = eventBox.x + eventBox.width / 2;
+  const y = eventBox.y + 2;
+  await page.keyboard.down('Alt');
+  await page.mouse.move(x, y);
+  await page.mouse.down();
+  return { event, eventBox, col, x, y };
+}
+
+const writes = (page: Page) => page.evaluate(() => window.__harness.calls
+  .filter((c) => c.cmd === 'update_event' || c.cmd === 'create_event'));
+
+test('Alt-drag over an event creates a blank draft and stays in create mode after Alt is released', async ({ page }) => {
+  const { event, eventBox, col, x, y } = await start(page);
+  await page.mouse.move(x, y + col.height / 24, { steps: 5 });
+  await expect(page.locator('.sweep')).toBeVisible();
+  await page.keyboard.up('Alt');
+  await page.mouse.move(x, y + col.height / 12, { steps: 5 });
+  await page.mouse.up();
+  const form = page.getByRole('dialog', { name: 'New event', exact: true });
+  await expect(form).toBeVisible();
+  await expect(form.getByLabel('Title', { exact: true })).toHaveValue('');
+  const startQuarter = Math.round((y - col.y) / col.height * 96);
+  const clock = (q: number) => `${String(Math.floor(q / 4)).padStart(2, '0')}:${String(q % 4 * 15).padStart(2, '0')}`;
+  await expect(form.getByLabel('Start', { exact: true })).toHaveValue(clock(startQuarter));
+  await expect(form.getByLabel('End', { exact: true })).toHaveValue(clock(startQuarter + 8));
+  expect(await writes(page)).toEqual([]);
+  await page.keyboard.press('Escape');
+  await expect(form).toHaveCount(0);
+  expect((await event.boundingBox())!.y).toBeCloseTo(eventBox.y, 1);
+  expect((await event.boundingBox())!.height).toBeCloseTo(eventBox.height, 1);
+});
+
+test('Alt-drag can start on an event and sweep across days', async ({ page }) => {
+  const { col, x, y } = await start(page);
+  await page.mouse.move(x + col.width, y + 12, { steps: 6 });
+  await expect(page.getByRole('status', { name: 'New event duration' }).locator('strong')).toHaveText('2 days');
+  await page.mouse.up();
+  await page.keyboard.up('Alt');
+  const form = page.getByRole('dialog', { name: 'New event', exact: true });
+  await expect(form).toBeVisible();
+  await expect(form.getByLabel('All day', { exact: true })).toBeChecked();
+  await expect(form.getByLabel('First day', { exact: true })).toHaveValue('2024-01-29');
+  await expect(form.getByLabel('Last day', { exact: true })).toHaveValue('2024-01-30');
+  expect(await writes(page)).toEqual([]);
+});
+
+test('Escape cancels an Alt-drag without opening a draft or moving the source', async ({ page }) => {
+  const { x, y } = await start(page);
+  await page.mouse.move(x, y + 50, { steps: 5 });
+  await expect(page.locator('.sweep')).toBeVisible();
+  await page.keyboard.press('Escape');
+  await page.mouse.up();
+  await page.keyboard.up('Alt');
+  await expect(page.locator('.sweep')).toHaveCount(0);
+  await expect(page.getByRole('dialog')).toHaveCount(0);
+  expect(await writes(page)).toEqual([]);
+});
+
+test('Alt changes a stationary hover from resize to crosshair, and resets on release or blur', async ({ page }) => {
+  await page.goto('/tests/harness/index.html?c=App&f=writable');
+  const event = page.locator('.ev').filter({ hasText: 'Board prep' });
+  await event.scrollIntoViewIfNeeded();
+  const box = (await event.boundingBox())!;
+  const point = { x: box.x + box.width / 2, y: box.y + 2 };
+  await page.mouse.move(point.x, point.y);
+  const cursor = () => page.evaluate(({ x, y }) => getComputedStyle(document.elementFromPoint(x, y)!).cursor, point);
+  await expect.poll(cursor).toBe('ns-resize');
+  await page.keyboard.down('Alt');
+  await expect.poll(cursor).toBe('crosshair');
+  await expect(event.locator('.grip')).toHaveCount(0);
+  await expect(event.locator('.tip')).toHaveCount(0);
+  await page.keyboard.up('Alt');
+  await expect.poll(cursor).toBe('ns-resize');
+  await page.keyboard.down('Alt');
+  await expect.poll(cursor).toBe('crosshair');
+  await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+  await expect.poll(cursor).toBe('ns-resize');
+  await page.keyboard.up('Alt');
+  expect(await writes(page)).toEqual([]);
+});
+
+test('the new-event preview paints above the existing event under the pointer', async ({ page }) => {
+  const { x } = await start(page);
+  const covered = page.locator('.ev').filter({ hasText: 'Client call' });
+  const box = (await covered.boundingBox())!;
+  await page.mouse.move(x, box.y + box.height / 2, { steps: 6 });
+  const ghost = page.locator('.sweep');
+  await expect(ghost).toBeVisible();
+  const paintsOnTop = await ghost.evaluate((el, targetBox) => {
+    const g = el.getBoundingClientRect();
+    const y = (Math.max(g.top, targetBox.y) + Math.min(g.bottom, targetBox.y + targetBox.height)) / 2;
+    const x = g.left + g.width / 2;
+    // Hit-testing follows paint order. Temporarily include the passive preview
+    // in it without changing its position, opacity or stacking order.
+    const old = el.style.pointerEvents;
+    el.style.pointerEvents = 'auto';
+    const hit = document.elementFromPoint(x, y);
+    el.style.pointerEvents = old;
+    return hit === el || el.contains(hit);
+  }, box);
+  expect(paintsOnTop).toBe(true);
+  await expect(page.locator('.ev .tip')).toHaveCount(0);
+  await page.keyboard.press('Escape');
+  await page.mouse.up();
+  await page.keyboard.up('Alt');
+  expect(await writes(page)).toEqual([]);
+});
+
+test('drag feedback shows the snapped duration live, including reverse drags', async ({ page }) => {
+  const { x, y, col } = await start(page);
+  const feedback = page.getByRole('status', { name: 'New event duration' });
+  await expect(feedback).toHaveCount(0);
+  for (const [hours, duration] of [[0.5, '30 min'], [1, '1h'], [1.25, '1h 15m'], [-0.5, '30 min']] as const) {
+    await page.mouse.move(x, y + col.height / 24 * hours, { steps: 5 });
+    await expect(feedback.locator('strong')).toHaveText(duration);
+  }
+  await page.mouse.up();
+  await page.keyboard.up('Alt');
+  await expect(feedback).toHaveCount(0);
+  await expect(page.getByRole('dialog', { name: 'New event', exact: true })).toBeVisible();
+  expect(await writes(page)).toEqual([]);
+});


### PR DESCRIPTION
Hold Alt (Option on macOS) while dragging in Day or Week to create a new event over an existing one, including its resize edges. The cursor changes to a crosshair, the new selection stays visible above saved events, and a live badge shows the duration and time range. Escape cancels without moving or changing the original event.

Svelte/TypeScript checks and 144 focused browser cases pass across Chromium and WebKit. Creation, cancellation, cursor, paint-order, and duration regressions were proven red before restoring the implementation.

Actual app UI with two synthetic events:

![Alt-drag selection and duration](https://raw.githubusercontent.com/jondkinney/omacal/8f88785cca8ccfa2c900c62ef20b0a8d8cbbdd6a/review/20260910/alt-drag.png)
