### PR TITLE
feat(calendar): choose visible hours for Day and Week

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1695,6 +1695,7 @@ pub fn run() {
             settings::set_week_start,
             settings::set_week_starts_today,
             settings::set_week_view_days,
+            settings::set_visible_hours,
             events::event_detail,
             events::respond_to_event,
             events::refresh_event,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -534,6 +534,8 @@ pub struct AppSettings {
     /// Total columns in the rolling Week view, including today. Only 3, 5 and
     /// 7 are written; an absent or hand-edited value falls back to 7.
     pub week_view_days: u8,
+    pub visible_start_hour: u8,
+    pub visible_end_hour: u8,
     /// The IANA zone every time in the app is read in, or `None` for the
     /// system's. Applied by exporting `TZ` before the webview starts — the
     /// one mechanism that keeps the browser, Rust, notifications and the
@@ -620,6 +622,7 @@ pub async fn read_settings(pool: &SqlitePool) -> AppSettings {
 /// [`read_settings`] with the appearance baseline supplied, so a test can
 /// tell the Omarchy story and the other one on whichever host runs it.
 pub(crate) async fn read_settings_with(pool: &SqlitePool, baseline: u8) -> AppSettings {
+    let (visible_start_hour, visible_end_hour) = visible_hours(pool).await;
     let absolute_transparency = read(pool, APPEARANCE_TRANSPARENCY_SEMANTICS_KEY)
         .await
         .as_deref()
@@ -739,6 +742,8 @@ pub(crate) async fn read_settings_with(pool: &SqlitePool, baseline: u8) -> AppSe
         // The select offers exactly these three. A row edited by hand must not
         // become an unbounded query or a zero-column grid, so all other values
         // return to the old seven-day shape.
+        visible_start_hour,
+        visible_end_hour,
         week_view_days: match read(pool, WEEK_VIEW_DAYS_KEY).await.as_deref() {
             Some("3") => 3,
             Some("5") => 5,
@@ -1449,12 +1454,41 @@ async fn set_week_view_days_impl(pool: &SqlitePool, days: u8) -> anyhow::Result<
     Ok(read_settings(pool).await)
 }
 
+async fn visible_hours(pool: &SqlitePool) -> (u8, u8) {
+    read(pool, "visible_hours").await.and_then(|value| {
+        let (start, end) = value.split_once(',')?;
+        let (start, end) = (start.parse::<u8>().ok()?, end.parse::<u8>().ok()?);
+        (start < end && end <= 24).then_some((start, end))
+    }).unwrap_or((0, 24))
+}
+
+#[tauri::command]
+pub async fn set_visible_hours(app: tauri::AppHandle, state: tauri::State<'_, AppState>, start: u8, end: u8) -> Result<AppSettings, String> {
+    if start >= end || end > 24 { return Err("Start time must be before end time.".into()); }
+    write(&state.pool, "visible_hours", &format!("{start},{end}")).await.map_err(|e| crate::errors::user_facing(&e))?;
+    refresh_menu_surfaces(&app, &state).await;
+    Ok(read_settings(&state.pool).await)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     async fn pool() -> SqlitePool {
         omacal_store::connect_memory().await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn visible_hours_default_and_reject_invalid_stored_ranges() {
+        let p = pool().await;
+        assert_eq!(visible_hours(&p).await, (0, 24));
+        write(&p, "visible_hours", "5,23").await.unwrap();
+        let settings = read_settings(&p).await;
+        assert_eq!((settings.visible_start_hour, settings.visible_end_hour), (5, 23));
+        for value in ["5,5", "23,5", "0,25", "-1,23", "oops"] {
+            write(&p, "visible_hours", value).await.unwrap();
+            assert_eq!(visible_hours(&p).await, (0, 24));
+        }
     }
 
     /// A fresh install has written none of these, and that is the ordinary

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -1,5 +1,6 @@
 <!-- ui/src/App.svelte -->
 <script lang="ts">
+  import { setVisibleHoursState } from "./lib/visiblehours.svelte";
   import { formatDate } from './lib/datefmt';
   import { dateFormat } from './lib/date.svelte';
   import { setDateFormat } from './lib/date.svelte';
@@ -764,6 +765,7 @@
         defaultCalendarId = s.defaultCalendarId;
         defaultEventDurationMinutes = s.defaultEventDurationMinutes;
         setClockFormat(s.timeFormat);
+      setVisibleHoursState(s.visibleStartHour, s.visibleEndHour);
       setDateFormat(s.dateFormat);
         setSecondZone(s.secondTimezone);
         setTemperatureUnit(s.temperatureUnit);
@@ -1951,6 +1953,7 @@
       defaultCalendarId = s.defaultCalendarId;
       defaultEventDurationMinutes = s.defaultEventDurationMinutes;
       setClockFormat(s.timeFormat);
+      setVisibleHoursState(s.visibleStartHour, s.visibleEndHour);
       setDateFormat(s.dateFormat);
       setSecondZone(s.secondTimezone);
       setTemperatureUnit(s.temperatureUnit);

--- a/ui/src/lib/SettingsModal.svelte
+++ b/ui/src/lib/SettingsModal.svelte
@@ -23,7 +23,7 @@
     setAppearance, APPEARANCE_OPTIONS,
     setQuitOnClose, setSecondTimezone, setSyncInterval, setTemperatureUnit, setTimeFormat,
     setShowDate, setTrayIcon, setWeatherEnabled, setWeekStart,
-    setWeekStartsToday, setWeekViewDays,
+    setWeekStartsToday, setWeekViewDays, setVisibleHours,
     type AppSettings, type Appearance, type StartOnLogin, type WeekViewDays,
     type WindowFrame, WINDOW_FRAME_OPTIONS, setWindowFrame,
   } from './settings';
@@ -31,6 +31,10 @@
   import type { TemperatureUnit } from './temperature';
   import type { WeekStartDay } from './weekstart';
 
+  async function changeVisibleHours(start: number, end: number) {
+    try { settings = await setVisibleHours(start, end); onsettingschange?.(settings); }
+    catch (e) { note = { text: String(e), kind: "error" }; }
+  }
   let {
     accounts,
     version = '',
@@ -1007,6 +1011,18 @@
       <!-- The canvas can only fade where the window can be seen through, and
            macOS's cannot (AppSettings.transparentWindow); a slider that moved
            nothing would read as broken, so there is no slider there. -->
+      <section class="appearance-section" aria-labelledby="visible-hours-heading">
+        <h2 id="visible-hours-heading">Visible hours</h2>
+        <div class="visible-hours-controls">
+          <label>Start time <select aria-label="Visible hours start time" value={settings?.visibleStartHour ?? 0} disabled={!settings} onchange={(e) => changeVisibleHours(Number(e.currentTarget.value), settings?.visibleEndHour ?? 24)}>
+            {#each Array.from({ length: 24 }, (_, h) => h) as h}<option value={h} disabled={h >= (settings?.visibleEndHour ?? 24)}>{formatClock(new Date(2020, 0, 1, h).getTime(), settings?.timeFormat ?? '24h')}</option>{/each}
+          </select></label>
+          <label>End time <select aria-label="Visible hours end time" value={settings?.visibleEndHour ?? 24} disabled={!settings} onchange={(e) => changeVisibleHours(settings?.visibleStartHour ?? 0, Number(e.currentTarget.value))}>
+            {#each Array.from({ length: 24 }, (_, h) => h + 1) as h}<option value={h} disabled={h <= (settings?.visibleStartHour ?? 0)}>{h === 24 ? 'Midnight (end of day)' : formatClock(new Date(2020, 0, 1, h).getTime(), settings?.timeFormat ?? '24h')}</option>{/each}
+          </select></label>
+        </div>
+        <p class="hint">Hours shown in Day and Week. Events outside this range remain in the agenda and search.</p>
+      </section>
       {#if settings?.transparentWindow ?? true}
       <section class="appearance-section" aria-labelledby="background-style-heading">
         <h2 id="background-style-heading">Calendar background</h2>
@@ -1414,6 +1430,8 @@
 </div>
 
 <style>
+  .visible-hours-controls { display: flex; flex-wrap: wrap; gap: 12px; }
+  .visible-hours-controls label { display: flex; flex-direction: column; gap: 8px; }
   .appearance-section { align-self: stretch; display: flex; flex-direction: column;
                         gap: 14px; padding: 8px 0 16px; margin-top: 16px; }
   .appearance-section + .appearance-section {

--- a/ui/src/lib/WeekGrid.svelte
+++ b/ui/src/lib/WeekGrid.svelte
@@ -1,5 +1,6 @@
 <!-- ui/src/lib/WeekGrid.svelte -->
 <script lang="ts">
+  import { visibleHours } from "./visiblehours.svelte";
   import { clockFormat } from './clock.svelte';
   import { gutterWidth, secondZone } from './secondzone.svelte';
   import { temperatureUnit } from './tempunit.svelte';
@@ -152,7 +153,8 @@
 
   // Every hour, not every second one: a rule at 10:00 with nothing at 11:00
   // makes a meeting's edge unplaceable by eye.
-  const HOURS = Array.from({ length: 24 }, (_, i) => i);
+  const HOURS = $derived(Array.from({ length: visibleHours().end - visibleHours().start }, (_, i) => i + visibleHours().start));
+  const visibleHeight = $derived(Math.round(hourPx) * (visibleHours().end - visibleHours().start));
   const DOW = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
   // Named from the day's own date, not its position in the week — the same
   // rule works for a 7-column week and a 1-column day.
@@ -170,6 +172,14 @@
     return (d.getTime() - day.start_ms) / (day.end_ms - day.start_ms);
   };
 
+  function crop(day: { start_ms: number; end_ms: number }) {
+    const start = hourFrac(day, visibleHours().start), end = hourFrac(day, visibleHours().end);
+    return end > start ? { start, span: end - start } : { start: 0, span: 1 };
+  }
+  function columnStyle(day: { start_ms: number; end_ms: number }) {
+    const range = crop(day), height = visibleHeight / range.span;
+    return `height:${height}px;min-height:0;top:${-range.start * height}px`;
+  }
   // The gutter labels are shared by all seven columns, so they use the first
   // ordinary-length day; a DST day's own rules still come from its own span.
   const gutterDay = $derived(
@@ -394,9 +404,11 @@
     if (revealRequested && !today) return;
     if (!revealRequested && hasScrolled) return;
 
-    const frac = today
+    const fullFrac = today
       ? (now - today.start_ms) / (today.end_ms - today.start_ms)
       : hourFrac(gutterDay, 8);
+    const range = crop(today ?? gutterDay);
+    const frac = (fullFrac - range.start) / range.span;
     hasScrolled = true;
     if (revealRequested) handledRevealNowRequest = revealNowRequest;
     // After layout: scrollHeight is meaningless until the columns have height.
@@ -1511,7 +1523,7 @@
 />
 
 <div class="grid body quiet-scroll" style="--cols:{renderedDays.length}; --visible:{visible}; --vis:{renderVis}; --pan:{panDays}; --gutter:{gutterWidth()}; --hour-px:{Math.round(hourPx)}px" bind:this={bodyEl} data-testid="week-body" onwheel={wheelPan}>
-  <div class="gutter">
+  <div class="hour-crop ruler" style:height={`${visibleHeight}px`}><div class="gutter" style={columnStyle(gutterDay)}>
     {#each HOURS as h}
       {#if secondZone()}
         <!-- The second clock's reading of this same rule — one instant, two
@@ -1522,13 +1534,13 @@
       {/if}
       <span style="top:{hourFrac(gutterDay, h) * 100}%">{gutterLabel(h, clockFormat())}</span>
     {/each}
-  </div>
+  </div></div>
 
   <div class="track"><div class="cols" class:sliding={panActive}>
   {#each renderedDays as day, dayIndex (day.start_ms)}
     {@const isToday = day.start_ms === todayStart}
     {@const ghost = sweepStyle(day)}
-    <div class="col" class:today={isToday}
+    <div class="hour-crop" style:height={`${visibleHeight}px`}><div class="col" style={columnStyle(day)} class:today={isToday}
          class:keyboard={keyboardCursor?.dayStartMs === day.start_ms}
          data-start-ms={day.start_ms}
          data-kbd-selected-day={keyboardCursor?.dayStartMs === day.start_ms ? '' : undefined}>
@@ -1623,7 +1635,7 @@
           style="top:{((nowMs - day.start_ms) / (day.end_ms - day.start_ms)) * 100}%"
         ></div>
       {/if}
-    </div>
+    </div></div>
   {/each}
   </div></div>
 </div>
@@ -1662,6 +1674,10 @@
 {/if}
 
 <style>
+  .hour-crop { overflow: clip; min-width: 0; }
+  /* Real headroom works in WebKit too; overflow-clip-margin alone does not.
+     The negative margin keeps hour labels aligned with the event grid. */
+  .ruler { padding-top: 8px; margin-top: -8px; }
   /* `--gutter` from `secondzone.svelte`'s one exported width: 44px alone,
      wider when the second clock takes the outer lane. A var rather than two
      hardcodings because the head row here, the body row below and the

--- a/ui/src/lib/settings.ts
+++ b/ui/src/lib/settings.ts
@@ -122,6 +122,8 @@ export type AppSettings = {
   weekStartsToday: boolean;
   /** Number of columns in that rolling Week view, including today. */
   weekViewDays: WeekViewDays;
+  visibleStartHour: number;
+  visibleEndHour: number;
   /** Whether the system tray icon is shown. On by default — the tray is where
    *  Quit lives. Turning it off is for setups where something else carries
    *  those actions, like Omarchy 4's bar widget. */
@@ -322,3 +324,5 @@ export const minutesOf = (ms: number): number => Math.round(ms / 60_000);
 export const msOfMinutes = (min: number): number => Math.round(min * 60_000);
 
 export const setDateFormatPreference = (format: DateFormat) => invoke<AppSettings>('set_date_format', { format });
+
+export const setVisibleHours = (start: number, end: number) => invoke<AppSettings>("set_visible_hours", { start, end });

--- a/ui/src/lib/visiblehours.svelte.ts
+++ b/ui/src/lib/visiblehours.svelte.ts
@@ -1,0 +1,5 @@
+const state = $state({ start: 0, end: 24 });
+export const visibleHours = () => state;
+export function setVisibleHoursState(start = 0, end = 24) {
+  state.start = start; state.end = end;
+}

--- a/ui/tests/app.spec.ts
+++ b/ui/tests/app.spec.ts
@@ -5251,3 +5251,36 @@ test('settings measures every pane at 650px and keeps its height across tabs', a
 });
 
 
+test('visible hours persist, shorten Day and Week, and keep click creation at the right time', async ({ page }) => {
+  await page.clock.setFixedTime(APP_NOW);
+  await page.goto(app('writable'));
+  const body = page.getByTestId('week-body');
+  await expect(body).toBeVisible();
+  const before = await body.evaluate(el => el.scrollHeight);
+  await page.getByRole('button', { name: 'Menu', exact: true }).click();
+  await page.getByRole('button', { name: 'Settings…' }).click();
+  const modal = page.getByRole('dialog', { name: 'Settings' });
+  await modal.getByRole('tab', { name: 'Appearance' }).click();
+  await modal.getByLabel('Visible hours start time').selectOption('5');
+  await modal.getByLabel('Visible hours end time').selectOption('23');
+  await page.keyboard.press('Escape');
+  expect(Math.abs(await body.evaluate(el => el.scrollHeight) - (before - 6 * 70))).toBeLessThanOrEqual(8);
+  await body.evaluate(el => { el.scrollTop = 0; });
+  await page.evaluate(() => (window as any).__setSecondZone('Asia/Kolkata'));
+  const clip = (await body.locator('.ruler').boundingBox())!;
+  for (const label of [body.locator('.gutter span.z2').first(), body.locator('.gutter span:not(.z2)').first()]) {
+    const bounds = (await label.boundingBox())!;
+    expect(bounds.y).toBeGreaterThanOrEqual(clip.y);
+  }
+  const box = (await body.locator('.hour-crop').nth(1).boundingBox())!;
+  await page.mouse.click(box.x + 20, box.y + 40);
+  await expect(page.getByRole('dialog', { name: 'New event' }).getByLabel('Start', { exact: true })).toHaveValue('05:30');
+  await page.keyboard.press('Escape');
+  await page.getByRole('button', { name: 'Day', exact: true }).click();
+  expect(Math.abs(await body.evaluate(el => el.scrollHeight) - (before - 6 * 70))).toBeLessThanOrEqual(8);
+  await page.getByRole('button', { name: 'Menu', exact: true }).click();
+  await page.getByRole('button', { name: 'Settings…' }).click();
+  await modal.getByRole('tab', { name: 'Appearance' }).click();
+  await expect(modal.getByLabel('Visible hours start time')).toHaveValue('5');
+  await expect(modal.getByLabel('Visible hours end time')).toHaveValue('23');
+});

--- a/ui/tests/harness/tauri.ts
+++ b/ui/tests/harness/tauri.ts
@@ -581,6 +581,8 @@ type StubSettings = {
   weekStart: WeekStartDay;
   weekStartsToday: boolean;
   weekViewDays: WeekViewDays;
+  visibleStartHour: number;
+  visibleEndHour: number;
   displayTimezone: string | null;
   secondTimezone: string | null;
   weatherEnabled: boolean;
@@ -633,6 +635,8 @@ const DEFAULT_SETTINGS: StubSettings = {
   weekStart: 'monday',
   weekStartsToday: false,
   weekViewDays: 7,
+  visibleStartHour: 0,
+  visibleEndHour: 24,
   displayTimezone: null,
   // Off, the backend's fresh-install default — and what keeps every
   // committed gutter golden describing a 44px ruler with one clock.
@@ -947,6 +951,9 @@ export function installTauriStub(scenario: string): Harness {
       case 'set_week_starts_today':
         settings = saveSettings({ ...settings, weekStartsToday: args.on as boolean });
         return { ...settings };
+      case 'set_visible_hours':
+        settings = saveSettings({ ...settings, visibleStartHour: args.start as number, visibleEndHour: args.end as number });
+        return settings;
       case 'set_week_view_days':
         settings = saveSettings({ ...settings, weekViewDays: args.days as WeekViewDays });
         return { ...settings };


### PR DESCRIPTION
Adds Start time and End time under Appearance so Day and Week can hide hours you never use—for example, show 5 AM through 11 PM. The default stays midnight to midnight. Events outside the range remain available in lists and search.

The grid keeps its existing click/drag coordinates, and both time-zone rulers leave room for the first hour label. Menu-bar day-view support is being submitted separately with that popup feature.

Validated with Svelte/TypeScript checks, the native persisted-range test, and Chromium/WebKit coverage for shorter grids, correct event creation times, persistence, and unclipped hour labels. These regressions were proven red before restoring the implementation.

Actual Appearance settings with synthetic calendar data:

![Visible hours preferences](https://raw.githubusercontent.com/jondkinney/omacal/6743cd963cc22846eab34d8390646c993b704c2e/review/20260910/visible-hours-settings.png)
